### PR TITLE
fix: Help > Documentation throws unhandled exception (fixes #82)

### DIFF
--- a/src/Commands/ShutdownCommand.cs
+++ b/src/Commands/ShutdownCommand.cs
@@ -114,7 +114,14 @@ public class ShutdownCommand : Command {
     public static void Shutdown(string shutdownArgs) {
         Logger.Instance.Log4.Debug($"ShutdownCommand: Invoking 'shutdown.exe {shutdownArgs}'");
 
-        Process proc = System.Diagnostics.Process.Start("shutdown", shutdownArgs);
+        Process? proc = Process.Start(new ProcessStartInfo {
+            FileName = "shutdown",
+            Arguments = shutdownArgs
+        });
+        if (proc == null) {
+            Logger.Instance.Log4.Error($"ShutdownCommand: failed to start 'shutdown.exe {shutdownArgs}'");
+            throw new System.ComponentModel.Win32Exception("Failed to start shutdown process");
+        }
         proc.WaitForExit(1000 * 2);
         if (proc.ExitCode != 0x0) {
             Logger.Instance.Log4.Error($"ShutdownCommand: 'shutdown.exe {shutdownArgs}' failed ({proc.ExitCode:X})");

--- a/src/Dialogs/About.cs
+++ b/src/Dialogs/About.cs
@@ -52,11 +52,11 @@ partial class About : Form {
 
     private void LinkLabelMceControllerLinkClicked(object sender, LinkLabelLinkClickedEventArgs e) {
         TelemetryService.Instance.TrackEvent("About Box License Link Clicked");
-        Process.Start(_linkLabelMceController.Tag!.ToString()!);
+        Program.LaunchExternal(_linkLabelMceController.Tag!.ToString()!);
     }
 
     private void LinkLabelCharlieLinkClicked(object sender, LinkLabelLinkClickedEventArgs e) {
         TelemetryService.Instance.TrackEvent("About Box Kindel Page Link Clicked");
-        Process.Start(_linkLabelKindel.Tag!.ToString()!);
+        Program.LaunchExternal(_linkLabelKindel.Tag!.ToString()!);
     }
 }

--- a/src/Dialogs/UpdateDialog.cs
+++ b/src/Dialogs/UpdateDialog.cs
@@ -29,7 +29,7 @@ public partial class UpdateDialog : Form {
     }
 
     private void linkReleasePage_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) {
-        Process.Start((string)linkReleasePage.Links[0].LinkData!);
+        Program.LaunchExternal((string)linkReleasePage.Links[0].LinkData!);
     }
 
     private void UpdateDialog_VisibleChanged(object sender, EventArgs e) {

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -840,20 +840,20 @@ public partial class MainWindow : Form {
     private void openCommandsFolderMenuItem_Click(object sender, EventArgs e) {
         TelemetryService.Instance.TrackEvent("openCommandsFolderMenuItem");
 
-        Process.Start(Program.ConfigPath);
+        Program.LaunchExternal(Program.ConfigPath);
     }
 
 
     private void docsMenuItem_Click(object sender, EventArgs e) {
         TelemetryService.Instance.TrackEvent("docsMenuItem");
 
-        Process.Start("https://tig.github.io/mcec/");
+        Program.LaunchExternal("https://tig.github.io/mcec/");
     }
 
     private void MenuItemEditCommands_Click(object sender, EventArgs e) {
         TelemetryService.Instance.TrackEvent("MenuItemEditCommands");
 
-        Process.Start(Program.ConfigPath);
+        Program.LaunchExternal(Program.ConfigPath);
     }
 
     private void updatesMenuItem_Click(object sender, EventArgs e) {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -2,6 +2,7 @@
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -31,6 +32,34 @@ internal static class Program {
             }
 
             return path;
+        }
+    }
+
+    /// <summary>
+    /// Safely launches a URL, file, or folder using the shell (UseShellExecute).
+    /// Catches launch errors (e.g. no browser association), logs them, and shows a non-fatal message.
+    /// </summary>
+    internal static void LaunchExternal(string target) {
+        if (string.IsNullOrWhiteSpace(target)) {
+            return;
+        }
+
+        try {
+            Process.Start(new ProcessStartInfo {
+                FileName = target,
+                UseShellExecute = true
+            });
+        } catch (Exception ex) {
+            Logger.Instance.Log4.Error($"Failed to launch external target '{target}': {ex.Message}");
+            try {
+                MessageBox.Show(
+                    $"MCE Controller could not open:\n{target}\n\n{ex.Message}",
+                    "MCE Controller",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            } catch {
+                // UI may not be available (e.g. headless)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes unhandled exception when clicking **Help > Documentation...** (and similar external launch actions).

- Introduced `Program.LaunchExternal(string)` helper that uses `ProcessStartInfo` + `UseShellExecute = true` (required on modern .NET/Windows for URLs and shell folders).
- All launches now go through the helper (or equivalent PSI pattern).
- Errors (Win32Exception, etc.) are caught, logged via Logger, and a non-crashing warning MessageBox is shown to the user.
- Audited and updated:
  - `docsMenuItem_Click` (the reported crash)
  - Folder open actions
  - About box links
  - Update dialog release link
  - `ShutdownCommand` (for consistency)
- `StartProcessCommand` and `UpdateService` already used safe PSI.

Closes #82
