### PR TITLE
actions: invoke returns promptly on modal dialogs (#105)

### DIFF
--- a/scripts/Run-Customer0Skeleton.ps1
+++ b/scripts/Run-Customer0Skeleton.ps1
@@ -252,16 +252,11 @@ try {
     #     skeleton run surfaced; the expand action + this targeting is the fix.) ---
     Invoke-Tool -Name "invoke" -Arguments @{ handle = $mainHandle; by = "name"; value = "Help"; action = "expand" } | Out-Null
     Start-Sleep -Milliseconds 400
-    # Invoking About... opens a MODAL dialog; because MCEC runs agent commands on its own UI
-    # thread in-process, the invoke call does not return until that modal closes. So fire it with
-    # a short timeout and let the verify step confirm the dialog actually opened. (Known limitation:
-    # synchronous actuation of modal-opening controls — feeds the actions/threading epic.)
-    try {
-        Invoke-Tool -Name "invoke" -Arguments @{ handle = $mainHandle; by = "name"; value = "About..."; action = "invoke" } -TimeoutSec 4 | Out-Null
-        $actNote = "expand Help -> invoke About..."
-    } catch {
-        $actNote = "expand Help -> invoke About... (call blocked on modal, expected; verifying)"
-    }
+    # Invoking About... opens a modal dialog. Since #105 the invoke returns promptly with
+    # modalPending instead of blocking for the dialog's lifetime, so no special timeout handling is
+    # needed; verify confirms the dialog opened.
+    $aboutInvoke = Invoke-Tool -Name "invoke" -Arguments @{ handle = $mainHandle; by = "name"; value = "About..."; action = "invoke" }
+    $actNote = "expand Help -> invoke About... (modalPending=$($aboutInvoke.modalPending))"
 
     $about = Wait-For -TimeoutMs 6000 -Condition {
         $q = Invoke-Tool -Name "query" -Arguments @{ window = "About"; maxDepth = 1 }

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -108,10 +108,10 @@ public static class AgentServer {
         "expand|collapse) over coordinate clicks — it is far more reliable. To click a menu item, first " +
         "`invoke` its parent menu with action `expand` (a closed menu's sub-items are not in the tree " +
         "until opened), then `invoke` the item. Invoking a control that opens a MODAL dialog (About, " +
-        "Settings, message/file dialogs) may not return until that dialog is dismissed — MCEC runs " +
-        "commands on the app's UI thread — so do not block on it; after firing the invoke, `query`/" +
-        "`capture` the expected window to confirm it opened. Use `find` to wait for a control to appear " +
-        "before acting. `send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
+        "Settings, message/file dialogs) returns promptly with `modalPending:true` — the action " +
+        "completes when the dialog closes — so just `query`/`capture` the new window to read it, and " +
+        "`invoke` its buttons to dismiss it. Use `find` to wait for a control to appear before acting. " +
+        "`send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
         "4. VERIFY with another `query` or `capture` — always confirm the act had the intended effect.\n" +
         "SECURITY: observation tools (capture/query/find/invoke) only work when the operator has set " +
         "AgentCommandsEnabled=true; otherwise they return an error — surface that to the user rather " +
@@ -225,8 +225,29 @@ public static class AgentServer {
         cmd.Cmd = name;
 
         AgentRuntime.Audit(name, args.ToJsonString(AgentJson.Options));
-        lock (ExecLock) {
-            cmd.Execute();
+
+        // `invoke` can activate a control that opens a MODAL dialog (About, Settings, message/file
+        // dialogs). The UIA Invoke runs the control's click handler synchronously, so the call would
+        // otherwise block — and hold ExecLock — for the dialog's whole lifetime, deadlocking every
+        // later tool call (the agent couldn't even query or dismiss the dialog it just opened). Run it
+        // on a worker and, if it hasn't returned within a short grace, report "modal pending" and
+        // return; the worker finishes when the dialog closes. capture/query/find/send_command keep the
+        // simple serialized path, and the legacy TCP/serial pipeline (MainWindow.ReceivedData ->
+        // CommandInvoker.ExecuteNext on the UI thread) is untouched, so home-automation sequences keep
+        // their in-order, synchronous behavior.
+        if (name == "invoke") {
+            if (!TryRunInvokeWithModalGrace(cmd)) {
+                AgentRuntime.Audit(name, "dispatched; a modal dialog appears to be open — returning without blocking");
+                return new JsonObject {
+                    ["content"] = new JsonArray { TextContent(InvokeModalPendingJson) },
+                    ["isError"] = false,
+                };
+            }
+        }
+        else {
+            lock (ExecLock) {
+                cmd.Execute();
+            }
         }
 
         string captured = reply.Captured.Trim();
@@ -262,6 +283,38 @@ public static class AgentServer {
         result["content"] = content;
         result["isError"] = isError;
         return result;
+    }
+
+    // Grace period for an `invoke` to complete before we assume it opened a modal dialog and return.
+    private const int InvokeModalGraceMs = 750;
+
+    private const string InvokeModalPendingJson =
+        "{\"success\":true,\"command\":\"invoke\",\"data\":{\"invoked\":true,\"modalPending\":true," +
+        "\"note\":\"The invoke opened a modal dialog (or a long-running action); it completes when the " +
+        "dialog closes. Query or capture the new window to read or dismiss it.\"}}";
+
+    /// <summary>
+    /// Runs an <c>invoke</c> on a background worker and waits up to <see cref="InvokeModalGraceMs"/> ms.
+    /// Returns true if it finished (its result is in the command's reply); false if it is still running,
+    /// which means the invoked control opened a modal dialog. We deliberately do NOT hold
+    /// <see cref="ExecLock"/> for an invoke: a modal opener must not block the later query/capture/invoke
+    /// calls the agent needs to read or dismiss the very dialog it opened. The worker ends on its own
+    /// when the dialog closes.
+    /// </summary>
+    private static bool TryRunInvokeWithModalGrace(Command cmd) {
+        Thread worker = new(() => {
+            try {
+                cmd.Execute();
+            }
+            catch (Exception e) {
+                Logger.Instance.Log4.Error($"AgentServer: invoke worker failed: {e.Message}");
+            }
+        }) {
+            IsBackground = true,
+            Name = "mcec-agent-invoke",
+        };
+        worker.Start();
+        return worker.Join(InvokeModalGraceMs);
     }
 
     private static JsonObject RunSendCommand(JsonObject args) {


### PR DESCRIPTION
## Summary
Fixes **#105**: invoking a UIA control that opens a **modal** dialog used to block the agent call (and hold `ExecLock`) for the dialog's entire lifetime — so an agent couldn't read or dismiss the dialog it just opened.

Measured before: `invoke` About took **21.8s**, a concurrent `query` **timed out at 8s**.
After: `invoke` returns in **0.8s** with `modalPending:true`, concurrent `query` succeeds in **2.2s**.

## Change
- `invoke` runs on a background worker with a 750ms grace. If it hasn't completed (a modal opened), return promptly with `{success:true, data:{invoked:true, modalPending:true}}` and let the worker finish when the dialog closes. `ExecLock` is not held for the modal's lifetime.
- Scope is limited to the agent `invoke` path. **`capture`/`query`/`find`/`send_command` unchanged**, and the **legacy TCP/serial pipeline** (`MainWindow.ReceivedData` → `CommandInvoker.ExecuteNext` on the UI thread) is **untouched** — home-automation sequences keep their in-order, synchronous behavior.
- Agent guidance (`AgentServer.Instructions`) and the walking skeleton updated for the new behavior.

## Verification
- All **135** unit tests pass (incl. `CommandInvokerTests` — home-auto sequencing intact).
- Walking skeleton (#98) **3/3 deterministic PASS**, `modalPending=True`, 0 leftover processes.

Closes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
