### PR TITLE
Modified client connection to circumvent DNS resolution

### DIFF
--- a/src/Services/SocketClient.cs
+++ b/src/Services/SocketClient.cs
@@ -128,7 +128,6 @@ namespace MCEControl {
             Log4.Debug($"SocketClient: Connect - {_host}:{_port}");
             Debug.Assert(_tcpClient != null);
             try {
-
                 // See if we've just been handed a straight IPv4 address, if so don't bother with DNS
                 IPAddress hostIp;
                 if (!IPAddress.TryParse(_host, out hostIp)) {


### PR DESCRIPTION
Fixes #29 

I thought the issue we had [Issue 29](https://github.com/tig/mcec/issues/29) was resolved, but it turns out that wasn't the case.
For some reason, DNS.GetHostEntry(...) fails on our network when a plain IPv4 address is provided.

I've added a quick check to SocketClient Connect to see if the address is already a dotted IP - if it is, use this rather than trying a lookup.  I've tested it and it works here.

Apologies if there's a better solution to this.