### PR TITLE
Customer 0 walking skeleton (#98) + expand/collapse UIA action + agent guidance

### DIFF
--- a/scripts/Run-Customer0Skeleton.ps1
+++ b/scripts/Run-Customer0Skeleton.ps1
@@ -79,14 +79,14 @@ function Add-Step {
 # MCP JSON-RPC over HTTP, with full request/response logging to tool-calls.jsonl
 # ---------------------------------------------------------------------------
 function Invoke-Mcp {
-    param([string]$Method, [hashtable]$Params)
+    param([string]$Method, [hashtable]$Params, [int]$TimeoutSec = 30)
     $script:rpcId++
     $req = @{ jsonrpc = "2.0"; id = $script:rpcId; method = $Method; params = $Params }
     $body = $req | ConvertTo-Json -Depth 12 -Compress
     $entry = [ordered]@{ ts = (Get-Date).ToString("o"); sessionId = $sessionId; direction = "request"; method = $Method; payload = $req }
     ($entry | ConvertTo-Json -Depth 12 -Compress) | Add-Content -Path $toolCallLog -Encoding utf8
 
-    $resp = Invoke-RestMethod -Uri $mcpUrl -Method Post -Body $body -ContentType "application/json" -TimeoutSec 30
+    $resp = Invoke-RestMethod -Uri $mcpUrl -Method Post -Body $body -ContentType "application/json" -TimeoutSec $TimeoutSec
     $rentry = [ordered]@{ ts = (Get-Date).ToString("o"); sessionId = $sessionId; direction = "response"; method = $Method; payload = $resp }
     ($rentry | ConvertTo-Json -Depth 20 -Compress) | Add-Content -Path $toolCallLog -Encoding utf8
     return $resp
@@ -94,8 +94,8 @@ function Invoke-Mcp {
 
 # Call an MCP tool and return the parsed structured JSON payload (content[0].text).
 function Invoke-Tool {
-    param([string]$Name, [hashtable]$Arguments = @{})
-    $resp = Invoke-Mcp -Method "tools/call" -Params @{ name = $Name; arguments = $Arguments }
+    param([string]$Name, [hashtable]$Arguments = @{}, [int]$TimeoutSec = 30)
+    $resp = Invoke-Mcp -Method "tools/call" -Params @{ name = $Name; arguments = $Arguments } -TimeoutSec $TimeoutSec
     if ($null -ne ($resp.PSObject.Properties['error']) -and $resp.error) {
         throw "MCP tool '$Name' error: $($resp.error | ConvertTo-Json -Compress)"
     }
@@ -150,6 +150,18 @@ function Wait-For {
     return $null
 }
 
+# Force-kill every mcec.exe launched from $dir and wait for them to exit, so a modal dialog left
+# open by a prior run (the invoke-on-modal blocks the call but the process is still killable) can't
+# bleed into the next run.
+function Stop-RunDirMcec {
+    param([string]$dir)
+    $sel = { Get-Process -Name "mcec" -ErrorAction SilentlyContinue |
+        Where-Object { try { $_.Path -and $_.Path.StartsWith($dir) } catch { $false } } }
+    & $sel | Stop-Process -Force -ErrorAction SilentlyContinue
+    $deadline = [DateTime]::UtcNow.AddSeconds(6)
+    while ([DateTime]::UtcNow -lt $deadline -and (& $sel)) { Start-Sleep -Milliseconds 200 }
+}
+
 # ===========================================================================
 # MAIN
 # ===========================================================================
@@ -158,10 +170,7 @@ try {
     # --- Provision an isolated, MCP-enabled config by copying the build output ---
     Add-Step "provision" "run" "copy build output -> $runDir"
     if (Test-Path $runDir) {
-        Get-Process -Name "mcec" -ErrorAction SilentlyContinue |
-            Where-Object { try { $_.Path -and $_.Path.StartsWith($runDir) } catch { $false } } |
-            Stop-Process -Force -ErrorAction SilentlyContinue
-        Start-Sleep -Milliseconds 300
+        Stop-RunDirMcec $runDir
         Remove-Item -LiteralPath $runDir -Recurse -Force -ErrorAction SilentlyContinue
     }
     New-Item -ItemType Directory -Force -Path (Split-Path $runDir) | Out-Null
@@ -216,45 +225,47 @@ try {
     Invoke-Mcp -Method "tools/list" -Params @{} | Out-Null
     Add-Step "launch" "pass" "MCP HTTP up on $mcpUrl"
 
-    # --- Wait for the main window (selector + wait stubs) ---
+    # --- Wait for the main window (selector + wait stubs). Match the title exactly ("MCEC") and
+    #     capture its handle, then target everything else by that handle — so a stale 'About'
+    #     dialog (which also belongs to process mcec) can never be mistaken for the main window. ---
     $win = Wait-For -TimeoutMs 20000 -Condition {
-        $q = Invoke-Tool -Name "query" -Arguments @{ process = "mcec"; maxDepth = 1 }
-        if ($q -and $q.window -and $q.window.handle) { return $q } else { return $null }
+        $q = Invoke-Tool -Name "query" -Arguments @{ window = "MCEC"; maxDepth = 1 }
+        if ($q -and $q.window -and $q.window.handle -and $q.window.title -eq "MCEC") { return $q } else { return $null }
     }
     if (-not $win) { throw "MCEC main window did not appear via query within 20s" }
-    $lastGoodObservation = "main window: '$($win.window.title)' handle=$($win.window.handle)"
+    $mainHandle = $win.window.handle
+    $lastGoodObservation = "main window: '$($win.window.title)' handle=$mainHandle"
     Add-Step "wait-window" "pass" $lastGoodObservation
 
-    # --- Observe: capture + non-blank validation ---
+    # --- Observe: capture + non-blank validation (target the main window by handle) ---
     $shot = Join-Path $artifactDir "screenshot.png"
-    $cap = Invoke-Tool -Name "capture" -Arguments @{ process = "mcec"; file = $shot }
+    $cap = Invoke-Tool -Name "capture" -Arguments @{ handle = $mainHandle; file = $shot }
     if (-not (Test-Path $shot)) { throw "capture did not produce $shot" }
     if (-not (Test-PngNonBlank $shot)) { throw "captured frame failed non-blank validation (likely black/blank)" }
     $lastGoodObservation = "non-blank capture $($cap.width)x$($cap.height) -> screenshot.png"
     Add-Step "observe" "pass" $lastGoodObservation
 
-    # --- Act: invoke Help > About via UIA. The dropdown is a separate popup HWND, so we
-    #     try the direct invoke first, then a Help-then-About sequence as a fallback. ---
-    $actNote = ""
+    # --- Act: open the Help menu with `expand` (ExpandCollapse, falling back to Invoke for the
+    #     WinForms ToolStripMenuItem), then invoke About... Once Help is expanded its sub-items
+    #     appear as descendants of the SAME main window (MCEC > Help > Menu > About...), so we
+    #     target the main window by handle — not the foreground. (This is the menu gap the first
+    #     skeleton run surfaced; the expand action + this targeting is the fix.) ---
+    Invoke-Tool -Name "invoke" -Arguments @{ handle = $mainHandle; by = "name"; value = "Help"; action = "expand" } | Out-Null
+    Start-Sleep -Milliseconds 400
+    # Invoking About... opens a MODAL dialog; because MCEC runs agent commands on its own UI
+    # thread in-process, the invoke call does not return until that modal closes. So fire it with
+    # a short timeout and let the verify step confirm the dialog actually opened. (Known limitation:
+    # synchronous actuation of modal-opening controls — feeds the actions/threading epic.)
     try {
-        Invoke-Tool -Name "invoke" -Arguments @{ process = "mcec"; by = "name"; value = "About..."; action = "invoke" } | Out-Null
-        $actNote = "invoke About... (direct)"
-    } catch { $actNote = "direct About... invoke threw: $($_.Exception.Message)" }
+        Invoke-Tool -Name "invoke" -Arguments @{ handle = $mainHandle; by = "name"; value = "About..."; action = "invoke" } -TimeoutSec 4 | Out-Null
+        $actNote = "expand Help -> invoke About..."
+    } catch {
+        $actNote = "expand Help -> invoke About... (call blocked on modal, expected; verifying)"
+    }
 
-    $about = Wait-For -TimeoutMs 5000 -Condition {
+    $about = Wait-For -TimeoutMs 6000 -Condition {
         $q = Invoke-Tool -Name "query" -Arguments @{ window = "About"; maxDepth = 1 }
         if ($q -and $q.window -and $q.window.handle) { return $q } else { return $null }
-    }
-    if (-not $about) {
-        # Fallback: open the Help menu, then invoke About...
-        try { Invoke-Tool -Name "invoke" -Arguments @{ process = "mcec"; by = "name"; value = "Help"; action = "invoke" } | Out-Null } catch {}
-        Start-Sleep -Milliseconds 600
-        try { Invoke-Tool -Name "invoke" -Arguments @{ by = "name"; value = "About..."; action = "invoke"; foreground = $true } | Out-Null } catch {}
-        $about = Wait-For -TimeoutMs 5000 -Condition {
-            $q = Invoke-Tool -Name "query" -Arguments @{ window = "About"; maxDepth = 1 }
-            if ($q -and $q.window -and $q.window.handle) { return $q } else { return $null }
-        }
-        $actNote += "; used Help->About fallback"
     }
     Add-Step "act" ($(if ($about) { "pass" } else { "fail" })) $actNote
 
@@ -317,8 +328,7 @@ finally {
 
     # --- Cleanup: stop the GUI (also closes the About dialog), remove the run dir ---
     if ($guiProc) { try { Stop-Process -Id $guiProc.Id -Force -ErrorAction SilentlyContinue } catch {} }
-    Get-Process -Name "mcec" -ErrorAction SilentlyContinue | Where-Object { try { $_.Path -and $_.Path.StartsWith($runDir) } catch { $false } } | Stop-Process -Force -ErrorAction SilentlyContinue
-    Start-Sleep -Milliseconds 500
+    Stop-RunDirMcec $runDir
     try { Remove-Item -Path $runDir -Recurse -Force -ErrorAction SilentlyContinue } catch {}
 
     # --- Zip the bundle ---

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -62,8 +62,11 @@ public static class UiaService {
 
     /// <summary>
     /// Finds an element (5s timeout) and dispatches <paramref name="action"/>
-    /// (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>). Returns true on success, false if
-    /// the element wasn't found or the required pattern is unsupported.
+    /// (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>).
+    /// Returns true on success, false if the element wasn't found or the required pattern is
+    /// unsupported. <c>expand</c> opens a collapsed menu/treeitem so its children become reachable —
+    /// a closed WinForms menu's sub-items are not in the UIA tree until the parent is opened. It uses
+    /// the ExpandCollapse pattern, falling back to Invoke for WinForms menu items that lack it.
     /// </summary>
     public static bool Invoke(IntPtr hwnd, string by, string value, string action, string? text) {
         if (hwnd == IntPtr.Zero) {
@@ -87,6 +90,8 @@ public static class UiaService {
                 "toggle" => InvokeToggle(el),
                 "setvalue" => InvokeSetValue(el, text),
                 "setfocus" => InvokeSetFocus(el),
+                "expand" => InvokeExpand(el),
+                "collapse" => InvokeCollapse(el),
                 _ => false,
             };
         }
@@ -100,7 +105,7 @@ public static class UiaService {
     /// (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>, case-insensitive).</summary>
     public static bool IsSupportedAction(string action) =>
         action?.ToLowerInvariant() switch {
-            "invoke" or "toggle" or "setvalue" or "setfocus" => true,
+            "invoke" or "toggle" or "setvalue" or "setfocus" or "expand" or "collapse" => true,
             _ => false,
         };
 
@@ -176,6 +181,32 @@ public static class UiaService {
 
     private static bool InvokeSetFocus(AutomationElement el) {
         el.Focus();
+        return true;
+    }
+
+    private static bool InvokeExpand(AutomationElement el) {
+        var pattern = el.Patterns.ExpandCollapse.PatternOrDefault;
+        if (pattern is not null) {
+            pattern.Expand();
+            return true;
+        }
+        // WinForms menu items (ToolStripMenuItem) open their dropdown via the Invoke pattern and do
+        // not expose ExpandCollapse. Fall back to Invoke so `expand` opens menus uniformly across
+        // WinForms and WPF/WinUI — letting an agent reach sub-items that aren't yet in the tree.
+        var invoke = el.Patterns.Invoke.PatternOrDefault;
+        if (invoke is not null) {
+            invoke.Invoke();
+            return true;
+        }
+        return false;
+    }
+
+    private static bool InvokeCollapse(AutomationElement el) {
+        var pattern = el.Patterns.ExpandCollapse.PatternOrDefault;
+        if (pattern is null) {
+            return false;
+        }
+        pattern.Collapse();
         return true;
     }
 

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -8,7 +8,7 @@ namespace MCEControl;
 
 /// <summary>
 /// Agent actuation command: resolves a target window, finds a single UIA element, then runs a UIA
-/// pattern action against it (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>). Gated by
+/// pattern action against it (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>). Gated by
 /// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited. Disabled by default (security).
 /// </summary>
 public class InvokeCommand : Command {

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -97,14 +97,22 @@ public static class AgentServer {
         "MCEC (Model Context Environment Controller) lets you see and drive native Windows apps.\n" +
         "Work the loop: observe -> target -> act -> observe.\n" +
         "1. TARGET a window by `window` (title substring), `process` (name without .exe), `className`, " +
-        "or `foreground:true`. You MUST give at least one of these — a call with no target fails.\n" +
+        "or `foreground:true` — you MUST give at least one; a call with no target fails. Reuse the " +
+        "`handle` a `query` returns for follow-up calls: it is stable, and a dialog you open shares the " +
+        "process name, so re-resolving by process/title can match the wrong window. Open menus and other " +
+        "untitled popups are not enumerated by title/process — target them by handle or `foreground:true`.\n" +
         "2. OBSERVE: `query` dumps the UI Automation tree (controlType, name, automationId, bounds, " +
         "state, value) so you can pick a control instead of guessing pixels; `capture` returns a PNG " +
         "of the window (works on composited WinUI/WPF surfaces).\n" +
-        "3. ACT: prefer `invoke` (by name/automationId/classname; action invoke|toggle|setvalue|setfocus) " +
-        "over coordinate clicks — it is far more reliable. Use `find`/`wait-for` to wait for a control " +
-        "to appear before acting. `send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
-        "4. VERIFY with another `query` or `capture`.\n" +
+        "3. ACT: prefer `invoke` (by name/automationId/classname; action invoke|toggle|setvalue|setfocus|" +
+        "expand|collapse) over coordinate clicks — it is far more reliable. To click a menu item, first " +
+        "`invoke` its parent menu with action `expand` (a closed menu's sub-items are not in the tree " +
+        "until opened), then `invoke` the item. Invoking a control that opens a MODAL dialog (About, " +
+        "Settings, message/file dialogs) may not return until that dialog is dismissed — MCEC runs " +
+        "commands on the app's UI thread — so do not block on it; after firing the invoke, `query`/" +
+        "`capture` the expected window to confirm it opened. Use `find` to wait for a control to appear " +
+        "before acting. `send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
+        "4. VERIFY with another `query` or `capture` — always confirm the act had the intended effect.\n" +
         "SECURITY: observation tools (capture/query/find/invoke) only work when the operator has set " +
         "AgentCommandsEnabled=true; otherwise they return an error — surface that to the user rather " +
         "than retrying. Every action is audit-logged on the host.";
@@ -154,7 +162,7 @@ public static class AgentServer {
         JsonObject invokeProps = WindowTargetProps();
         invokeProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
         invokeProps["value"] = PropSchema("string", "Value to match");
-        invokeProps["action"] = PropSchema("string", "invoke | toggle | setvalue | setfocus (default invoke)");
+        invokeProps["action"] = PropSchema("string", "invoke | toggle | setvalue | setfocus | expand | collapse (default invoke). Use expand to open a menu before invoking its items.");
         invokeProps["text"] = PropSchema("string", "Text for the setvalue action");
         tools.Add(Tool("invoke",
             "Drive a UI Automation element (Invoke/Toggle/Value/SetFocus) — more reliable than coordinate clicks.",


### PR DESCRIPTION
## Summary
The first MCEC 3.0 dogfood loop: MCEC drives **itself** through its own MCP HTTP surface, plus the actuation fix that loop surfaced.

- **`scripts/Run-Customer0Skeleton.ps1`** (#98 walking skeleton): provision an isolated MCP-enabled config → launch the GUI → wait for the main window → capture + non-blank validate → open Help via UIA `expand` → invoke About... → verify the dialog → emit a zipped evidence bundle (session.json, tool-calls.jsonl, screenshot.png, environment.json, failure-summary.md). 3/3 deterministic PASS.
- **`expand`/`collapse` UIA action** (`UiaService`): closed WinForms menus don't expose sub-items until opened, and `ToolStripMenuItem` lacks ExpandCollapse — `expand` uses ExpandCollapse, falling back to Invoke so it opens menus across WinForms and WPF/WinUI.
- **Sharpened in-product agent guidance** (`AgentServer.Instructions`): reuse a window `handle`; open menus are untitled popups; `expand` a menu before invoking items; invoking a modal-opening control may not return until it closes (UI-thread) so fire-and-verify.
- **`scripts/Allow-McecFirewall.ps1`**: self-elevating inbound allow rules so MCEC never prompts on launch.
- `.gitignore`: exclude `artifacts/` (evidence bundles / desktop screenshots).

## Evidence / follow-ups
- Surfaced **#105** (agent commands run on the UI thread → invoking modal-opening controls blocks). Runner uses a fire-and-verify workaround until #105 lands.

Refs #98. Surfaces #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
