### PR TITLE
Apply Dependabot bumps + fix ConfigPath for 64-bit Program Files installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # full history for GitVersion
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -51,7 +51,7 @@ jobs:
           comment_mode: off
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="all" />
+    <PackageReference Include="GitVersion.MsBuild" Version="6.7.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- House-style analyzers (one type per file, no nested types). Excluded from the

--- a/src/MCEControl.csproj
+++ b/src/MCEControl.csproj
@@ -43,9 +43,9 @@
     <ItemGroup>
         <PackageReference Include="log4net" Version="3.3.2" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-        <PackageReference Include="Octokit" Version="13.0.1" />
-        <PackageReference Include="System.IO.Ports" Version="8.0.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="Octokit" Version="14.0.0" />
+        <PackageReference Include="System.IO.Ports" Version="10.0.9" />
+        <PackageReference Include="System.Text.Json" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -12,14 +12,22 @@ internal static class Program {
         get {
             // Get dir of mcecontrol.exe
             string path = AppDomain.CurrentDomain.BaseDirectory;
-            string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
             string appdata = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
-            // is this in Program Files?
-            if (path.Contains(programFiles)) {
-                // We're running from the default install location. Use %appdata%.
-                // strip % programfiles %
-                path = $@"{appdata}\{path.Substring(programFiles.Length + 1)}";
+            // If we're running from a (read-only) Program Files install location, redirect log/
+            // settings/command files to %AppData%. Check both 64-bit ("Program Files") and 32-bit
+            // ("Program Files (x86)") roots — the installer puts the self-contained x64 build under
+            // 64-bit Program Files, while older installs used the x86 path.
+            foreach (Environment.SpecialFolder folder in new[] {
+                Environment.SpecialFolder.ProgramFiles,
+                Environment.SpecialFolder.ProgramFilesX86,
+            }) {
+                string programFiles = Environment.GetFolderPath(folder);
+                if (!string.IsNullOrEmpty(programFiles) &&
+                    path.StartsWith(programFiles, StringComparison.OrdinalIgnoreCase)) {
+                    path = $@"{appdata}\{path.Substring(programFiles.Length + 1)}";
+                    break;
+                }
             }
 
             return path;

--- a/tests/MCEControl.xUnit/MCEControl.xUnit.csproj
+++ b/tests/MCEControl.xUnit/MCEControl.xUnit.csproj
@@ -9,13 +9,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tools/MCEControl.Analyzers/MCEControl.Analyzers.csproj
+++ b/tools/MCEControl.Analyzers/MCEControl.Analyzers.csproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0-2.25625.1" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Folds together the P1 review note on #65 and the open Dependabot PRs.

## P1 fix — keep installed data out of Program Files (review comment on #65)
The new installer puts the self-contained **x64** build under **64-bit** `Program Files`, but `Program.ConfigPath` only detected `ProgramFilesX86` before redirecting `MCEControl.log`/`.settings`/`.commands` to `%AppData%`. A normal user would then try to write into the read-only install dir and fail on startup/save. Now detects **both** `Program Files` and `Program Files (x86)` (case-insensitive `StartsWith`).

## Dependabot bumps applied
| Area | Package | From → To | PR |
|---|---|---|---|
| src | Octokit | 13.0.1 → 14.0.0 | #62 |
| src | System.IO.Ports | 8.0.0 → 10.0.9 | #63 |
| src | System.Text.Json | 8.0.5 → 10.0.9 | #64 |
| tests | Microsoft.NET.Test.Sdk | 17.11.1 → 18.7.0 | #59 |
| tests | xunit | 2.9.2 → 2.9.3 | #51 |
| tests | xunit.runner.visualstudio | 2.8.2 → 3.1.5 | #61 |
| tests | coverlet.collector | 6.0.2 → 10.0.1 | #52 |
| build | GitVersion.MsBuild | 6.4.0 → 6.7.0 | #54/#53 |
| analyzer | Microsoft.CodeAnalysis.CSharp | 4.11.0 → 5.3.0 | #60 |
| analyzer | Microsoft.CodeAnalysis.Analyzers | 3.11.0 → 5.3.0-2.25625.1 | #60 |
| CI | actions/checkout | v4 → v7 | #48 |
| CI | actions/setup-dotnet | v4 → v5 | #50 |
| CI | actions/upload-artifact | v4 → v7 | #49 |

This supersedes Dependabot PRs #48–#54, #56, #59–#64 (GitHub will auto-close them once this lands on `develop`).

## ⚠️ Held back: ApplicationInsights 2.22.0 (Dependabot #56 → 3.1.2)
v3 is a **breaking rewrite** — it removes `TelemetryDebugWriter`, changes the channel API, and changes the `TrackEvent` signature used in `TelemetryService`. Porting an **opt-in, disabled-by-default** telemetry path to a v3 API that can't be verified here is beyond a dependency bump. Left as a tracked follow-up (#56 stays open).

## Testing
- [x] Build green; **115/115 tests pass**.
- [x] Roslyn 5.x analyzer verified still loaded and enforcing `MCEC0001`/`MCEC0002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)