### PR TITLE
winget packaging + auto-submit (Kindel.mcec)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ permissions:
 
 env:
   SIGN: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' && secrets.AZURE_SIGNING_ACCOUNT != '' && secrets.AZURE_SIGNING_PROFILE != '' && secrets.AZURE_SIGNING_ENDPOINT != '' }}
+  HAS_WINGET: ${{ secrets.WINGET_TOKEN != '' }}
 
 jobs:
   release:
@@ -100,3 +101,30 @@ jobs:
             --generate-notes `
             --latest `
             artifacts/MCEController.Setup.exe
+
+  # Auto-submit the new version to winget-pkgs on every STABLE release (skips pre-releases
+  # and is gated on the WINGET_TOKEN secret). Requires a one-time manual bootstrap of the
+  # package into microsoft/winget-pkgs — see packaging/winget/README.md.
+  winget:
+    name: Submit to winget-pkgs
+    needs: release
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && !contains(github.ref_name, '-') }}
+    steps:
+      - name: Derive version (strip leading v)
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Submit to winget-pkgs
+        if: ${{ env.HAS_WINGET == 'true' }}
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Kindel.mcec
+          version: ${{ steps.ver.outputs.version }}
+          release-tag: ${{ github.ref_name }}
+          installers-regex: 'MCEController\.Setup\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}
+
+      - name: Skipped (no WINGET_TOKEN)
+        if: ${{ env.HAS_WINGET != 'true' }}
+        run: echo "::notice::WINGET_TOKEN not set — skipping winget-pkgs submission. See packaging/winget/README.md."

--- a/packaging/winget/Kindel.mcec.installer.yaml
+++ b/packaging/winget/Kindel.mcec.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+# Replace {{version}}, {{installerUrl}}, {{installerSha256}}, {{releaseDate}} with values
+# from the signed release (https://github.com/tig/mcec/releases). See README.md.
+PackageIdentifier: Kindel.mcec
+PackageVersion: "{{version}}"
+# MCE Controller ships an NSIS installer (per-machine; requires elevation). winget's
+# "nullsoft" type knows the silent switch is /S.
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+ReleaseDate: "{{releaseDate}}"
+Installers:
+  - Architecture: x64
+    InstallerUrl: "{{installerUrl}}"
+    InstallerSha256: "{{installerSha256}}"
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/packaging/winget/Kindel.mcec.locale.en-US.yaml
+++ b/packaging/winget/Kindel.mcec.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+PackageIdentifier: Kindel.mcec
+PackageVersion: "{{version}}"
+PackageLocale: en-US
+Publisher: Kindel Systems
+PublisherUrl: https://github.com/tig
+PublisherSupportUrl: https://github.com/tig/mcec/issues
+Author: Kindel Systems
+PackageName: MCE Controller
+PackageUrl: https://github.com/tig/mcec
+License: MIT
+Copyright: Copyright © Kindel Systems, LLC.
+ShortDescription: Control a Windows PC over the network or serial port.
+Description: |-
+  MCE Controller lets you control a Windows PC — Windows Media Center and beyond — over
+  the network (TCP/IP) or a serial port. It runs as a server that receives text commands
+  and turns them into keystrokes, mouse actions, launched programs, window activations,
+  and power/shutdown actions, with a configurable command set.
+Moniker: mcec
+Tags:
+  - media-center
+  - remote-control
+  - automation
+  - home-theater
+  - htpc
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/packaging/winget/Kindel.mcec.yaml
+++ b/packaging/winget/Kindel.mcec.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+# Template for submitting MCE Controller to microsoft/winget-pkgs.
+# Replace {{version}} (e.g. 2.4.1). Ongoing releases are auto-submitted by CI
+# (the `winget` job in .github/workflows/release.yml) — these files are the
+# source-of-truth template + the one-time bootstrap. See README.md.
+PackageIdentifier: Kindel.mcec
+PackageVersion: "{{version}}"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,61 @@
+# winget packaging
+
+Makes `winget install Kindel.mcec` work by publishing manifests to the
+[microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) community repository
+(winget's default source). The files here are the manifest **templates** and the source of
+truth for the one-time bootstrap; ongoing version updates are automated by CI.
+
+## How it works
+
+| Stage | Who | What |
+|-------|-----|------|
+| First version | **manual, once** | Submit the initial manifests to winget-pkgs (it requires a package to already exist before it can be auto-updated). Done for 2.4.1 — see below. |
+| Every later release | **automated** | The `winget` job in `.github/workflows/release.yml` runs `winget-releaser` on each **stable** tag, opening a winget-pkgs PR with the new version + signed installer. |
+
+The installer is Authenticode-signed (Azure Trusted Signing — see `../../docs/code-signing.md`),
+which smooths winget validation (sandbox install/uninstall + SmartScreen).
+
+## One-time setup
+
+1. **Create the token.** A classic GitHub **PAT** with **`public_repo`** scope (fine-grained
+   PATs are *not* supported by winget-releaser). Save it as the repo secret **`WINGET_TOKEN`**.
+   The PAT's account must have a fork of `microsoft/winget-pkgs` (tig already does). Until this
+   secret exists, the `winget` CI job is skipped (gated on `HAS_WINGET`).
+
+2. **Bootstrap the first version** into winget-pkgs. This was done for **2.4.1** as
+   [microsoft/winget-pkgs#394798](https://github.com/microsoft/winget-pkgs/pull/394798)
+   (manifests under `manifests/k/Kindel/mcec/2.4.1/`). First submissions for a new
+   package are **manually reviewed** by winget-pkgs moderators.
+
+   To bootstrap another version by hand: render the templates here (replace `{{version}}`,
+   `{{installerUrl}}`, `{{installerSha256}}`, `{{releaseDate}}`), `winget validate --manifest .`,
+   and open a PR under `manifests/k/Kindel/mcec/<version>/`. `komac` automates this:
+   ```bash
+   komac update Kindel.mcec --version <v> \
+     --urls https://github.com/tig/mcec/releases/download/v<v>/MCEController.Setup.exe \
+     --token <PAT> --submit
+   ```
+
+After the package exists in winget-pkgs and `WINGET_TOKEN` is set, **no further manual steps
+are needed** — each stable release auto-submits its update.
+
+## Values for a bootstrap submission (fill from the release)
+
+```
+PackageVersion:  2.4.1
+InstallerUrl:    https://github.com/tig/mcec/releases/download/v2.4.1/MCEController.Setup.exe
+InstallerSha256: 393B4066AFF168482038A7C61916B5D526617CFCED73F5D832315B3100338652
+ReleaseDate:     2026-06-29
+```
+
+## Notes / things to validate on a real install
+
+- **Installer type `nullsoft`** (NSIS), **`Scope: machine`** — installs to
+  `C:\Program Files\Kindel Systems\MCE Controller` and requires elevation. winget's silent mode
+  and the winget-pkgs sandbox use the NSIS `/S` switch.
+- **`winget upgrade` correlation:** the manifests intentionally omit `AppsAndFeaturesEntries`
+  for now. The NSIS installer registers its Add/Remove Programs `DisplayName` as
+  "MCE Controller `<version>`" (includes the version). Before adding `AppsAndFeaturesEntries`,
+  standardize the installer `DisplayName` to just "MCE Controller" (drop the version, keep
+  `DisplayVersion`) so upgrade detection is stable across versions.
+- Only the **x64** installer is published; add more `Installers` entries if other arches ship.


### PR DESCRIPTION
Makes `winget install Kindel.mcec` work and keeps it updated on every release.

- **`packaging/winget/`** — winget manifest templates (version / installer / locale) for **`Kindel.mcec`**: NSIS (`nullsoft`), per-machine x64, validated with `winget validate` — plus a README covering the bootstrap and the automated flow.
- **`.github/workflows/release.yml`** — new **`winget`** job: on each stable tag, `winget-releaser` opens a winget-pkgs PR with the new version + signed installer. Gated on `WINGET_TOKEN` (skips cleanly when unset); skips pre-release tags.

The **2.4.1 bootstrap** PR to microsoft/winget-pkgs is [microsoft/winget-pkgs#394798](https://github.com/microsoft/winget-pkgs/pull/394798).

**To turn on auto-updates:** add a classic GitHub PAT with `public_repo` scope as the repo secret **`WINGET_TOKEN`** (the account already has a winget-pkgs fork). Until then the job no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)