### PR TITLE
Sign releases with Azure Trusted Signing (reuse WinPrint's identity)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+# Cuts a release: builds the self-contained installer, signs it with Azure Trusted
+# Signing (Azure Artifact Signing) via GitHub OIDC, and publishes a GitHub Release.
+#
+# Trigger by pushing a version tag:   git push origin v2.5.0
+# Or run manually (workflow_dispatch) with a version, e.g. for a dry run.
+#
+# Signing is GATED on the six AZURE_* secrets (set by scripts/SetupAzure.ps1). Without
+# them the job still builds and publishes an UNSIGNED installer (with a ::warning::), so
+# the release path works on a fork or before signing is configured. See docs/code-signing.md.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g. 2.5.0, no v prefix)'
+        required: true
+
+permissions:
+  contents: write   # create the GitHub Release
+  id-token: write   # Azure OIDC federation (no client secret)
+
+env:
+  SIGN: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' && secrets.AZURE_SIGNING_ACCOUNT != '' && secrets.AZURE_SIGNING_PROFILE != '' && secrets.AZURE_SIGNING_ENDPOINT != '' }}
+
+jobs:
+  release:
+    name: Build, sign, and publish installer
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Determine version
+        id: ver
+        shell: pwsh
+        run: |
+          $v = if ('${{ github.event_name }}' -eq 'workflow_dispatch') { '${{ github.event.inputs.version }}' } else { '${{ github.ref_name }}' }
+          $v = $v.TrimStart('v')
+          if ($v -notmatch '^\d+\.\d+\.\d+$') { throw "Version '$v' must be X.Y.Z (tag like v2.5.0)" }
+          "version=$v" >> $env:GITHUB_OUTPUT
+          "tag=v$v"    >> $env:GITHUB_OUTPUT
+          Write-Host "Building version $v"
+
+      - name: Install NSIS
+        run: choco install nsis -y --no-progress
+
+      - name: Build installer
+        shell: pwsh
+        run: ./Release.ps1 -Version ${{ steps.ver.outputs.version }}
+
+      - name: Stage installer for signing
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          Copy-Item src/bin/MCEController.Setup.exe artifacts/MCEController.Setup.exe -Force
+
+      - name: Azure login (OIDC)
+        if: ${{ env.SIGN == 'true' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign installer (Azure Trusted Signing)
+        if: ${{ env.SIGN == 'true' }}
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE }}
+          files-folder: ${{ github.workspace }}\artifacts
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Warn that installer is unsigned
+        if: ${{ env.SIGN != 'true' }}
+        run: echo "::warning::AZURE_* signing secrets not set — installer is UNSIGNED. Run 'pwsh scripts/SetupAzure.ps1 -SetGitHubSecrets' to enable Azure Trusted Signing (see docs/code-signing.md)."
+
+      - name: Publish GitHub Release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ steps.ver.outputs.tag }} `
+            --title "MCE Controller ${{ steps.ver.outputs.tag }}" `
+            --generate-notes `
+            --latest `
+            artifacts/MCEController.Setup.exe

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,0 +1,101 @@
+# Code signing — Azure Trusted Signing (runbook)
+
+MCE Controller signs its Windows installer (`MCEController.Setup.exe`) with **Azure Trusted
+Signing** (a.k.a. Azure Artifact Signing), authenticating from GitHub Actions via **OIDC
+federation** — there is **no client secret** and nothing sensitive to rotate. Signing is wired
+into [`.github/workflows/release.yml`](../.github/workflows/release.yml) and gated on the six
+`AZURE_*` repo secrets, so the release path still works (unsigned, with a warning) before signing
+is configured or on a fork.
+
+## Reuses WinPrint's signing identity
+
+This repo **reuses the Trusted Signing account and certificate profile already validated for
+[tig/winprint](https://github.com/tig/winprint)** (publisher identity = **Kindel LLC**). A
+Trusted Signing certificate represents the *publisher*, not a single app, so one validated
+identity signs any number of apps. The one-time Microsoft **identity validation is NOT repeated**.
+
+All that's created for this repo is a **dedicated app registration (`mcec`)** with its own GitHub
+OIDC federated credentials, granted the signer role on the same certificate profile. So winprint's
+trust is untouched and independent.
+
+| | Value |
+|---|---|
+| Subscription | Kindel LLC (`7bee0c7c-…`) |
+| Resource group | `WinPrint_Resources` |
+| Trusted Signing account | `winprint` (reused) |
+| Certificate profile | `WinPrint` — Public Trust, Kindel LLC (reused) |
+| App registration (this repo) | `mcec` (created by `SetupAzure.ps1`) |
+| OIDC subjects | `repo:tig/mcec:ref:refs/heads/{develop,main}` + flexible `refs/tags/*` |
+
+The single source of truth for these values is [`scripts/Azure.Config.ps1`](../scripts/Azure.Config.ps1).
+
+## One-time setup (you run this)
+
+Prereqs: `pwsh` 7+, `az` (Azure CLI) logged in as an account with rights to create an app
+registration + role assignment on the `winprint` Trusted Signing account, and `gh` (to push
+secrets). The signing account/profile already exist (from winprint), so there is **no portal step**.
+
+```bash
+az login                                         # interactive — run it yourself
+pwsh scripts/SetupAzure.ps1 -SetGitHubSecrets    # creates the mcec app reg + OIDC trust + role, pushes the 6 secrets
+pwsh scripts/ValidateAzure.ps1                   # read-only verification
+```
+
+`SetupAzure.ps1` is **find-or-create** at every step — safe to re-run any time (e.g. after editing
+`Branches`). Omit `-SetGitHubSecrets` to print the six secret values without touching the repo. It
+creates:
+
+1. App registration `mcec` + its service principal.
+2. Federated credentials — exact-match subjects for `develop`/`main`, plus a **flexible**
+   credential (`claimsMatchingExpression`) for `refs/tags/*` (Entra `subject` is exact-match, so a
+   wildcard tag subject can't work — see the gotchas in the script).
+3. Role assignment **“Artifact Signing Certificate Profile Signer”** at the certificate-profile scope.
+4. The six repo secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`,
+   `AZURE_SIGNING_ACCOUNT`, `AZURE_SIGNING_PROFILE`, `AZURE_SIGNING_ENDPOINT`.
+
+## Cutting a (signed) release
+
+Once the secrets are set, releasing is one push:
+
+```bash
+git tag -a v2.5.0 -m "MCE Controller v2.5.0"
+git push origin v2.5.0
+```
+
+`release.yml` then builds the self-contained installer (`Release.ps1`), signs
+`MCEController.Setup.exe` via Azure Trusted Signing, and publishes the GitHub Release with
+auto-generated notes. (You can also run it from the Actions tab via **workflow_dispatch** with a
+version, for a dry run.)
+
+For a **local, unsigned** build, `pwsh ./Release.ps1 -Version 2.5.0` still produces the installer in
+`src/bin/` — handy for testing, but Windows SmartScreen will warn on an unsigned build.
+
+## How `release.yml` consumes the trust
+
+- `SIGN` (env) is true only when all six secrets are present; the `azure/login` (OIDC) and
+  `azure/artifact-signing-action` steps are gated on it.
+- The job requests `permissions: id-token: write`; `azure/login@v2` exchanges the GitHub OIDC token
+  for the federated credential — **no secret**. Tag pushes match the flexible `refs/tags/*`
+  credential; `workflow_dispatch` runs match the per-branch credentials.
+
+## Gotchas (baked into the scripts)
+
+- **Entra federated `subject` is EXACT-match — wildcards don't work.** Tags use a *flexible*
+  federated identity credential (`claimsMatchingExpression`) created via the **beta** Microsoft
+  Graph endpoint; the `v1.0` endpoint and `az ad app federated-credential create` reject/omit it.
+- **PowerShell `$var:` trap.** `"...$GhRepo:ref..."` makes PowerShell read `GhRepo:` as a scope
+  qualifier and drop the repo name — always brace: `${GhRepo}`.
+- **Role rename.** “Trusted Signing Certificate Profile Signer” → “Artifact Signing Certificate
+  Profile Signer”. `ValidateAzure.ps1` accepts both.
+- **RBAC propagation.** A freshly created role assignment can take a few minutes before the first
+  CI signing call succeeds.
+- **First signed run validates the action.** The signing step uses `azure/artifact-signing-action@v2`;
+  because OIDC signing can't be exercised outside CI, confirm the first tag-triggered run is green.
+
+## Teardown (if ever needed)
+
+```bash
+# Remove this repo's CI trust (leaves winprint and the shared signing account/profile intact):
+APPID=$(az ad app list --display-name mcec --query "[0].appId" -o tsv)
+az ad app delete --id "$APPID"   # deletes the mcec app + SP + federated creds; role assignment is GC'd
+```

--- a/scripts/Azure.Config.ps1
+++ b/scripts/Azure.Config.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+  Single source of truth for MCE Controller's Azure Trusted Signing + GitHub OIDC trust.
+.DESCRIPTION
+  Dot-sourced/invoked by SetupAzure.ps1 and ValidateAzure.ps1. Edit values HERE only.
+  Returns a hashtable when invoked:  $cfg = & "$PSScriptRoot/Azure.Config.ps1"
+  None of these values are secret — they are Azure/GitHub identifiers, not credentials.
+  The actual trust is the federated credential (no client secret is ever created).
+
+  REUSE NOTE: MCE Controller reuses WinPrint's already-validated Trusted Signing account
+  and certificate profile (publisher identity = Kindel LLC). The one-time Microsoft
+  identity validation is therefore NOT repeated. Only a *dedicated app registration*
+  ('mcec') with its own GitHub OIDC federated credentials is created for this repo, and
+  it is granted the signer role on the same certificate profile. See docs/code-signing.md.
+#>
+@{
+    # --- Subscription / signing identity (REUSED from WinPrint — do not recreate) ---
+    SubscriptionId = '7bee0c7c-3217-4628-a783-dd7d687112d3'   # Kindel LLC
+    ResourceGroup  = 'WinPrint_Resources'                     # where the signing account lives
+    Location       = 'eastus'
+    SigningAccount = 'winprint'                               # existing Trusted Signing account
+    CertProfile    = 'WinPrint'                               # existing Public Trust cert profile (Kindel LLC)
+
+    # --- Dedicated app registration + OIDC trust for THIS repo (created by SetupAzure.ps1) ---
+    AppDisplayName = 'mcec'
+    GhOwner        = 'tig'
+    GhRepo         = 'mcec'
+    Branches       = @('develop', 'main')   # plus refs/tags/* (always added)
+    SignerRole     = 'Artifact Signing Certificate Profile Signer'
+}

--- a/scripts/SetupAzure.ps1
+++ b/scripts/SetupAzure.ps1
@@ -1,0 +1,208 @@
+<#
+.SYNOPSIS
+  One-shot, idempotent setup of MCE Controller's Azure Trusted Signing OIDC trust for CI.
+
+.DESCRIPTION
+  Creates (or reuses, if already present) everything release.yml needs to sign Windows
+  builds with Azure Trusted Signing using GitHub OIDC — NO client secret:
+
+    1. Entra ID app registration  (Azure.Config.ps1 -> AppDisplayName)
+    2. Its service principal
+    3. Federated credentials      (refs/tags/* + each configured branch)
+    4. Role assignment            (SignerRole, at the certificate-profile scope)
+    5. (optional) the six GitHub Actions repo secrets
+
+  Re-running is safe: each step is find-or-create. Run it again any time the config
+  changes (e.g. you add a branch) and it will converge.
+
+  PREREQUISITES THAT THIS SCRIPT DOES NOT CREATE (manual, one-time — see docs/code-signing.md):
+    * The Trusted Signing *account* and a *PublicTrust certificate profile*. Public-trust
+      profiles require a Microsoft identity-validation request that is completed in the
+      Azure Portal and cannot be fully scripted. Create those first; this script then
+      wires CI up to them. Pass -CreateResourceGroup to create just the resource group.
+
+.EXAMPLE
+  pwsh scripts/SetupAzure.ps1
+  pwsh scripts/SetupAzure.ps1 -SetGitHubSecrets        # also push the 6 repo secrets via gh
+
+.NOTES
+  Requires: pwsh 7+, Azure CLI (az) logged in (`az login`) with rights to create app
+  registrations and role assignments, and — for -SetGitHubSecrets — GitHub CLI (gh) auth'd.
+#>
+#requires -Version 7
+[CmdletBinding()]
+param(
+    [string]$ConfigPath = "$PSScriptRoot/Azure.Config.ps1",
+    [switch]$CreateResourceGroup,
+    [switch]$SetGitHubSecrets
+)
+
+$ErrorActionPreference = 'Stop'
+$cfg = & $ConfigPath
+
+function Require-Cli([string]$name, [string]$hint) {
+    if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
+        throw "Required CLI '$name' not found. $hint"
+    }
+}
+Require-Cli az  "Install: brew install azure-cli  (then: az login)"
+if ($SetGitHubSecrets) { Require-Cli gh "Install: brew install gh  (then: gh auth login)" }
+
+# Fail early with a clear message if not logged in.
+$null = az account show 2>$null
+if ($LASTEXITCODE -ne 0) { throw "Not logged in to Azure. Run: az login" }
+
+Write-Host "==> Selecting subscription $($cfg.SubscriptionId)" -ForegroundColor Cyan
+az account set --subscription $cfg.SubscriptionId
+$TenantId = az account show --query tenantId -o tsv
+
+# ---------------------------------------------------------------------------
+# 0. (optional) resource group — the signing account/profile must be made by hand.
+# ---------------------------------------------------------------------------
+if ($CreateResourceGroup) {
+    Write-Host "==> Ensuring resource group $($cfg.ResourceGroup)" -ForegroundColor Cyan
+    az group create --name $cfg.ResourceGroup --location $cfg.Location --only-show-errors | Out-Null
+}
+
+$ProfileScope = "/subscriptions/$($cfg.SubscriptionId)/resourceGroups/$($cfg.ResourceGroup)" +
+    "/providers/Microsoft.CodeSigning/codeSigningAccounts/$($cfg.SigningAccount)" +
+    "/certificateProfiles/$($cfg.CertProfile)"
+
+# Verify the manually-created signing account/profile actually exist before wiring CI to them.
+$acct = az resource show --ids "/subscriptions/$($cfg.SubscriptionId)/resourceGroups/$($cfg.ResourceGroup)/providers/Microsoft.CodeSigning/codeSigningAccounts/$($cfg.SigningAccount)" --query "name" -o tsv 2>$null
+if (-not $acct) {
+    throw "Trusted Signing account '$($cfg.SigningAccount)' not found in RG '$($cfg.ResourceGroup)'. " +
+          "Create the account + a PublicTrust certificate profile in the Azure Portal first (see docs/code-signing.md)."
+}
+
+# ---------------------------------------------------------------------------
+# 1. App registration (find-or-create by display name)
+# ---------------------------------------------------------------------------
+Write-Host "==> App registration '$($cfg.AppDisplayName)'" -ForegroundColor Cyan
+$AppId = az ad app list --display-name $cfg.AppDisplayName --query "[0].appId" -o tsv
+if (-not $AppId) {
+    $AppId = az ad app create --display-name $cfg.AppDisplayName --query appId -o tsv
+    Write-Host "    created appId=$AppId"
+} else {
+    Write-Host "    exists  appId=$AppId"
+}
+
+# ---------------------------------------------------------------------------
+# 2. Service principal (find-or-create)
+# ---------------------------------------------------------------------------
+Write-Host "==> Service principal" -ForegroundColor Cyan
+$SpObjectId = az ad sp show --id $AppId --query id -o tsv 2>$null
+if (-not $SpObjectId) {
+    $SpObjectId = az ad sp create --id $AppId --query id -o tsv
+    Write-Host "    created spObjectId=$SpObjectId"
+} else {
+    Write-Host "    exists  spObjectId=$SpObjectId"
+}
+
+# ---------------------------------------------------------------------------
+# 3. Federated credentials
+#
+#    Branches use exact-match `subject` credentials. Tags use a *flexible* FIC
+#    (`claimsMatchingExpression`) instead, because Entra federated-credential
+#    `subject` is an EXACT string match — a wildcard subject like
+#    "repo:o/r:ref:refs/tags/*" never matches a real tag token and OIDC login
+#    fails with AADSTS700213. The flexible form (beta Graph endpoint) supports
+#    the `matches` operator and covers every `v*` tag with one credential.
+# ---------------------------------------------------------------------------
+Write-Host "==> Federated credentials" -ForegroundColor Cyan
+$AppObjectId = az ad app show --id $AppId --query id -o tsv
+$ficUrl = "https://graph.microsoft.com/beta/applications/$AppObjectId/federatedIdentityCredentials"
+$existing = (az rest --method get --url $ficUrl | ConvertFrom-Json).value
+
+# 3a. Branch credentials (exact subject)
+foreach ($b in $cfg.Branches) {
+    $name = "gh-$b"
+    $subject = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
+    if (@($existing.subject) -contains $subject) {
+        Write-Host "    exists  $name -> $subject"
+        continue
+    }
+    $body = @{
+        name      = $name
+        issuer    = 'https://token.actions.githubusercontent.com'
+        subject   = $subject
+        audiences = @('api://AzureADTokenExchange')
+    } | ConvertTo-Json -Compress
+    $tmp = New-TemporaryFile
+    Set-Content -Path $tmp -Value $body -Encoding utf8
+    az ad app federated-credential create --id $AppId --parameters "@$tmp" --only-show-errors | Out-Null
+    Remove-Item $tmp
+    Write-Host "    created $name -> $subject"
+}
+
+# 3b. Tag credential (flexible claimsMatchingExpression)
+$tagName = 'gh-tags'
+$tagExpr = "claims['sub'] matches 'repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*'"
+$tagCred = $existing | Where-Object { $_.name -eq $tagName }
+if ($tagCred -and $tagCred.subject) {
+    # Legacy broken form (wildcard subject) from before the flexible-FIC fix — replace it.
+    az ad app federated-credential delete --id $AppId --federated-credential-id $tagCred.id --only-show-errors | Out-Null
+    Write-Host "    removed legacy subject-based $tagName"
+    $tagCred = $null
+}
+if (-not $tagCred) {
+    $body = @{
+        name                     = $tagName
+        issuer                   = 'https://token.actions.githubusercontent.com'
+        audiences                = @('api://AzureADTokenExchange')
+        claimsMatchingExpression = @{ value = $tagExpr; languageVersion = 1 }
+    } | ConvertTo-Json -Compress -Depth 5
+    $tmp = New-TemporaryFile
+    Set-Content -Path $tmp -Value $body -Encoding utf8
+    az rest --method post --url $ficUrl --headers "Content-Type=application/json" --body "@$tmp" | Out-Null
+    Remove-Item $tmp
+    Write-Host "    created (flexible) $tagName -> $tagExpr"
+} else {
+    Write-Host "    exists  (flexible) $tagName"
+}
+
+# ---------------------------------------------------------------------------
+# 4. Role assignment at the certificate-profile scope
+# ---------------------------------------------------------------------------
+Write-Host "==> Role assignment '$($cfg.SignerRole)'" -ForegroundColor Cyan
+$have = az role assignment list --assignee-object-id $SpObjectId --scope $ProfileScope --include-inherited `
+    --query "[?roleDefinitionName=='$($cfg.SignerRole)'] | length(@)" -o tsv
+if ($have -eq '0' -or -not $have) {
+    az role assignment create `
+        --assignee-object-id $SpObjectId `
+        --assignee-principal-type ServicePrincipal `
+        --role $cfg.SignerRole `
+        --scope $ProfileScope --only-show-errors | Out-Null
+    Write-Host "    created (propagation can take a few minutes)"
+} else {
+    Write-Host "    exists"
+}
+
+# ---------------------------------------------------------------------------
+# 5. Discover the signing endpoint and emit the GitHub secret values
+# ---------------------------------------------------------------------------
+$Endpoint = az rest --method get `
+    --url "https://management.azure.com$('/subscriptions/' + $cfg.SubscriptionId + '/resourceGroups/' + $cfg.ResourceGroup + '/providers/Microsoft.CodeSigning/codeSigningAccounts/' + $cfg.SigningAccount)?api-version=2024-02-05-preview" `
+    --query "properties.accountUri" -o tsv
+
+$secrets = [ordered]@{
+    AZURE_CLIENT_ID       = $AppId
+    AZURE_TENANT_ID       = $TenantId
+    AZURE_SUBSCRIPTION_ID = $cfg.SubscriptionId
+    AZURE_SIGNING_ACCOUNT = $cfg.SigningAccount
+    AZURE_SIGNING_PROFILE = $cfg.CertProfile
+    AZURE_SIGNING_ENDPOINT = $Endpoint
+}
+
+Write-Host "`n==> GitHub Actions secrets (release.yml):" -ForegroundColor Green
+foreach ($k in $secrets.Keys) { "{0}={1}" -f $k, $secrets[$k] }
+
+if ($SetGitHubSecrets) {
+    Write-Host "`n==> Pushing secrets to $($cfg.GhOwner)/$($cfg.GhRepo)" -ForegroundColor Cyan
+    foreach ($k in $secrets.Keys) {
+        gh secret set $k --repo "$($cfg.GhOwner)/$($cfg.GhRepo)" --body $secrets[$k]
+        Write-Host "    set $k"
+    }
+}
+
+Write-Host "`nSetup complete. Verify with: pwsh scripts/ValidateAzure.ps1" -ForegroundColor Green

--- a/scripts/ValidateAzure.ps1
+++ b/scripts/ValidateAzure.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+  Verifies MCE Controller's Azure Trusted Signing OIDC trust is correctly configured for CI.
+
+.DESCRIPTION
+  Read-only. Reads scripts/Azure.Config.ps1, discovers the app registration by display
+  name, then asserts: the expected federated-credential subjects exist and a valid signer
+  role is assigned at the certificate-profile scope. Throws on the first problem.
+  Run after SetupAzure.ps1 (or any time you suspect drift).
+
+.NOTES
+  Requires: pwsh 7+, Azure CLI (az) logged in with read access to the app + subscription.
+#>
+#requires -Version 7
+[CmdletBinding()]
+param(
+    [string]$ConfigPath = "$PSScriptRoot/Azure.Config.ps1"
+)
+
+$ErrorActionPreference = 'Stop'
+$cfg = & $ConfigPath
+
+az account set --subscription $cfg.SubscriptionId
+$TenantId = az account show --query tenantId -o tsv
+
+$AppId = az ad app list --display-name $cfg.AppDisplayName --query "[0].appId" -o tsv
+if (-not $AppId) { throw "App registration '$($cfg.AppDisplayName)' not found. Run scripts/SetupAzure.ps1 first." }
+$SpObjectId = az ad sp show --id $AppId --query id -o tsv
+
+$ProfileScope = "/subscriptions/$($cfg.SubscriptionId)/resourceGroups/$($cfg.ResourceGroup)" +
+    "/providers/Microsoft.CodeSigning/codeSigningAccounts/$($cfg.SigningAccount)" +
+    "/certificateProfiles/$($cfg.CertProfile)"
+
+Write-Host "TenantId:     $TenantId"
+Write-Host "AppId:        $AppId"
+Write-Host "SP ObjectId:  $SpObjectId"
+Write-Host "ProfileScope: $ProfileScope"
+
+# 1) Federated credentials. Read via the beta Graph endpoint so the flexible tag
+#    credential's claimsMatchingExpression is visible (the v1.0 `az` list omits it).
+#    Branches are exact-match subjects; tags are a flexible claimsMatchingExpression
+#    (Entra `subject` is exact-match, so a wildcard tag subject can't work — see
+#    SetupAzure.ps1 / docs/code-signing.md). Note ${GhRepo}: the bare $GhRepo:ref form
+#    makes PowerShell treat 'GhRepo:' as a scope qualifier and silently drops the repo name.
+$AppObjectId = az ad app show --id $AppId --query id -o tsv
+$fics = (az rest --method get --url "https://graph.microsoft.com/beta/applications/$AppObjectId/federatedIdentityCredentials" | ConvertFrom-Json).value
+$fics | Select-Object name, subject, @{ n = 'claimsExpr'; e = { $_.claimsMatchingExpression.value } } | Format-Table -AutoSize
+
+# Branches: exact subject must be present
+foreach ($b in $cfg.Branches) {
+    $subject = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/heads/$b"
+    if (-not ($fics.subject -contains $subject)) {
+        throw "Missing federated credential subject: $subject"
+    }
+}
+
+# Tags: a flexible credential whose expression covers refs/tags/* must be present
+$expectedTagPattern = "repo:$($cfg.GhOwner)/$($cfg.GhRepo):ref:refs/tags/*"
+$tagCred = $fics | Where-Object { $_.claimsMatchingExpression -and $_.claimsMatchingExpression.value -like "*$expectedTagPattern*" }
+if (-not $tagCred) {
+    throw "Missing flexible federated credential (claimsMatchingExpression) covering: $expectedTagPattern"
+}
+
+# 2) Role assignment at the certificate-profile scope
+$assignments = az role assignment list `
+    --assignee-object-id $SpObjectId `
+    --scope $ProfileScope `
+    --include-inherited `
+    --query "[].{role:roleDefinitionName,scope:scope,principalType:principalType}" | ConvertFrom-Json
+
+$assignments | Format-Table -AutoSize
+
+# Accept either the current or the legacy role name (Microsoft renamed it).
+$validRoles = @(
+    'Artifact Signing Certificate Profile Signer',
+    'Trusted Signing Certificate Profile Signer'
+)
+if (-not ($assignments | Where-Object { $validRoles -contains $_.role })) {
+    throw "Expected signer role not found at certificate profile scope."
+}
+
+# 3) GitHub secret values to set/confirm
+$Endpoint = az rest --method get `
+    --url "https://management.azure.com$('/subscriptions/' + $cfg.SubscriptionId + '/resourceGroups/' + $cfg.ResourceGroup + '/providers/Microsoft.CodeSigning/codeSigningAccounts/' + $cfg.SigningAccount)?api-version=2024-02-05-preview" `
+    --query "properties.accountUri" -o tsv
+
+"AZURE_CLIENT_ID=$AppId"
+"AZURE_TENANT_ID=$TenantId"
+"AZURE_SUBSCRIPTION_ID=$($cfg.SubscriptionId)"
+"AZURE_SIGNING_ACCOUNT=$($cfg.SigningAccount)"
+"AZURE_SIGNING_PROFILE=$($cfg.CertProfile)"
+"AZURE_SIGNING_ENDPOINT=$Endpoint"
+
+Write-Host "`nValidation complete." -ForegroundColor Green


### PR DESCRIPTION
Answers "can I reuse winprint's signing for mcec?" — **yes**, and this wires it up. winprint's Windows signing is **Azure Trusted Signing via GitHub OIDC** (no `.pfx`, no client secret), so there's nothing to copy — the certificate identity (publisher = **Kindel LLC**) is reusable across apps; only a repo-scoped OIDC trust + a signing step are new.

## What this adds
- **`scripts/Azure.Config.ps1`** — single source of truth. **Reuses** winprint's validated Trusted Signing account (`winprint`) + cert profile (`WinPrint`) in `WinPrint_Resources`; creates a **dedicated `mcec` app registration** with its own OIDC federated credentials for `repo:tig/mcec` (`develop`/`main` + flexible `refs/tags/*`). **No identity re-validation.**
- **`scripts/SetupAzure.ps1` / `ValidateAzure.ps1`** — idempotent find-or-create of the app reg, federated creds, and signer-role assignment; pushes the six `AZURE_*` secrets. Copied from winprint (fully config-driven; the OIDC gotchas are preserved — beta-Graph flexible tag credential, exact-match subjects, the “Artifact Signing …” role rename).
- **`.github/workflows/release.yml`** — on a `v*` tag (or manual dispatch): builds the self-contained installer via `Release.ps1`, signs `MCEController.Setup.exe` with `azure/artifact-signing-action@v2`, and publishes the GitHub Release. **Gated** on the `AZURE_*` secrets — without them it still builds + publishes an **unsigned** installer with a `::warning::`, so the path works on forks / before signing is set up.
- **`docs/code-signing.md`** — the runbook.

## To turn signing on (one-time, you run it)
The signing account/profile already exist (winprint), so there's **no Azure portal step**:
```bash
az login
pwsh scripts/SetupAzure.ps1 -SetGitHubSecrets
pwsh scripts/ValidateAzure.ps1
```
Then every `git push origin vX.Y.Z` cuts a **signed** release (fixes the SmartScreen "unknown publisher" warning on v2.4.0's unsigned installer).

## Verified
- [x] All three PowerShell scripts parse; `Azure.Config.ps1` returns the expected hashtable.
- [x] `release.yml` is valid YAML; build/release path mirrors the working `ci.yml` conventions.
- [x] No change to app build/tests (this is scripts + workflow + docs) — `ci.yml` is unaffected.

> ⚠️ The OIDC **signing step itself can't be exercised from here** (needs the federated credential, which only exists after you run `SetupAzure.ps1`). It's constructed to match the documented `azure/artifact-signing-action@v2` inputs — please confirm the first tag-triggered signed run is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)