### PR TITLE
feat(agent): observation hardening — blank-frame detection & UIA tree caps (#90)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,13 @@ in sync. In short:
 > 1. **Target** a window by `window` (title substring), `process` (name without `.exe`), `className`,
 >    or `foreground:true`. At least one is required — a call with no target fails by design.
 > 2. **Observe** — `query` dumps the UI Automation tree (controlType, name, automationId, bounds,
->    state, value); `capture` returns a PNG (renders composited WinUI/WPF surfaces correctly).
+>    state, value; bounded by `maxDepth` and `maxNodes`); `capture` returns a PNG (renders composited
+>    WinUI/WPF surfaces correctly). **Check results before trusting them:** a `capture` with
+>    `errorCategory: capture-blank` is a black/empty frame (minimized/cloaked/occluded/locked session) —
+>    restore or foreground the window and retry, don't trust the image; a `capture-fallback` warning
+>    means PrintWindow was refused and the picture may be wrong; a `query` with `truncated:true` (a
+>    `tree-truncated` warning) hit the node cap — raise `maxNodes` or target a deeper window. `warnings`
+>    are non-fatal; `errorCategory` tells you how to recover. (Shape: `docs/design/agent-tool-result-contract.md`.)
 > 3. **Act** — prefer `invoke` (`by` name/automationId/classname; `action` invoke|toggle|setvalue|
 >    setfocus) over coordinate clicks. Use `find`/`wait-for` to wait for a control. `send_command`
 >    sends any raw MCEC command (keystrokes, mouse, launch).
@@ -87,6 +93,13 @@ exe (`winr`, `chars:`, `enter`, `mouse:`, `key_a`, `key_esc`, `alt_f`, `key_x`) 
 
 ## Working in this repo
 
+- **Agent-facing guidance is part of "Done" — not optional, not "later."** Any change to how an agent
+  observes/targets/acts — a new tool, arg, failure mode, warning/error category, or driving technique —
+  MUST update `AgentServer.Instructions` (the connect-time observe→target→act playbook in
+  [`src/Services/AgentServer.cs`](src/Services/AgentServer.cs)) **and** the [built-in guidance](#the-built-in-guidance-single-source-of-truth)
+  block in this file, in the same change. Updating a per-tool `Tool(...)` description is **not** a
+  substitute — those describe *args*; `Instructions` teaches *recovery and strategy*. Read the trigger
+  by principle, not keyword: it fires on feature work, not just dogfooding. Treat it like updating tests.
 - Build is strict: `Nullable=enable`, `TreatWarningsAsErrors=true`, and house analyzers **MCEC0001
   (one top-level type per file)** / **MCEC0002 (no nested types)**. New code must be warning-clean.
 - Agent subsystem lives in `src/Agent/` + `src/Services/AgentServer.cs`; commands plug into the

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -87,8 +87,8 @@ case-insensitive), `handle` (HWND), `process` (process name without `.exe`),
 
 | Command    | What it does                                                                      | Key args |
 |------------|-----------------------------------------------------------------------------------|----------|
-| `capture`  | Screenshot a window (`PrintWindow` + `PW_RENDERFULLCONTENT`, captures WinUI/WPF surfaces) or a screen region, returned as base64 PNG. | window target, or region `x`/`y`/`width`/`height`; optional `file` |
-| `query`    | Dump the **UI Automation tree** of a window: control type, name, automation id, bounds, enabled/offscreen state, value. | window target, `maxDepth` (default 6) |
+| `capture`  | Screenshot a window (`PrintWindow` + `PW_RENDERFULLCONTENT`, captures WinUI/WPF surfaces) or a screen region, returned as base64 PNG. Blank/black frames are detected and flagged (see [Observation hardening](#observation-hardening--known-limitations)). | window target, or region `x`/`y`/`width`/`height`; optional `file` |
+| `query`    | Dump the **UI Automation tree** of a window: control type, name, automation id, bounds, enabled/offscreen state, value. | window target, `maxDepth` (default 6), `maxNodes` (default 1000) |
 | `find`     | Find a **UI Automation element** by name / automation id / class.                 | window target, `by` (`name`\|`automationid`\|`classname`), `value`, `timeout` |
 | `wait-for` | Same as `find`, but waits up to a timeout for the element to appear (default 5 s). | window target, `by`, `value`, `timeout` |
 | `invoke`   | Drive a UI Automation element pattern — far more reliable than coordinate clicks. | window target, `by`, `value`, `action` (`invoke`\|`toggle`\|`setvalue`\|`setfocus`), `text` |
@@ -100,9 +100,18 @@ All five return a `CommandResult` JSON object via `Reply.WriteLine`:
   "success": true,
   "command": "query",
   "error": null,
-  "data": { /* command-specific payload */ }
+  "data": { /* command-specific payload */ },
+  "warnings": [ { "code": "tree-truncated", "detail": "…" } ]
 }
 ```
+
+`warnings` is present only when there are non-fatal conditions to report. On failure the
+result additionally carries `errorCode` (a stable, fine-grained string) and `errorCategory`
+(a coarse class from the closed taxonomy: `timeout`, `ambiguous-selector`, `stale-element`,
+`no-target`, `capture-blank`, `focus`, `elevation`, `foreground`, `internal`). These fields
+track the shared agent result contract in
+[`docs/design/agent-tool-result-contract.md`](design/agent-tool-result-contract.md) (#101);
+they are additive over the legacy `success`/`error`/`data` shape, which still works.
 
 On failure (including when the security gates are off):
 
@@ -132,6 +141,7 @@ geometry:
     "encoding": "png",
     "bytes": 48213,
     "base64": "iVBORw0KGgoAAAANSUhEUgAA...",
+    "blankCheck": { "blank": false, "dominantFraction": 0.34, "dominantIsDark": false },
     "window": {
       "handle": 1576490,
       "title": "Untitled - Notepad",
@@ -144,8 +154,15 @@ geometry:
 }
 ```
 
+`blankCheck` reports the blank-frame analysis (see
+[Observation hardening](#observation-hardening--known-limitations)). When a **window** capture
+comes back blank the result is a failure with `errorCategory: "capture-blank"` — but the PNG
+stays in `data` so it is never a *silent* bad image. A blank **region** capture is reported as
+a `capture-blank` warning instead, since a user-specified region can legitimately be empty.
+
 (Over MCP, `capture` additionally returns the PNG as an `image` content block so the
-model can view it directly, in addition to the JSON text above.)
+model can view it directly, in addition to the JSON text above — including for a blank-frame
+failure, so the agent can see what was grabbed.)
 
 ### `query` result example
 
@@ -161,6 +178,8 @@ model can view it directly, in addition to the JSON text above.)
       "className": "Notepad", "processName": "notepad", "processId": 21344,
       "x": 120, "y": 80, "width": 1024, "height": 768
     },
+    "nodeCount": 7,
+    "truncated": false,
     "tree": {
       "controlType": "Window",
       "name": "Untitled - Notepad",
@@ -175,6 +194,73 @@ model can view it directly, in addition to the JSON text above.)
   }
 }
 ```
+
+---
+
+## Observation hardening & known limitations
+
+An agent can only act on what it can reliably see, so `capture` and `query` are built to fail
+loudly rather than hand back a plausible-looking but wrong observation. This section documents
+what is trustworthy and what is not.
+
+### Blank / black frame detection
+
+Every capture is analyzed for blank content: the frame is sampled on a bounded grid, each pixel
+is quantized to 5 bits per channel, and the share held by the single most common color is
+measured. A real application window is busy and scores low; a failed grab is a flat fill and
+scores ~1.0. When the dominant color covers ≥ 99% of the frame it is flagged blank, and a
+near-black dominant color is distinguished from a legitimately empty (e.g. white) surface.
+
+- A **window** capture that comes back blank is a failure (`errorCategory: "capture-blank"`,
+  `errorCode: "frame-all-black"` or `"frame-uniform"`). The PNG is still returned in `data` (and
+  as an MCP image block) so it is never a *silent* bad image and can serve as the failure's last
+  observation.
+- A **region** capture that comes back blank is reported as a `capture-blank` **warning**, since
+  a user-specified region can legitimately be empty.
+- The raw numbers are always in `data.blankCheck` (`blank`, `dominantFraction`, `dominantIsDark`).
+
+### `PrintWindow` and the on-screen-blit fallback
+
+Window capture uses `PrintWindow(PW_RENDERFULLCONTENT)`, which renders DirectComposition / WinUI 3
+/ WPF surfaces that a plain screen grab returns black for, and captures windows even when occluded.
+Known limits:
+
+- **Fallback is degraded.** If the driver refuses `PrintWindow`, capture falls back to an
+  on-screen blit (`Graphics.CopyFromScreen`). That blit grabs whatever pixels are physically on
+  screen, so it returns black for composited/occluded surfaces and cannot see a window that is
+  behind another. When the fallback runs, the result carries a `capture-fallback` warning.
+- **Minimized windows** have no on-screen pixels; `PrintWindow` typically yields a blank frame
+  (caught by blank detection). Restore the window before capturing.
+- **Cloaked windows** (e.g. background virtual-desktop or some UWP states) may not render.
+- **Hardware-overlay/protected content** (some video players, DRM surfaces) renders black by
+  design and cannot be captured.
+
+### Locked sessions and UAC
+
+- **Locked / disconnected sessions:** when the workstation is locked or the session is detached,
+  the desktop cannot be rendered and captures are blank. This is detected (blank frame) but cannot
+  be worked around from user space. Live validation of locked-session behavior is tracked
+  separately in [#78].
+- **Elevation (UAC):** MCEC running at medium integrity cannot read the UIA tree of, drive, or
+  reliably capture a window owned by an elevated (high-integrity) process. Such targets surface as
+  empty/failed observations; run MCEC elevated only if you explicitly need to automate elevated
+  apps, and understand the security trade-off.
+
+### UIA tree size & stability
+
+`query` is bounded on two axes so its output stays stable for agent reasoning even on pathological
+trees (e.g. a virtualized list with thousands of items):
+
+- `maxDepth` (default 6) bounds tree depth.
+- `maxNodes` (default 1000) bounds the total node count. When the cap clips the walk, the result
+  reports `truncated: true` and a `tree-truncated` warning rather than silently returning a partial
+  tree; `nodeCount` always reports how many nodes were captured. Raise `maxNodes` or narrow the
+  target (deeper `window`/`handle` selector) for a complete tree.
+
+Individual stale or unsupported UIA nodes never abort the whole walk — they are skipped and the
+rest of the tree is returned.
+
+[#78]: https://github.com/tig/mcec/issues/78
 
 ---
 

--- a/src/Agent/CaptureResult.cs
+++ b/src/Agent/CaptureResult.cs
@@ -1,0 +1,11 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// The outcome of a capture: the PNG bytes plus the diagnostics observation hardening (#90) needs to
+/// avoid returning silent bad images — whether the on-screen-blit fallback was used (which returns
+/// black for composited/occluded surfaces) and the blank-frame <see cref="ImageStats"/>.
+/// </summary>
+public sealed record CaptureResult(byte[] Png, int Width, int Height, bool UsedFallback, ImageStats Stats);

--- a/src/Agent/ImageStats.cs
+++ b/src/Agent/ImageStats.cs
@@ -1,0 +1,13 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// Blank/near-uniform content statistics for a captured frame. <see cref="DominantFraction"/> is the
+/// share of sampled pixels occupying the single most common (quantized) color; a real app window is
+/// busy and scores low, while a failed <c>PrintWindow</c> grab is a flat fill and scores ~1.0.
+/// <see cref="IsBlank"/> is the thresholded verdict; <see cref="DominantIsDark"/> distinguishes the
+/// classic all-black failure from a legitimately empty (e.g. white) surface.
+/// </summary>
+public readonly record struct ImageStats(bool IsBlank, double DominantFraction, bool DominantIsDark);

--- a/src/Agent/ScreenCapture.cs
+++ b/src/Agent/ScreenCapture.cs
@@ -2,6 +2,7 @@
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -13,17 +14,26 @@ namespace MCEControl;
 /// <c>PrintWindow</c> with <c>PW_RENDERFULLCONTENT</c> (which correctly renders DirectComposition /
 /// WinUI 3 / WPF surfaces that a plain screen grab returns black for) and falls back to
 /// <see cref="Graphics.CopyFromScreen(int, int, int, int, Size)"/> when the driver refuses
-/// <c>PrintWindow</c>. All captures are encoded as PNG.
+/// <c>PrintWindow</c>. All captures are encoded as PNG and analyzed for blank/black content.
 /// </summary>
 public static class ScreenCapture {
+    /// <summary>A frame whose dominant color covers at least this fraction of sampled pixels is blank.</summary>
+    public const double BlankDominantFractionThreshold = 0.99;
+
+    /// <summary>Luminance (0-255) below which the dominant color counts as "dark" (a black frame).</summary>
+    private const double DarkLuminanceThreshold = 24.0;
+
+    /// <summary>Upper bound on samples per axis; keeps blank analysis O(1) regardless of image size.</summary>
+    private const int MaxSamplesPerAxis = 64;
+
     /// <summary>
-    /// Captures a top-level window by handle and returns PNG-encoded bytes. Uses
-    /// <c>PrintWindow(PW_RENDERFULLCONTENT)</c>, falling back to an on-screen blit if that fails.
+    /// Captures a top-level window by handle. Uses <c>PrintWindow(PW_RENDERFULLCONTENT)</c>, falling
+    /// back to an on-screen blit if that fails, and reports which path ran plus blank-frame stats.
     /// </summary>
     /// <param name="hwnd">The window handle to capture.</param>
-    /// <returns>PNG-encoded image bytes.</returns>
+    /// <returns>The PNG bytes and capture diagnostics.</returns>
     /// <exception cref="ArgumentException">Thrown when the window has no on-screen area.</exception>
-    public static byte[] CaptureWindow(IntPtr hwnd) {
+    public static CaptureResult CaptureWindow(IntPtr hwnd) {
         if (!AgentNativeMethods.GetWindowRect(hwnd, out NativeRect rect)) {
             throw new ArgumentException("Could not get window bounds.", nameof(hwnd));
         }
@@ -38,29 +48,32 @@ public static class ScreenCapture {
         using Graphics gfx = Graphics.FromImage(bmp);
 
         IntPtr hdc = gfx.GetHdc();
-        bool ok = AgentNativeMethods.PrintWindow(hwnd, hdc, AgentNativeMethods.PW_RENDERFULLCONTENT);
+        bool printed = AgentNativeMethods.PrintWindow(hwnd, hdc, AgentNativeMethods.PW_RENDERFULLCONTENT);
         gfx.ReleaseHdc(hdc);
 
-        if (!ok) {
-            // Fallback: blit the corresponding screen region into the same bitmap.
+        bool usedFallback = false;
+        if (!printed) {
+            // Fallback: blit the corresponding screen region into the same bitmap. This grabs whatever
+            // is on screen at those coordinates, so it returns black for composited/occluded windows
+            // and is reported to the caller as a degraded path.
             gfx.CopyFromScreen(rect.Left, rect.Top, 0, 0, new Size(width, height));
+            usedFallback = true;
         }
 
-        using MemoryStream ms = new();
-        bmp.Save(ms, ImageFormat.Png);
-        return ms.ToArray();
+        ImageStats stats = AnalyzeBlank(bmp);
+        return new CaptureResult(Encode(bmp), width, height, usedFallback, stats);
     }
 
     /// <summary>
-    /// Captures an arbitrary screen region (screen coordinates) and returns PNG-encoded bytes.
+    /// Captures an arbitrary screen region (screen coordinates) and reports blank-frame stats.
     /// </summary>
     /// <param name="x">Left screen coordinate.</param>
     /// <param name="y">Top screen coordinate.</param>
     /// <param name="width">Region width in pixels.</param>
     /// <param name="height">Region height in pixels.</param>
-    /// <returns>PNG-encoded image bytes.</returns>
+    /// <returns>The PNG bytes and capture diagnostics (<c>UsedFallback</c> is always false for regions).</returns>
     /// <exception cref="ArgumentException">Thrown when the region has no area.</exception>
-    public static byte[] CaptureRegion(int x, int y, int width, int height) {
+    public static CaptureResult CaptureRegion(int x, int y, int width, int height) {
         if (width <= 0 || height <= 0) {
             throw new ArgumentException("Region has no area to capture.", nameof(width));
         }
@@ -69,8 +82,62 @@ public static class ScreenCapture {
         using Graphics gfx = Graphics.FromImage(bmp);
         gfx.CopyFromScreen(x, y, 0, 0, new Size(width, height));
 
+        ImageStats stats = AnalyzeBlank(bmp);
+        return new CaptureResult(Encode(bmp), width, height, UsedFallback: false, stats);
+    }
+
+    private static byte[] Encode(Bitmap bmp) {
         using MemoryStream ms = new();
         bmp.Save(ms, ImageFormat.Png);
         return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Estimates whether a bitmap is blank (a flat fill) by sampling a bounded grid of pixels,
+    /// quantizing each to 5 bits per channel (so anti-aliasing noise collapses), and measuring the
+    /// share held by the single most common color. A busy app window scores well under the threshold;
+    /// a failed black/empty grab scores ~1.0. Sampling is capped so cost is independent of image size.
+    /// </summary>
+    public static ImageStats AnalyzeBlank(Bitmap bmp) {
+        int w = bmp.Width;
+        int h = bmp.Height;
+        if (w <= 0 || h <= 0) {
+            return new ImageStats(IsBlank: true, DominantFraction: 1.0, DominantIsDark: true);
+        }
+
+        int stepX = Math.Max(1, w / MaxSamplesPerAxis);
+        int stepY = Math.Max(1, h / MaxSamplesPerAxis);
+
+        Dictionary<int, int> counts = [];
+        int total = 0;
+        int bestKey = 0;
+        int bestCount = 0;
+
+        for (int y = 0; y < h; y += stepY) {
+            for (int x = 0; x < w; x += stepX) {
+                Color c = bmp.GetPixel(x, y);
+                int key = ((c.R >> 3) << 10) | ((c.G >> 3) << 5) | (c.B >> 3);
+                int n = counts.TryGetValue(key, out int existing) ? existing + 1 : 1;
+                counts[key] = n;
+                if (n > bestCount) {
+                    bestCount = n;
+                    bestKey = key;
+                }
+                total++;
+            }
+        }
+
+        double dominantFraction = total == 0 ? 1.0 : (double)bestCount / total;
+
+        // Reconstruct the mid-value of the dominant quantized color to judge dark-vs-light.
+        int r = (((bestKey >> 10) & 0x1F) << 3) | 0x04;
+        int g = (((bestKey >> 5) & 0x1F) << 3) | 0x04;
+        int b = ((bestKey & 0x1F) << 3) | 0x04;
+        double luminance = (0.299 * r) + (0.587 * g) + (0.114 * b);
+
+        return new ImageStats(
+            IsBlank: dominantFraction >= BlankDominantFractionThreshold,
+            DominantFraction: dominantFraction,
+            DominantIsDark: luminance < DarkLuminanceThreshold);
     }
 }

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -19,22 +19,28 @@ namespace MCEControl;
 public static class UiaService {
     /// <summary>
     /// Snapshots the UIA tree rooted at <paramref name="hwnd"/> down to <paramref name="maxDepth"/>
-    /// levels (depth 0 = the root node only). Returns null if the window can't be attached to.
+    /// levels (depth 0 = the root node only) and at most <paramref name="maxNodes"/> nodes. The node
+    /// cap keeps the result size bounded and stable for agent reasoning on pathological trees (e.g. a
+    /// virtualized list with thousands of items); when it bites, <see cref="UiaTreeResult.Truncated"/>
+    /// is set so the caller can warn rather than silently return a clipped tree. <paramref name="maxNodes"/>
+    /// &lt;= 0 means unbounded. Returns a result with a null root if the window can't be attached to.
     /// </summary>
-    public static UiaElementInfo? DumpTree(IntPtr hwnd, int maxDepth) {
+    public static UiaTreeResult DumpTree(IntPtr hwnd, int maxDepth, int maxNodes) {
         if (hwnd == IntPtr.Zero) {
-            return null;
+            return new UiaTreeResult(null, 0, false);
         }
         try {
             using UIA3Automation automation = new();
             AutomationElement root = automation.FromHandle(hwnd);
-            return BuildNode(root, 0, maxDepth);
+            UiaTreeBudget budget = new() { MaxNodes = maxNodes <= 0 ? int.MaxValue : maxNodes };
+            UiaElementInfo node = BuildNode(root, 0, maxDepth, budget);
+            return new UiaTreeResult(node, budget.Count, budget.Truncated);
         }
         catch (Exception e) {
             // FromHandle/UIA can throw COMException or FlaUI-specific exceptions on a window that
             // closes mid-call; never let it escape the command's Execute().
             Logger.Instance.Log4.Error($"UiaService.DumpTree failed: {e.Message}");
-            return null;
+            return new UiaTreeResult(null, 0, false);
         }
     }
 
@@ -109,7 +115,8 @@ public static class UiaService {
             _ => false,
         };
 
-    private static UiaElementInfo BuildNode(AutomationElement el, int depth, int maxDepth) {
+    private static UiaElementInfo BuildNode(AutomationElement el, int depth, int maxDepth, UiaTreeBudget budget) {
+        budget.Count++;
         UiaElementInfo info = Describe(el);
         if (depth >= maxDepth) {
             return info;
@@ -125,8 +132,13 @@ public static class UiaService {
         }
 
         foreach (AutomationElement child in children) {
+            if (budget.Count >= budget.MaxNodes) {
+                // Hit the node cap: stop expanding and flag it so the caller surfaces a warning.
+                budget.Truncated = true;
+                break;
+            }
             try {
-                info.Children.Add(BuildNode(child, depth + 1, maxDepth));
+                info.Children.Add(BuildNode(child, depth + 1, maxDepth, budget));
             }
             catch (COMException) {
                 // Skip a node that went stale mid-walk; keep the rest of the tree.

--- a/src/Agent/UiaTreeBudget.cs
+++ b/src/Agent/UiaTreeBudget.cs
@@ -1,0 +1,14 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// Mutable walk state threaded through <see cref="UiaService"/>'s tree dump: the node cap
+/// (<see cref="MaxNodes"/>) and the running <see cref="Count"/>/<see cref="Truncated"/> flag.
+/// </summary>
+internal sealed class UiaTreeBudget {
+    public int MaxNodes { get; init; } = int.MaxValue;
+    public int Count { get; set; }
+    public bool Truncated { get; set; }
+}

--- a/src/Agent/UiaTreeResult.cs
+++ b/src/Agent/UiaTreeResult.cs
@@ -1,0 +1,12 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// The result of a UIA tree snapshot (<see cref="UiaService.DumpTree"/>): the (possibly null) root
+/// node, the total <see cref="NodeCount"/> captured, and whether the node cap clipped the walk
+/// (<see cref="Truncated"/>). Carrying the count and truncation flag lets <c>query</c> surface a
+/// <c>tree-truncated</c> warning instead of returning a silently clipped tree.
+/// </summary>
+public sealed record UiaTreeResult(UiaElementInfo? Root, int NodeCount, bool Truncated);

--- a/src/Commands/CaptureCommand.cs
+++ b/src/Commands/CaptureCommand.cs
@@ -91,16 +91,24 @@ public class CaptureCommand : Command {
             if (Width > 0 && Height > 0 && !hasWindowTarget) {
                 AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height}");
 
-                byte[] png = ScreenCapture.CaptureRegion(X, Y, Width, Height);
+                CaptureResult regionCap = ScreenCapture.CaptureRegion(X, Y, Width, Height);
                 data = new JsonObject {
                     ["encoding"] = "png",
-                    ["width"] = Width,
-                    ["height"] = Height,
-                    ["bytes"] = png.Length,
-                    ["base64"] = Convert.ToBase64String(png),
+                    ["width"] = regionCap.Width,
+                    ["height"] = regionCap.Height,
+                    ["bytes"] = regionCap.Png.Length,
+                    ["base64"] = Convert.ToBase64String(regionCap.Png),
+                    ["blankCheck"] = BlankCheckJson(regionCap.Stats),
                 };
-                WriteFileIfRequested(png, data);
-                Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
+                WriteFileIfRequested(regionCap.Png, data);
+
+                // A user-specified region can legitimately be empty, so a blank region is a non-fatal
+                // warning (not a capture-blank error) — the agent still gets the image and the signal.
+                CommandResult regionRes = CommandResult.Ok(Cmd, data);
+                if (regionCap.Stats.IsBlank) {
+                    regionRes.Warn("capture-blank", "Captured region is blank (a flat fill); it may be off-screen or genuinely empty.");
+                }
+                Reply?.WriteLine(regionRes.ToJson());
                 return true;
             }
 
@@ -108,25 +116,48 @@ public class CaptureCommand : Command {
                 Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
             if (win is null) {
                 AgentRuntime.Audit(Cmd, "no matching window");
-                Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window").ToJson());
+                Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
                 return false;
             }
 
             AgentRuntime.Audit(Cmd, $"window 0x{win.Handle:X} \"{win.Title}\" ({win.ProcessName})");
 
-            byte[] winPng = ScreenCapture.CaptureWindow(new IntPtr(win.Handle));
+            CaptureResult cap = ScreenCapture.CaptureWindow(new IntPtr(win.Handle));
             data = new JsonObject {
                 ["handle"] = win.Handle,
-                ["width"] = win.Width,
-                ["height"] = win.Height,
+                ["width"] = cap.Width,
+                ["height"] = cap.Height,
                 ["encoding"] = "png",
-                ["bytes"] = winPng.Length,
-                ["base64"] = Convert.ToBase64String(winPng),
+                ["bytes"] = cap.Png.Length,
+                ["base64"] = Convert.ToBase64String(cap.Png),
                 ["window"] = win.ToJsonObject(),
+                ["blankCheck"] = BlankCheckJson(cap.Stats),
             };
-            WriteFileIfRequested(winPng, data);
-            Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
-            return true;
+            WriteFileIfRequested(cap.Png, data);
+
+            // A blank window frame is a hard observation failure: don't return a silent bad image.
+            // The PNG stays in `data` (so the agent still sees what was grabbed and it can serve as the
+            // contract's lastObservation), but the result is flagged capture-blank so the agent branches.
+            CommandResult res;
+            bool ok;
+            if (cap.Stats.IsBlank) {
+                string code = cap.Stats.DominantIsDark ? "frame-all-black" : "frame-uniform";
+                string detail = cap.UsedFallback
+                    ? "Captured frame is blank — PrintWindow was refused and the on-screen-blit fallback returned a flat image (composited/occluded/minimized window or a locked session)."
+                    : "Captured frame is blank (a flat fill); the window may be minimized, cloaked, or rendering off-screen.";
+                AgentRuntime.Audit(Cmd, $"blank frame ({code}, dominant {cap.Stats.DominantFraction:P0}, fallback={cap.UsedFallback})");
+                res = CommandResult.Fail(Cmd, detail, code, "capture-blank", data);
+                ok = false;
+            }
+            else {
+                res = CommandResult.Ok(Cmd, data);
+                ok = true;
+            }
+            if (cap.UsedFallback) {
+                res.Warn("capture-fallback", "PrintWindow was refused; used an on-screen blit, which returns black for composited/occluded surfaces and cannot see windows behind others.");
+            }
+            Reply?.WriteLine(res.ToJson());
+            return ok;
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"{GetType().Name}: Capture failed: {e.Message}");
@@ -134,6 +165,13 @@ public class CaptureCommand : Command {
             return false;
         }
     }
+
+    /// <summary>Serializes the blank-frame analysis so an agent can see why a capture was flagged.</summary>
+    private static JsonObject BlankCheckJson(ImageStats stats) => new() {
+        ["blank"] = stats.IsBlank,
+        ["dominantFraction"] = System.Math.Round(stats.DominantFraction, 4),
+        ["dominantIsDark"] = stats.DominantIsDark,
+    };
 
     /// <summary>
     /// Writes the captured PNG to <see cref="File"/> if set, recording the path in <paramref name="data"/>.

--- a/src/Commands/CommandResult.cs
+++ b/src/Commands/CommandResult.cs
@@ -1,6 +1,7 @@
 // Copyright © Kindel, LLC - http://www.kindel.com
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
 
 namespace MCEControl;
@@ -9,18 +10,52 @@ namespace MCEControl;
 /// Structured result for the MCEC 3.0 agent commands (capture/query/find/invoke). The legacy HTPC
 /// command path keeps returning opaque strings; agent commands additionally return one of these,
 /// serialized as JSON, so an MCP client (or the HTTP façade) can reason over success/error + data.
+///
+/// The fields here track the shared result contract in <c>docs/design/agent-tool-result-contract.md</c>
+/// (#101): <see cref="Success"/>→<c>ok</c>, <see cref="Data"/>→<c>result</c>, <see cref="Error"/>→
+/// <c>error.detail</c>, with <see cref="ErrorCode"/>/<see cref="ErrorCategory"/> carrying the stable
+/// taxonomy and <see cref="Warnings"/> the non-fatal conditions. The full envelope rename
+/// (<c>ok</c>/<c>result</c>/nested <c>error</c>) lands with the session runtime (#98); these fields are
+/// added additively so existing consumers that read <c>success</c>/<c>data</c>/<c>error</c> keep working.
 /// </summary>
 public sealed class CommandResult {
     public bool Success { get; set; }
     public string? Command { get; set; }
     public string? Error { get; set; }
+
+    /// <summary>Stable, fine-grained error code (kebab-case) — narrows <see cref="ErrorCategory"/>.</summary>
+    public string? ErrorCode { get; set; }
+
+    /// <summary>Coarse failure class from the closed taxonomy in the agent result contract
+    /// (timeout, ambiguous-selector, stale-element, no-target, capture-blank, focus, elevation,
+    /// foreground, internal).</summary>
+    public string? ErrorCategory { get; set; }
+
     public JsonObject? Data { get; set; }
+
+    /// <summary>Non-fatal conditions surfaced alongside the result; can be present on success or failure.</summary>
+    public List<CommandWarning> Warnings { get; } = [];
 
     public static CommandResult Ok(string command, JsonObject? data = null) =>
         new() { Success = true, Command = command, Data = data };
 
     public static CommandResult Fail(string command, string error) =>
         new() { Success = false, Command = command, Error = error };
+
+    /// <summary>
+    /// Builds a failure result carrying the structured taxonomy (<paramref name="code"/>/
+    /// <paramref name="category"/>) and, optionally, partial <paramref name="data"/> — e.g. a blank
+    /// capture still returns the (suspect) image so it is not lost. <paramref name="data"/> doubles as
+    /// the contract's <c>lastObservation</c>: the last good state carried forward on failure.
+    /// </summary>
+    public static CommandResult Fail(string command, string error, string code, string category, JsonObject? data = null) =>
+        new() { Success = false, Command = command, Error = error, ErrorCode = code, ErrorCategory = category, Data = data };
+
+    /// <summary>Appends a non-fatal warning and returns <c>this</c> for fluent chaining.</summary>
+    public CommandResult Warn(string code, string detail) {
+        Warnings.Add(new CommandWarning(code, detail));
+        return this;
+    }
 
     /// <summary>Serializes this result to a compact, camelCase JSON object.</summary>
     public JsonObject ToJsonObject() {
@@ -33,8 +68,21 @@ public sealed class CommandResult {
         if (Error is not null) {
             obj["error"] = Error;
         }
+        if (ErrorCode is not null) {
+            obj["errorCode"] = ErrorCode;
+        }
+        if (ErrorCategory is not null) {
+            obj["errorCategory"] = ErrorCategory;
+        }
         if (Data is not null) {
             obj["data"] = Data.DeepClone();
+        }
+        if (Warnings.Count > 0) {
+            JsonArray warnings = [];
+            foreach (CommandWarning w in Warnings) {
+                warnings.Add(new JsonObject { ["code"] = w.Code, ["detail"] = w.Detail });
+            }
+            obj["warnings"] = warnings;
         }
         return obj;
     }

--- a/src/Commands/CommandWarning.cs
+++ b/src/Commands/CommandWarning.cs
@@ -1,0 +1,12 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// A non-fatal condition surfaced alongside a result (e.g. a capture that fell back to an on-screen
+/// blit, or a UIA tree clipped to a node cap). <see cref="Code"/> is a stable, branchable string and
+/// <see cref="Detail"/> is human-readable. Mirrors the warning shape in the agent result contract
+/// (<c>docs/design/agent-tool-result-contract.md</c>).
+/// </summary>
+public sealed record CommandWarning(string Code, string Detail);

--- a/src/Commands/QueryCommand.cs
+++ b/src/Commands/QueryCommand.cs
@@ -19,6 +19,10 @@ public class QueryCommand : Command {
     [XmlAttribute("foreground")] public bool Foreground { get; set; }
     [XmlAttribute("maxDepth")] public int MaxDepth { get; set; } = 6;
 
+    /// <summary>Upper bound on UIA nodes returned; keeps the result bounded for huge/virtualized trees.
+    /// A clipped walk is reported via a <c>tree-truncated</c> warning. 0 means unbounded.</summary>
+    [XmlAttribute("maxNodes")] public int MaxNodes { get; set; } = 1000;
+
     public static new List<Command> BuiltInCommands {
         get => [new QueryCommand { Cmd = "query" }];
     }
@@ -30,6 +34,7 @@ public class QueryCommand : Command {
         ClassName = this.ClassName,
         Foreground = this.Foreground,
         MaxDepth = this.MaxDepth,
+        MaxNodes = this.MaxNodes,
     });
 
     public override bool Execute() {
@@ -42,21 +47,27 @@ public class QueryCommand : Command {
             Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
             return false;
         }
-        AgentRuntime.Audit(Cmd, $"query window handle={Handle} title='{Window}' process='{Process}' class='{ClassName}' fg={Foreground} maxDepth={MaxDepth}");
+        AgentRuntime.Audit(Cmd, $"query window handle={Handle} title='{Window}' process='{Process}' class='{ClassName}' fg={Foreground} maxDepth={MaxDepth} maxNodes={MaxNodes}");
 
         WindowInfo? win = WindowResolver.Resolve(Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
         if (win is null) {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window").ToJson());
+            Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
             return false;
         }
 
         IntPtr h = new IntPtr(win.Handle);
-        UiaElementInfo? tree = UiaService.DumpTree(h, MaxDepth);
+        UiaTreeResult tree = UiaService.DumpTree(h, MaxDepth, MaxNodes);
         JsonObject data = new() {
             ["window"] = win.ToJsonObject(),
-            ["tree"] = tree?.ToJsonObject(),
+            ["nodeCount"] = tree.NodeCount,
+            ["truncated"] = tree.Truncated,
+            ["tree"] = tree.Root?.ToJsonObject(),
         };
-        Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
+        CommandResult res = CommandResult.Ok(Cmd, data);
+        if (tree.Truncated) {
+            res.Warn("tree-truncated", $"UIA tree exceeded the {MaxNodes}-node cap and was clipped; raise maxNodes or narrow the target for a complete tree.");
+        }
+        Reply?.WriteLine(res.ToJson());
         return true;
     }
 }

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -103,7 +103,13 @@ public static class AgentServer {
         "untitled popups are not enumerated by title/process — target them by handle or `foreground:true`.\n" +
         "2. OBSERVE: `query` dumps the UI Automation tree (controlType, name, automationId, bounds, " +
         "state, value) so you can pick a control instead of guessing pixels; `capture` returns a PNG " +
-        "of the window (works on composited WinUI/WPF surfaces).\n" +
+        "of the window (works on composited WinUI/WPF surfaces). Check results for trouble: a `capture` " +
+        "with errorCategory `capture-blank` is a black/empty frame (minimized, cloaked, occluded, or a " +
+        "locked session) — restore/foreground the window and retry instead of trusting the image; a " +
+        "`capture-fallback` warning means PrintWindow was refused and the picture may be wrong. If " +
+        "`query` returns `truncated:true` (a `tree-truncated` warning), the tree hit the node cap — raise " +
+        "`maxNodes` or target a deeper window so you don't reason over a partial tree. warnings are " +
+        "non-fatal; errorCategory tells you how to recover.\n" +
         "3. ACT: prefer `invoke` (by name/automationId/classname; action invoke|toggle|setvalue|setfocus|" +
         "expand|collapse) over coordinate clicks — it is far more reliable. To click a menu item, first " +
         "`invoke` its parent menu with action `expand` (a closed menu's sub-items are not in the tree " +

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -142,13 +142,14 @@ public static class AgentServer {
         captureProps["height"] = PropSchema("integer", "Region height");
         captureProps["file"] = PropSchema("string", "Optional path to also save the PNG to");
         tools.Add(Tool("capture",
-            "Screenshot a window (PrintWindow PW_RENDERFULLCONTENT, captures WinUI/WPF surfaces) or a screen region; returns PNG.",
+            "Screenshot a window (PrintWindow PW_RENDERFULLCONTENT, captures WinUI/WPF surfaces) or a screen region; returns PNG. Blank/black frames are detected and reported as a capture-blank error (window) or warning (region) rather than a silent bad image.",
             captureProps, []));
 
         JsonObject queryProps = WindowTargetProps();
         queryProps["maxDepth"] = PropSchema("integer", "Max UI Automation tree depth (default 6)");
+        queryProps["maxNodes"] = PropSchema("integer", "Max UI Automation nodes returned (default 1000); a clipped tree is flagged with a tree-truncated warning");
         tools.Add(Tool("query",
-            "Dump the UI Automation tree of a window: control type, name, automation id, bounds, state.",
+            "Dump the UI Automation tree of a window: control type, name, automation id, bounds, state. Returns nodeCount/truncated and warns when the node cap clips the tree.",
             queryProps, []));
 
         JsonObject findProps = WindowTargetProps();
@@ -364,6 +365,7 @@ public static class AgentServer {
             ClassName = Str(args, "className")!,
             Foreground = Bool(args, "foreground"),
             MaxDepth = Int(args, "maxDepth") is int d and > 0 ? d : 6,
+            MaxNodes = Int(args, "maxNodes") is int n and > 0 ? n : 1000,
         },
         "find" => new FindCommand {
             Window = Str(args, "window")!,

--- a/tests/MCEControl.xUnit/Agent/ScreenCaptureTests.cs
+++ b/tests/MCEControl.xUnit/Agent/ScreenCaptureTests.cs
@@ -1,0 +1,71 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Drawing;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Blank-frame detection (#90 observation hardening): a failed capture is a flat fill and must be
+/// flagged, while a real (busy) window must not trip the detector.
+/// </summary>
+public class ScreenCaptureTests {
+    private static Bitmap SolidBitmap(Color color, int w = 200, int h = 150) {
+        Bitmap bmp = new(w, h);
+        using Graphics g = Graphics.FromImage(bmp);
+        g.Clear(color);
+        return bmp;
+    }
+
+    [Fact]
+    public void AnalyzeBlank_AllBlack_IsBlankAndDark() {
+        using Bitmap bmp = SolidBitmap(Color.Black);
+
+        ImageStats stats = ScreenCapture.AnalyzeBlank(bmp);
+
+        Assert.True(stats.IsBlank);
+        Assert.True(stats.DominantIsDark);
+        Assert.Equal(1.0, stats.DominantFraction, 3);
+    }
+
+    [Fact]
+    public void AnalyzeBlank_AllWhite_IsBlankButNotDark() {
+        using Bitmap bmp = SolidBitmap(Color.White);
+
+        ImageStats stats = ScreenCapture.AnalyzeBlank(bmp);
+
+        // A legitimately empty white surface is still "blank" but must not be reported as a black frame.
+        Assert.True(stats.IsBlank);
+        Assert.False(stats.DominantIsDark);
+    }
+
+    [Fact]
+    public void AnalyzeBlank_BusyImage_IsNotBlank() {
+        using Bitmap bmp = new(200, 150);
+        // Paint a high-variety gradient/checker so no single quantized color dominates.
+        for (int y = 0; y < bmp.Height; y++) {
+            for (int x = 0; x < bmp.Width; x++) {
+                bmp.SetPixel(x, y, Color.FromArgb((x * 7) % 256, (y * 11) % 256, ((x + y) * 13) % 256));
+            }
+        }
+
+        ImageStats stats = ScreenCapture.AnalyzeBlank(bmp);
+
+        Assert.False(stats.IsBlank);
+        Assert.True(stats.DominantFraction < ScreenCapture.BlankDominantFractionThreshold);
+    }
+
+    [Fact]
+    public void AnalyzeBlank_MostlyUniformWithSpeck_StillBlank() {
+        using Bitmap bmp = SolidBitmap(Color.Black);
+        // A couple of stray bright pixels (a cursor/artifact) must not rescue an otherwise-black frame.
+        bmp.SetPixel(0, 0, Color.Red);
+        bmp.SetPixel(199, 149, Color.Lime);
+
+        ImageStats stats = ScreenCapture.AnalyzeBlank(bmp);
+
+        Assert.True(stats.IsBlank);
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
+++ b/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright © Kindel, LLC - http://www.kindel.com
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
+using System;
 using Xunit;
 using MCEControl;
 
@@ -24,5 +25,17 @@ public class UiaServiceTests {
     [InlineData("foo")]
     public void IsSupportedAction_UnknownActions_ReturnsFalse(string action) {
         Assert.False(UiaService.IsSupportedAction(action));
+    }
+
+    [Fact]
+    public void DumpTree_ZeroHandle_ReturnsEmptyUntruncatedResult() {
+        // The guard path must return a well-formed result (null root, no nodes, not truncated) rather
+        // than null, so query can always read nodeCount/truncated.
+        UiaTreeResult result = UiaService.DumpTree(IntPtr.Zero, maxDepth: 6, maxNodes: 1000);
+
+        Assert.NotNull(result);
+        Assert.Null(result.Root);
+        Assert.Equal(0, result.NodeCount);
+        Assert.False(result.Truncated);
     }
 }

--- a/tests/MCEControl.xUnit/Commands/CommandResultTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CommandResultTests.cs
@@ -1,0 +1,63 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Serialization of the structured result fields added for observation hardening (#90): warnings and
+/// the taxonomy-aligned error code/category, kept additive over the legacy success/error/data shape.
+/// </summary>
+public class CommandResultTests {
+    [Fact]
+    public void Ok_NoWarnings_OmitsWarningsArray() {
+        JsonObject json = CommandResult.Ok("query", new JsonObject { ["x"] = 1 }).ToJsonObject();
+
+        Assert.True(json["success"]!.GetValue<bool>());
+        Assert.Null(json["warnings"]);
+        Assert.Null(json["errorCode"]);
+    }
+
+    [Fact]
+    public void Warn_OnSuccess_EmitsWarningsArray() {
+        CommandResult res = CommandResult.Ok("capture", [])
+            .Warn("capture-fallback", "used blit");
+
+        JsonObject json = res.ToJsonObject();
+
+        Assert.True(json["success"]!.GetValue<bool>());
+        JsonArray warnings = json["warnings"]!.AsArray();
+        Assert.Single(warnings);
+        Assert.Equal("capture-fallback", warnings[0]!["code"]!.GetValue<string>());
+        Assert.Equal("used blit", warnings[0]!["detail"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void StructuredFail_EmitsCodeCategoryAndCarriesData() {
+        JsonObject data = new() { ["base64"] = "AAAA" };
+
+        JsonObject json = CommandResult
+            .Fail("capture", "Captured frame is blank", "frame-all-black", "capture-blank", data)
+            .ToJsonObject();
+
+        Assert.False(json["success"]!.GetValue<bool>());
+        Assert.Equal("Captured frame is blank", json["error"]!.GetValue<string>());
+        Assert.Equal("frame-all-black", json["errorCode"]!.GetValue<string>());
+        Assert.Equal("capture-blank", json["errorCategory"]!.GetValue<string>());
+        // The suspect image is preserved (contract's lastObservation), not dropped on failure.
+        Assert.Equal("AAAA", json["data"]!["base64"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void LegacyFail_OmitsStructuredErrorFields() {
+        JsonObject json = CommandResult.Fail("query", "No matching window").ToJsonObject();
+
+        Assert.False(json["success"]!.GetValue<bool>());
+        Assert.Equal("No matching window", json["error"]!.GetValue<string>());
+        Assert.Null(json["errorCode"]);
+        Assert.Null(json["errorCategory"]);
+    }
+}


### PR DESCRIPTION
Part of #90 (Epic: Observation hardening). Implements the **core hardening slice**: make `capture`/`query` fail loudly instead of returning plausible-but-wrong observations, using the structured error/warning vocabulary from the #101 contract (additive over the legacy `success`/`error`/`data` shape).

## Capture
- `ScreenCapture` analyzes every frame for blank/flat content (bounded grid sample → 5-bit quantize → dominant-color fraction) and reports whether the on-screen-blit fallback ran. `CaptureWindow`/`CaptureRegion` now return a `CaptureResult` (`Png`, `Width`, `Height`, `UsedFallback`, `Stats`).
- A blank **window** capture → `capture-blank` **failure** (`frame-all-black` / `frame-uniform`), but the PNG is still returned in `data` and as the MCP image block — never a *silent* bad image, and usable as the failure's last observation.
- A blank **region** capture → `capture-blank` **warning** (a user-specified region can legitimately be empty).
- The `PrintWindow`→blit fallback adds a `capture-fallback` warning.
- `data.blankCheck` carries `{ blank, dominantFraction, dominantIsDark }`.

## Query
- UIA tree dump gains a `maxNodes` cap (default 1000). `DumpTree` returns a `UiaTreeResult` (`Root`, `NodeCount`, `Truncated`). A clipped walk surfaces a `tree-truncated` warning plus `data.nodeCount`/`data.truncated` instead of a silently partial tree. (Existing per-node stale-skip behavior unchanged.)

## Contract alignment
- `CommandResult` gains `Warnings` + `ErrorCode`/`ErrorCategory` (closed taxonomy from `docs/design/agent-tool-result-contract.md`, #101). `"No matching window"` → `no-target`/`window-not-found`. Existing consumers reading `success`/`error`/`data` are unaffected.
- `AgentServer` exposes `maxNodes` and updated tool descriptions.

## Docs
- `docs/agent-server.md`: new **Observation hardening & known limitations** section — blank detection; `PrintWindow` + fallback limits; minimized/cloaked/protected-content; locked sessions + UAC/elevation; UIA size/stability. Tied to [#78] and the #101 contract.

## Acceptance criteria (#90)
- ✅ Capture failures return structured errors/warnings, not silent bad images.
- ✅ Query output bounded/stable (depth + node cap, truncation flagged) for selectors/agent reasoning.
- ✅ Composited/locked-session/UAC behavior documented honestly.
- ✅ Tests cover nonblank image validation and UIA guard-path handling.
- ↪️ Deferred (out of this slice, confirmed scope): live locked-session/composited validation fixture (#78), element-bounds capture, GIF.

## Validation
Full xUnit suite: **144 passed, 22 skipped (pre-existing), 0 failed.** New tests:
- `ScreenCaptureTests` — all-black (blank+dark), all-white (blank, not dark), busy gradient (not blank), mostly-uniform-with-speck (still blank).
- `CommandResultTests` — warnings array emitted/omitted; structured `errorCode`/`errorCategory` + data carried on failure; legacy `Fail` stays flat.
- `UiaServiceTests` — `DumpTree` zero-handle guard returns a well-formed empty result.

[#78]: https://github.com/tig/mcec/issues/78

🤖 Generated with [Claude Code](https://claude.com/claude-code)