### PR TITLE
test: stop WindowsInput simulator tests from injecting real keyboard/mouse

### DIFF
--- a/tests/MCEControl.xUnit/WindowsInput/DesktopInputFactAttribute.cs
+++ b/tests/MCEControl.xUnit/WindowsInput/DesktopInputFactAttribute.cs
@@ -1,0 +1,22 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using Xunit;
+
+namespace MCEControl.xUnit.WindowsInput;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> for tests that dispatch REAL keyboard/mouse input through
+/// <c>SendInput</c>. They move the cursor and type into whatever window currently has focus — i.e.
+/// the terminal running <c>dotnet test</c> — which disrupts the desktop. These tests are therefore
+/// skipped by default and only run when <c>MCEC_DESKTOP_E2E=1</c> is set (the same opt-in as the
+/// desktop end-to-end test), so a normal <c>dotnet test</c> never injects input.
+/// </summary>
+public sealed class DesktopInputFactAttribute : FactAttribute {
+    public DesktopInputFactAttribute() {
+        if (Environment.GetEnvironmentVariable("MCEC_DESKTOP_E2E") != "1") {
+            Skip = "Dispatches real keyboard/mouse input into the active desktop; set MCEC_DESKTOP_E2E=1 to run.";
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/WindowsInput/InputSimulatorTests.cs
+++ b/tests/MCEControl.xUnit/WindowsInput/InputSimulatorTests.cs
@@ -7,28 +7,28 @@ namespace MCEControl.xUnit.WindowsInput;
 
 public class InputSimulatorTests
 {
-    [Fact]
+    [DesktopInputFact]
     public void Constructor_InitializesSimulator()
     {
         var simulator = new InputSimulator();
         Assert.NotNull(simulator);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void Keyboard_PropertyNotNull()
     {
         var simulator = new InputSimulator();
         Assert.NotNull(simulator.Keyboard);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void Mouse_PropertyNotNull()
     {
         var simulator = new InputSimulator();
         Assert.NotNull(simulator.Mouse);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void InputDeviceState_PropertyNotNull()
     {
         var simulator = new InputSimulator();

--- a/tests/MCEControl.xUnit/WindowsInput/KeyboardSimulatorTests.cs
+++ b/tests/MCEControl.xUnit/WindowsInput/KeyboardSimulatorTests.cs
@@ -7,7 +7,7 @@ namespace MCEControl.xUnit.WindowsInput;
 
 public class KeyboardSimulatorTests
 {
-    [Fact]
+    [DesktopInputFact]
     public void Constructor_InitializesSimulator()
     {
         var simulator = new InputSimulator();
@@ -15,7 +15,7 @@ public class KeyboardSimulatorTests
         Assert.NotNull(keyboard);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void KeyDown_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -23,7 +23,7 @@ public class KeyboardSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void KeyUp_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -31,7 +31,7 @@ public class KeyboardSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void KeyPress_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -39,7 +39,7 @@ public class KeyboardSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void TextEntry_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -47,7 +47,7 @@ public class KeyboardSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void TextEntry_WithEmptyString_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -55,7 +55,7 @@ public class KeyboardSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void ModifiedKeyStroke_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -63,7 +63,7 @@ public class KeyboardSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void ModifiedKeyStroke_WithMultipleModifiers_DoesNotThrow()
     {
         var simulator = new InputSimulator();

--- a/tests/MCEControl.xUnit/WindowsInput/MouseSimulatorTests.cs
+++ b/tests/MCEControl.xUnit/WindowsInput/MouseSimulatorTests.cs
@@ -7,7 +7,7 @@ namespace MCEControl.xUnit.WindowsInput;
 
 public class MouseSimulatorTests
 {
-    [Fact]
+    [DesktopInputFact]
     public void Constructor_InitializesSimulator()
     {
         var simulator = new InputSimulator();
@@ -15,7 +15,7 @@ public class MouseSimulatorTests
         Assert.NotNull(mouse);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void LeftButtonClick_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -23,7 +23,7 @@ public class MouseSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void LeftButtonDown_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -31,7 +31,7 @@ public class MouseSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void LeftButtonUp_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -39,7 +39,7 @@ public class MouseSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void LeftButtonDoubleClick_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -47,7 +47,7 @@ public class MouseSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void RightButtonClick_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -55,7 +55,7 @@ public class MouseSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void MoveMouseBy_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -63,7 +63,7 @@ public class MouseSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void MoveMouseTo_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -71,7 +71,7 @@ public class MouseSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void VerticalScroll_DoesNotThrow()
     {
         var simulator = new InputSimulator();
@@ -79,7 +79,7 @@ public class MouseSimulatorTests
         Assert.Null(exception);
     }
 
-    [Fact]
+    [DesktopInputFact]
     public void HorizontalScroll_DoesNotThrow()
     {
         var simulator = new InputSimulator();


### PR DESCRIPTION
`KeyboardSimulatorTests`, `MouseSimulatorTests`, and `InputSimulatorTests` exercised the real `InputSimulator` (`KeyPress`, `TextEntry`, `LeftButtonClick`, `MoveMouseBy`, …), which dispatches **`SendInput`** into whatever window has focus. So a plain `dotnet test` actually **typed characters and clicked into the active terminal** — disrupting the desktop (and dismissing interactive prompts). The tests only asserted *"does not throw"*, so there was no value to justify the side effect.

This gates them behind a new **`[DesktopInputFact]`** that skips unless `MCEC_DESKTOP_E2E=1` is set — the same opt-in as the desktop E2E — so a normal `dotnet test` never injects input. To run them deliberately: `$env:MCEC_DESKTOP_E2E=1; dotnet test`.

No production code changes; 4 files (1 new attribute + 3 test files re-annotated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)