### PR TITLE
trace: standard evidence bundle module + format doc (#87)

### DIFF
--- a/docs/evidence-bundles.md
+++ b/docs/evidence-bundles.md
@@ -1,0 +1,82 @@
+# MCEC evidence bundles
+
+*Issue #87 — trace, replay, and artifact bundles.*
+
+Every MCEC dogfood run (Customer 0 self-dogfood, Customer 1 WinPrint, future benchmarks) produces
+the **same** evidence bundle, so a failed run can be understood without rerunning it and a bundle can
+be attached to an issue as-is. The bundle is produced by [`scripts/McecEvidence.psm1`](../scripts/McecEvidence.psm1)
+— any runner that imports the module emits an identical layout.
+
+## Layout
+
+```
+<artifactDir>/                      e.g. artifacts/customer0/20260629-195442-5f19c9c01a3f/
+  session.json          session record: id, scenario, ordered steps, pass/fail, last observation
+  tool-calls.jsonl      one JSON object per MCP request/response (image bytes redacted)
+  environment.json      OS, .NET, display, DPI, app version, host
+  failure-summary.md    PASS/FAIL, last good observation, the failing step
+  screenshot*.png ...    observation artifacts the runner writes into the directory
+<artifactDir>.zip                   the same directory, zipped for issue attachment
+```
+
+`artifacts/` is git-ignored — bundles are run output, and screenshots may contain desktop contents.
+
+## Files
+
+### `session.json`
+```jsonc
+{
+  "sessionId": "5f19c9c01a3f",
+  "scenario": "customer0-walking-skeleton",
+  "issue": 98,
+  "startedAt": "20260629-195442",
+  "passed": true,
+  "lastObservation": "About window appeared: 'About' handle=10553630",
+  "steps": [ { "name": "observe", "status": "pass", "detail": "...", "at": "<iso8601>" } ],
+  "toolCallLogTruncated": false,
+  "artifacts": [ "environment.json", "failure-summary.md", "screenshot.png", "tool-calls.jsonl" ]
+}
+```
+
+### `tool-calls.jsonl`
+One JSON object per line, in call order — the replay transcript:
+```jsonc
+{ "ts": "<iso8601>", "sessionId": "...", "direction": "request|response", "method": "tools/call", "payload": { ... } }
+```
+`payload` is the raw JSON-RPC request or response. Base64 image data in `capture` responses is replaced
+with `"<redacted base64>"` — the PNG is kept as a separate artifact instead, which keeps the transcript
+small and avoids embedding screen contents in the log.
+
+### `environment.json`
+`os`, `dotnet`, `mcecVersion`, `display` (WxH), `dpi`, `host`, `mcpUrl` — captured by `Get-McecEnvironment`.
+
+### `failure-summary.md`
+Always written. On failure it names the failing step and the **last good observation** so another agent
+can triage without watching the run.
+
+## Producing a bundle
+
+```powershell
+Import-Module ./scripts/McecEvidence.psm1
+$s = New-McecSession -Scenario "winprint-hero-gif" -Issue 84 -ArtifactRoot ./artifacts/customer1
+Add-McecStep $s "launch" "pass" "winprint up"
+Write-McecToolCall $s "request" "tools/call" $req      # called from your MCP wrapper
+# ... write screenshots into $s.ArtifactDir ...
+$s.LastObservation = "hero frames captured"
+Complete-McecSession -Session $s -Passed $true -Environment (Get-McecEnvironment -ExePath $exe -McpUrl $url)
+```
+
+## Size and privacy
+
+- **Size:** the transcript is capped at 8 MB (`$MaxToolCallBytes`); past that it stops appending and sets
+  `toolCallLogTruncated: true` in `session.json`. Image bytes never enter the transcript.
+- **Privacy:** screenshots can contain whatever is on screen — treat bundles as sensitive, and `artifacts/`
+  is git-ignored. Bind addresses and credentials are not collected.
+
+## Replay / export (partial)
+
+`tool-calls.jsonl` is an ordered, replayable transcript: each `request` line is a literal JSON-RPC call
+that can be re-POSTed to a fresh MCEC `/mcp` to reproduce the sequence, and each `response` line is the
+expected result to diff against. A full deterministic replayer (timing, window-handle remapping, screenshot
+diffing) is future work; the format is stable enough to build it on. GIF recording (#80) lands as additional
+`*.gif` artifacts in the same bundle.

--- a/scripts/McecEvidence.psm1
+++ b/scripts/McecEvidence.psm1
@@ -1,0 +1,140 @@
+<#
+.SYNOPSIS
+    Standard MCEC dogfood evidence bundle (issue #87).
+
+.DESCRIPTION
+    A reusable layer that any MCEC-driven runner (Customer 0 self-dogfood, Customer 1 WinPrint, ...)
+    uses to produce an identical, inspectable, zip-able evidence bundle so a failed run can be
+    understood without rerunning it. Layout:
+
+        <artifactDir>/
+          session.json        - session record: id, scenario, ordered steps, pass/fail, last observation
+          tool-calls.jsonl    - one JSON object per MCP request/response (base64 image bytes redacted)
+          environment.json    - OS, .NET, display, DPI, app version, host
+          failure-summary.md  - PASS/FAIL, last good observation, the failing step
+          screenshot*.png ... - observation artifacts the runner writes into ArtifactDir
+        <artifactDir>.zip     - the same directory, zipped for issue attachment
+
+    See docs/evidence-bundles.md for the format spec and replay/export notes.
+#>
+
+# Size cap for the transcript so a long run can't produce an unbounded log.
+$script:MaxToolCallBytes = 8MB
+
+function New-McecSession {
+    <#.SYNOPSIS Starts a session and allocates its artifact directory.#>
+    param(
+        [Parameter(Mandatory)][string]$Scenario,
+        [int]$Issue = 0,
+        [Parameter(Mandatory)][string]$ArtifactRoot
+    )
+    $id = ([guid]::NewGuid()).ToString("N").Substring(0, 12)
+    $stamp = (Get-Date).ToString("yyyyMMdd-HHmmss")
+    $dir = Join-Path $ArtifactRoot "$stamp-$id"
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    return @{
+        SessionId       = $id
+        Scenario        = $Scenario
+        Issue           = $Issue
+        StartedAt       = $stamp
+        ArtifactRoot    = $ArtifactRoot
+        ArtifactDir     = $dir
+        ToolCallLog     = (Join-Path $dir "tool-calls.jsonl")
+        Steps           = [System.Collections.Generic.List[object]]::new()
+        LastObservation = $null
+        ToolCallBytes   = 0
+        Truncated       = $false
+    }
+}
+
+function Add-McecStep {
+    <#.SYNOPSIS Records an ordered step and echoes it to the host.#>
+    param([Parameter(Mandatory)]$Session, [Parameter(Mandatory)][string]$Name,
+          [Parameter(Mandatory)][string]$Status, [string]$Detail = "")
+    $Session.Steps.Add([ordered]@{ name = $Name; status = $Status; detail = $Detail; at = (Get-Date).ToString("o") })
+    Write-Host ("[{0,-7}] {1} {2}" -f $Status.ToUpper(), $Name, $Detail)
+}
+
+function Write-McecToolCall {
+    <#.SYNOPSIS Appends one request/response record to tool-calls.jsonl (base64 redacted, size-capped).#>
+    param([Parameter(Mandatory)]$Session, [Parameter(Mandatory)][string]$Direction,
+          [string]$Method, $Payload)
+    if ($Session.Truncated) { return }
+    $entry = [ordered]@{ ts = (Get-Date).ToString("o"); sessionId = $Session.SessionId; direction = $Direction; method = $Method; payload = $Payload }
+    $json = ($entry | ConvertTo-Json -Depth 20 -Compress)
+    # Privacy + size: keep image bytes out of the transcript — the PNG is a separate artifact.
+    $json = [regex]::Replace($json, '("(?:data|base64)"\s*:\s*")[A-Za-z0-9+/=]{200,}(")', '${1}<redacted base64>${2}')
+    if ($Session.ToolCallBytes + $json.Length -gt $script:MaxToolCallBytes) {
+        Add-Content -Path $Session.ToolCallLog -Value '{"truncated":"tool-call log size cap reached"}' -Encoding utf8
+        $Session.Truncated = $true
+        return
+    }
+    Add-Content -Path $Session.ToolCallLog -Value $json -Encoding utf8
+    $Session.ToolCallBytes += $json.Length + 1
+}
+
+function Get-McecEnvironment {
+    <#.SYNOPSIS Captures standard environment metadata for a bundle.#>
+    param([string]$ExePath, [string]$McpUrl)
+    $screen = $null
+    try { Add-Type -AssemblyName System.Windows.Forms; $screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds } catch {}
+    $dpi = "unknown"
+    try {
+        Add-Type -AssemblyName System.Drawing
+        $g = [System.Drawing.Graphics]::FromHwnd([IntPtr]::Zero)
+        $dpi = "$([int]$g.DpiX)"; $g.Dispose()
+    } catch {}
+    $ver = try { (Get-Item $ExePath).VersionInfo.ProductVersion } catch { "unknown" }
+    return [ordered]@{
+        os          = [System.Environment]::OSVersion.VersionString
+        dotnet      = "$([System.Environment]::Version)"
+        mcecVersion = $ver
+        display     = if ($screen) { "$($screen.Width)x$($screen.Height)" } else { "unknown" }
+        dpi         = $dpi
+        host        = $env:COMPUTERNAME
+        mcpUrl      = $McpUrl
+    }
+}
+
+function Complete-McecSession {
+    <#.SYNOPSIS Writes session.json/environment.json/failure-summary.md and zips the bundle.#>
+    param([Parameter(Mandatory)]$Session, [Parameter(Mandatory)][bool]$Passed, [hashtable]$Environment)
+    $dir = $Session.ArtifactDir
+
+    $envObj = [ordered]@{ sessionId = $Session.SessionId; timestamp = (Get-Date).ToString("o") }
+    if ($Environment) { foreach ($k in $Environment.Keys) { $envObj[$k] = $Environment[$k] } }
+    ($envObj | ConvertTo-Json -Depth 6) | Set-Content -Path (Join-Path $dir "environment.json") -Encoding utf8
+
+    $fail = $Session.Steps | Where-Object { $_.status -eq "fail" } | Select-Object -First 1
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine("# $($Session.Scenario) — $(if ($Passed) { 'PASS' } else { 'FAIL' })")
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("- Session: ``$($Session.SessionId)``")
+    [void]$sb.AppendLine("- Scenario: $($Session.Scenario)$(if ($Session.Issue) { " (#$($Session.Issue))" })")
+    [void]$sb.AppendLine("- Last good observation: $($Session.LastObservation)")
+    if ($fail) { [void]$sb.AppendLine("- Failing step: **$($fail.name)** — $($fail.detail)") }
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("## Steps")
+    foreach ($s in $Session.Steps) { [void]$sb.AppendLine("- [$($s.status)] $($s.name): $($s.detail)") }
+    $sb.ToString() | Set-Content -Path (Join-Path $dir "failure-summary.md") -Encoding utf8
+
+    $sessionObj = [ordered]@{
+        sessionId            = $Session.SessionId
+        scenario             = $Session.Scenario
+        issue                = $Session.Issue
+        startedAt            = $Session.StartedAt
+        passed               = $Passed
+        lastObservation      = $Session.LastObservation
+        steps                = $Session.Steps
+        toolCallLogTruncated = $Session.Truncated
+        artifacts            = @(Get-ChildItem -File $dir | Select-Object -ExpandProperty Name | Sort-Object)
+    }
+    ($sessionObj | ConvertTo-Json -Depth 10) | Set-Content -Path (Join-Path $dir "session.json") -Encoding utf8
+
+    $bundle = Join-Path $Session.ArtifactRoot ("{0}-{1}.zip" -f $Session.StartedAt, $Session.SessionId)
+    try { Compress-Archive -Path (Join-Path $dir '*') -DestinationPath $bundle -Force } catch { $bundle = $null }
+
+    return [pscustomobject]@{ Passed = $Passed; ArtifactDir = $dir; Bundle = $bundle }
+}
+
+Export-ModuleMember -Function New-McecSession, Add-McecStep, Write-McecToolCall, Get-McecEnvironment, Complete-McecSession

--- a/scripts/Run-Customer0Skeleton.ps1
+++ b/scripts/Run-Customer0Skeleton.ps1
@@ -51,28 +51,30 @@ if (-not (Test-Path $exe)) {
 }
 if (-not $ArtifactRoot) { $ArtifactRoot = Join-Path $repoRoot "artifacts/customer0" }
 
-$sessionId = ([guid]::NewGuid()).ToString("N").Substring(0, 12)
-$stamp = (Get-Date).ToString("yyyyMMdd-HHmmss")
-$artifactDir = Join-Path $ArtifactRoot "$stamp-$sessionId"
+# Standard evidence bundle (session record, JSONL transcript, environment, failure summary, zip)
+# lives in McecEvidence.psm1 so every MCEC-driven runner produces an identical bundle (#87).
+Import-Module (Join-Path $PSScriptRoot "McecEvidence.psm1") -Force
+$session = New-McecSession -Scenario "customer0-walking-skeleton" -Issue 98 -ArtifactRoot $ArtifactRoot
+$sessionId = $session.SessionId
+$artifactDir = $session.ArtifactDir
+$toolCallLog = $session.ToolCallLog
+
 # Stable run dir (NOT a per-run temp path): the mcec.exe path is then constant across runs,
 # so a single Windows Firewall allow rule (scripts/Allow-McecFirewall.ps1) suppresses prompts
 # for every run instead of Windows re-prompting for each new temp copy.
 $runDir = Join-Path $env:LOCALAPPDATA "Kindel\mcec-skeleton-run"
-New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
 
-$toolCallLog = Join-Path $artifactDir "tool-calls.jsonl"
 $mcpUrl = "http://127.0.0.1:$Port/mcp"
 $baseUrl = "http://127.0.0.1:$Port/"
 
-$steps = [System.Collections.Generic.List[object]]::new()
 $lastGoodObservation = $null
 $guiProc = $null
 $rpcId = 0
 
+# Thin wrapper so existing call sites stay unchanged.
 function Add-Step {
     param([string]$Name, [string]$Status, [string]$Detail = "")
-    $steps.Add([ordered]@{ name = $Name; status = $Status; detail = $Detail; at = (Get-Date).ToString("o") })
-    Write-Host ("[{0,-7}] {1} {2}" -f $Status.ToUpper(), $Name, $Detail)
+    Add-McecStep $script:session $Name $Status $Detail
 }
 
 # ---------------------------------------------------------------------------
@@ -83,12 +85,10 @@ function Invoke-Mcp {
     $script:rpcId++
     $req = @{ jsonrpc = "2.0"; id = $script:rpcId; method = $Method; params = $Params }
     $body = $req | ConvertTo-Json -Depth 12 -Compress
-    $entry = [ordered]@{ ts = (Get-Date).ToString("o"); sessionId = $sessionId; direction = "request"; method = $Method; payload = $req }
-    ($entry | ConvertTo-Json -Depth 12 -Compress) | Add-Content -Path $toolCallLog -Encoding utf8
+    Write-McecToolCall $script:session "request" $Method $req
 
     $resp = Invoke-RestMethod -Uri $mcpUrl -Method Post -Body $body -ContentType "application/json" -TimeoutSec $TimeoutSec
-    $rentry = [ordered]@{ ts = (Get-Date).ToString("o"); sessionId = $sessionId; direction = "response"; method = $Method; payload = $resp }
-    ($rentry | ConvertTo-Json -Depth 20 -Compress) | Add-Content -Path $toolCallLog -Encoding utf8
+    Write-McecToolCall $script:session "response" $Method $resp
     return $resp
 }
 
@@ -279,63 +279,23 @@ catch {
     Add-Step "error" "fail" $_.Exception.Message
 }
 finally {
-    # --- environment.json ---
-    $screen = $null
-    try { Add-Type -AssemblyName System.Windows.Forms; $screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds } catch {}
-    $mcecVer = try { (Get-Item $exe).VersionInfo.ProductVersion } catch { "unknown" }
-    $env = [ordered]@{
-        sessionId   = $sessionId
-        timestamp   = (Get-Date).ToString("o")
-        os          = "$([System.Environment]::OSVersion.VersionString)"
-        dotnet      = "$([System.Environment]::Version)"
-        mcecVersion = $mcecVer
-        display     = if ($screen) { "$($screen.Width)x$($screen.Height)" } else { "unknown" }
-        host        = $env:COMPUTERNAME
-        mcpUrl      = $mcpUrl
-    }
-    ($env | ConvertTo-Json -Depth 5) | Set-Content -Path (Join-Path $artifactDir "environment.json") -Encoding utf8
-
-    # --- session.json ---
-    $session = [ordered]@{
-        sessionId = $sessionId
-        scenario  = "customer0-walking-skeleton"
-        issue     = 98
-        startedAt = $stamp
-        passed    = $passed
-        steps     = $steps
-        artifacts = @("session.json", "tool-calls.jsonl", "screenshot.png", "environment.json", "failure-summary.md")
-    }
-    ($session | ConvertTo-Json -Depth 8) | Set-Content -Path (Join-Path $artifactDir "session.json") -Encoding utf8
-
-    # --- failure-summary.md (always written; says PASS when green) ---
-    $fail = $steps | Where-Object { $_.status -eq "fail" } | Select-Object -First 1
-    $sb = [System.Text.StringBuilder]::new()
-    [void]$sb.AppendLine("# Customer 0 Walking Skeleton — $($(if($passed){'PASS'}else{'FAIL'}))")
-    [void]$sb.AppendLine("")
-    [void]$sb.AppendLine("- Session: ``$sessionId``")
-    [void]$sb.AppendLine("- Scenario: customer0-walking-skeleton (#98)")
-    [void]$sb.AppendLine("- Last good observation: $lastGoodObservation")
-    if ($fail) {
-        [void]$sb.AppendLine("- Failing step: **$($fail.name)** — $($fail.detail)")
-    }
-    [void]$sb.AppendLine("")
-    [void]$sb.AppendLine("## Steps")
-    foreach ($s in $steps) { [void]$sb.AppendLine("- [$($s.status)] $($s.name): $($s.detail)") }
-    $sb.ToString() | Set-Content -Path (Join-Path $artifactDir "failure-summary.md") -Encoding utf8
-
     # --- Cleanup: stop the GUI (also closes the About dialog), remove the run dir ---
     if ($guiProc) { try { Stop-Process -Id $guiProc.Id -Force -ErrorAction SilentlyContinue } catch {} }
     Stop-RunDirMcec $runDir
     try { Remove-Item -Path $runDir -Recurse -Force -ErrorAction SilentlyContinue } catch {}
 
-    # --- Zip the bundle ---
-    $bundle = Join-Path $ArtifactRoot "$stamp-$sessionId.zip"
-    try { Compress-Archive -Path (Join-Path $artifactDir '*') -DestinationPath $bundle -Force; Add-Step "bundle" "pass" $bundle } catch { Add-Step "bundle" "fail" $_.Exception.Message }
+    # --- Write the standard evidence bundle (#87): session.json, environment.json,
+    #     failure-summary.md, and the zip — all produced by McecEvidence.psm1. ---
+    $session.LastObservation = $lastGoodObservation
+    $environment = Get-McecEnvironment -ExePath $exe -McpUrl $mcpUrl
+    $result = Complete-McecSession -Session $session -Passed $passed -Environment $environment
+    $bundle = $result.Bundle
 
     Write-Host ""
     Write-Host "==================================================================="
     Write-Host (" RESULT: {0}" -f $(if ($passed) { "PASS" } else { "FAIL" }))
     Write-Host (" Bundle: {0}" -f $artifactDir)
+    Write-Host (" Zip:    {0}" -f $bundle)
     Write-Host "==================================================================="
 }
 


### PR DESCRIPTION
## Summary
Advances **#87**: turns the evidence bundle the walking skeleton already emitted into a **reusable, documented standard** so Customer 0 (now) and Customer 1 / benchmarks (next) produce identical bundles.

- **`scripts/McecEvidence.psm1`** — `New-McecSession` / `Add-McecStep` / `Write-McecToolCall` / `Get-McecEnvironment` / `Complete-McecSession`. Emits `session.json`, `tool-calls.jsonl`, `environment.json`, `failure-summary.md` + the runner's screenshots, then zips the directory.
- **Privacy + size:** base64 image bytes are redacted from the transcript (PNG kept as a separate artifact); transcript capped at 8MB with a `toolCallLogTruncated` flag. Skeleton transcript dropped ~80KB → ~13KB.
- **`environment.json`** now includes display + DPI.
- **`docs/evidence-bundles.md`** documents the layout, each file, how to produce a bundle, size/privacy, and the partial replay/export story.
- **`Run-Customer0Skeleton.ps1`** refactored onto the module — **3/3 deterministic PASS**, redaction verified.

Remaining under #87 (not in this PR): Customer 1 wiring (rides with #84), GIF recording (#80), a full deterministic replayer.

Refs #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
