### PR TITLE
agent: expose wait-for as a first-class MCP tool (#75)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -214,7 +214,8 @@ When connected, the server advertises these tools:
 |----------------|----------------------------------------------------------------|
 | `capture`      | The `capture` command (window screenshot → base64 PNG).        |
 | `query`        | The `query` command (describe a window).                       |
-| `find`         | The `find` command (enumerate / match windows).                |
+| `find`         | The `find` command (match a UI element, one-shot).             |
+| `wait-for`     | The `wait-for` command (poll for a UI element until a timeout). |
 | `invoke`       | The `invoke` command (run an existing MCEC command).           |
 | `send_command` | Generic raw-command passthrough — send any MCEC command line.  |
 

--- a/scripts/Run-Customer0Skeleton.ps1
+++ b/scripts/Run-Customer0Skeleton.ps1
@@ -206,6 +206,7 @@ try {
   <query Cmd="query" Enabled="true" />
   <capture Cmd="capture" Enabled="true" />
   <find Cmd="find" Enabled="true" />
+  <find Cmd="wait-for" Enabled="true" />
   <invoke Cmd="invoke" Enabled="true" />
 </Commands>
 </MCEController>
@@ -251,7 +252,8 @@ try {
     #     target the main window by handle — not the foreground. (This is the menu gap the first
     #     skeleton run surfaced; the expand action + this targeting is the fix.) ---
     Invoke-Tool -Name "invoke" -Arguments @{ handle = $mainHandle; by = "name"; value = "Help"; action = "expand" } | Out-Null
-    Start-Sleep -Milliseconds 400
+    # Synchronize on the menu item appearing with the first-class wait-for tool (#75) — no sleep.
+    Invoke-Tool -Name "wait-for" -Arguments @{ handle = $mainHandle; by = "name"; value = "About..."; timeout = 3000 } | Out-Null
     # Invoking About... opens a modal dialog. Since #105 the invoke returns promptly with
     # modalPending instead of blocking for the dialog's lifetime, so no special timeout handling is
     # needed; verify confirms the dialog opened.

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -110,7 +110,8 @@ public static class AgentServer {
         "until opened), then `invoke` the item. Invoking a control that opens a MODAL dialog (About, " +
         "Settings, message/file dialogs) returns promptly with `modalPending:true` — the action " +
         "completes when the dialog closes — so just `query`/`capture` the new window to read it, and " +
-        "`invoke` its buttons to dismiss it. Use `find` to wait for a control to appear before acting. " +
+        "`invoke` its buttons to dismiss it. Use `wait-for` (or `find` with a timeout) to wait for a " +
+        "control to appear before acting. " +
         "`send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
         "4. VERIFY with another `query` or `capture` — always confirm the act had the intended effect.\n" +
         "SECURITY: observation tools (capture/query/find/invoke) only work when the operator has set " +
@@ -159,6 +160,14 @@ public static class AgentServer {
             "Find (or wait for, with a timeout) a UI Automation element by name / automation id / class.",
             findProps, ["value"]));
 
+        JsonObject waitForProps = WindowTargetProps();
+        waitForProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
+        waitForProps["value"] = PropSchema("string", "Value to match");
+        waitForProps["timeout"] = PropSchema("integer", "Milliseconds to wait for the element (default 5000)");
+        tools.Add(Tool("wait-for",
+            "Wait for a UI Automation element to appear: polls until found or the timeout elapses (default 5s).",
+            waitForProps, ["value"]));
+
         JsonObject invokeProps = WindowTargetProps();
         invokeProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
         invokeProps["value"] = PropSchema("string", "Value to match");
@@ -198,7 +207,7 @@ public static class AgentServer {
             return RunSendCommand(args);
         }
 
-        if (name is "capture" or "query" or "find" or "invoke") {
+        if (name is "capture" or "query" or "find" or "wait-for" or "invoke") {
             if (!AgentRuntime.AgentCommandsEnabled) {
                 AgentRuntime.Audit(name, "BLOCKED — agent commands disabled");
                 return ToolError($"Agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
@@ -365,7 +374,7 @@ public static class AgentServer {
             Foreground = Bool(args, "foreground"),
             MaxDepth = Int(args, "maxDepth") is int d and > 0 ? d : 6,
         },
-        "find" => new FindCommand {
+        "find" or "wait-for" => new FindCommand {
             Window = Str(args, "window")!,
             Handle = Long(args, "handle"),
             Process = Str(args, "process")!,

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -34,7 +34,7 @@ public class AgentServerTests {
     }
 
     [Fact]
-    public void Dispatch_ToolsList_IncludesCaptureAndQuery() {
+    public void Dispatch_ToolsList_IncludesAllAgentTools() {
         JsonObject resp = AgentServer.Dispatch(Request(2, "tools/list"))!;
 
         JsonArray tools = resp["result"]!.AsObject()["tools"]!.AsArray();
@@ -49,6 +49,10 @@ public class AgentServerTests {
 
         Assert.Contains("capture", names);
         Assert.Contains("query", names);
+        Assert.Contains("find", names);
+        Assert.Contains("wait-for", names);
+        Assert.Contains("invoke", names);
+        Assert.Contains("send_command", names);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Closes **#75**: `wait-for` was implemented in the command layer (`FindCommand` registers both `find` and `wait-for`) but never advertised over MCP, so agents couldn't discover it despite the guidance referencing it.

- `tools/list` now includes **`wait-for`** (input schema matches `find`).
- `tools/call` dispatches `wait-for` distinctly; `Cmd="wait-for"` applies its default 5s timeout.
- Agent guidance (`AgentServer.Instructions`) and `docs/agent-server.md`'s MCP tool table updated to match the real surface.
- Test now asserts the full advertised catalog: `capture`/`query`/`find`/`wait-for`/`invoke`/`send_command`.
- **Dogfood:** the walking skeleton (#98) now synchronizes on the `About...` menu item with `wait-for` instead of a fixed sleep — 3/3 deterministic PASS.

All 135 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
