### PR TITLE
Add GIF recording for agent sessions or selected segments (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 By Tig Kindel ([@tigkindel on Twitter](http://www.twitter.com/ckindel)) - Copyright © [Kindel](http://www.kindel.com), LLC.
 
-![mcec](https://tig.github.io/mcec/mainwindow.png "MCEC")
+![mcec](https://tig.github.io/mcec/hero.gif "MCEC — one agent driving another: launch, Help ▸ About, File ▸ Settings, File ▸ Exit, recorded with MCEC's own agent tools")
 
 **MCEC** (Model Context Environment Controller) is eyes, hands, and a safe front door for agents on Windows; and the same battle-tested remote control for smart-home systems.
 

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -92,8 +92,9 @@ case-insensitive), `handle` (HWND), `process` (process name without `.exe`),
 | `find`     | Find a **UI Automation element** by name / automation id / class.                 | window target, `by` (`name`\|`automationid`\|`classname`), `value`, `timeout` |
 | `wait-for` | Same as `find`, but waits up to a timeout for the element to appear (default 5 s). | window target, `by`, `value`, `timeout` |
 | `invoke`   | Drive a UI Automation element pattern — far more reliable than coordinate clicks. | window target, `by`, `value`, `action` (`invoke`\|`toggle`\|`setvalue`\|`setfocus`), `text` |
+| `record`   | Record a window or region to an **animated GIF** over time (start/stop or a bounded one-shot). | window target, or region `x`/`y`/`width`/`height`; `action` (`start`\|`stop`\|`oneshot`), `fps`, `durationMs`, `maxWidth`, `file` |
 
-All five return a `CommandResult` JSON object via `Reply.WriteLine`:
+All return a `CommandResult` JSON object via `Reply.WriteLine`:
 
 ```json
 {
@@ -146,6 +147,66 @@ geometry:
 
 (Over MCP, `capture` additionally returns the PNG as an `image` content block so the
 model can view it directly, in addition to the JSON text above.)
+
+### `record` — capturing change over time
+
+`capture` answers "what does this look like **now**". When you need to show change *over
+time* — an animation for a demo or issue report, or a repro of a transient/flicker — use
+`record`, which writes an **animated GIF**.
+
+> **⚠️ Privacy:** a recording captures whatever is on screen for its *entire* duration,
+> not just one instant — it is a louder disclosure than a still `capture`. Only record
+> what you mean to, keep recordings short, and be aware the GIF may contain sensitive
+> content (credentials, messages, other windows). Recording is off unless the operator has
+> enabled the agent commands, and every start/stop/write is `AGENT-AUDIT:`-logged.
+
+Two ways to bound a recording:
+
+- **One-shot:** give `durationMs` (and optional `fps`); MCEC records that long, then writes
+  the GIF and returns metadata in a single call.
+- **Segment:** `action: "start"` begins recording and returns immediately; `action: "stop"`
+  ends it, encodes, writes the file, and returns metadata. Only one recording runs at a time.
+
+Safety limits (operator-configurable in `mcec.settings`, requests above them are *clamped*,
+not failed) keep an agent from producing an unbounded file:
+
+| Setting                    | Default  | Meaning |
+|----------------------------|----------|---------|
+| `AgentRecordMaxFps`        | 30       | Max frames per second (`fps` default is 5). |
+| `AgentRecordMaxDurationMs` | 60000    | Max recording length (60 s). |
+| `AgentRecordMaxFrames`     | 600      | Hard cap on captured frames. |
+| `AgentRecordMaxWidth`      | 1280     | Frames are downscaled so width fits this. |
+
+A finished `record` (one-shot or `stop`) returns the output path and metadata:
+
+```json
+{
+  "success": true,
+  "command": "record",
+  "data": {
+    "file": "C:\\Users\\me\\AppData\\Local\\Temp\\mcec-rec-20260629-141503.gif",
+    "frames": 73,
+    "durationMs": 14600,
+    "fps": 5,
+    "width": 1280,
+    "height": 824,
+    "bytes": 1048576,
+    "target": {
+      "handle": 1576490, "title": "Untitled - Notepad", "className": "Notepad",
+      "processName": "notepad", "processId": 21344,
+      "x": 120, "y": 80, "width": 1024, "height": 768
+    }
+  }
+}
+```
+
+`action: "start"` returns `{ "recording": true, "fps": 5, "maxDurationMs": 60000, "target": { … } }`.
+If `file` is omitted, MCEC writes to a timestamped path under the system temp directory and
+reports it in `file`.
+
+No extra dependency is used: each frame is quantized + LZW-compressed to a GIF by GDI+, and
+the frames are stitched into one GIF89a (Netscape loop extension + per-frame delays). See
+`docs/design/gif-recording.md` for the full design.
 
 ### `query` result example
 
@@ -217,6 +278,7 @@ When connected, the server advertises these tools:
 | `find`         | The `find` command (match a UI element, one-shot).             |
 | `wait-for`     | The `wait-for` command (poll for a UI element until a timeout). |
 | `invoke`       | The `invoke` command (run an existing MCEC command).           |
+| `record`       | The `record` command (window/region → animated GIF over time). |
 | `send_command` | Generic raw-command passthrough — send any MCEC command line.  |
 
 ---
@@ -242,7 +304,7 @@ is not a general-purpose web API and is not exposed off-box by default.
 
 ## Summary
 
-- New, opt-in agent surface: `capture`, `query`, `find`, `wait-for`, `invoke`.
+- New, opt-in agent surface: `capture`, `query`, `find`, `wait-for`, `invoke`, `record`.
 - Structured JSON results; same commands exposed as MCP/HTTP tools.
 - **Three independent off-by-default gates:** `AgentCommandsEnabled`, per-command
   `Enabled`, and `McpServerEnabled` (localhost-bound).

--- a/docs/design/gif-recording.md
+++ b/docs/design/gif-recording.md
@@ -1,0 +1,99 @@
+# Mini-spec: GIF recording for agent sessions (#80)
+
+## Goal
+
+Let an MCEC 3.0 agent record agent-driven desktop activity as an animated GIF — either a
+whole short segment (explicit start/stop) or a bounded one-shot — reusing the same target
+model and security gate as `capture`. This makes dogfooding, debugging, demos, and issue
+reports far easier: the loop that can `capture` a still frame can now produce a compact
+moving artifact of what happened over time.
+
+## Surface
+
+A single `record` command / MCP tool with three modes, selected by `action`:
+
+| `action`  | Behavior                                                                            |
+| --------- | ----------------------------------------------------------------------------------- |
+| `start`   | Begin capturing the target at `fps` on a background thread; returns immediately.    |
+| `stop`    | Stop the in-progress recording, encode the GIF, write `file`, return metadata.      |
+| `oneshot` | `start`, capture for `durationMs`, then auto-stop/encode/write in one blocking call. |
+
+`action` defaults to `oneshot` when `durationMs` is given, else `start`.
+
+**Target** (same resolver as `capture`): `window` (title substring), `handle`, `process`,
+`className`, `foreground:true`, or an explicit region (`x`/`y`/`width`/`height`). The target
+is resolved and fixed at `start`/`oneshot`; `stop` needs no target.
+
+**Other args:** `fps` (default 5), `durationMs` (one-shot length / auto-stop cap),
+`file` (output `.gif` path; a temp path is generated if omitted), `maxWidth`
+(downscale longest side, default 1280 to keep GIFs bounded).
+
+Only one recording may be active at a time; `start` while recording returns an error, and
+`stop` with nothing recording returns an error.
+
+## Result envelope
+
+Returns the shared `CommandResult` JSON (`success` / `command` / `error` / `data`). On a
+successful `stop`/`oneshot`, `data` carries:
+
+```json
+{
+  "file": "C:\\...\\rec.gif",
+  "frames": 73,
+  "durationMs": 14600,
+  "fps": 5,
+  "width": 1280,
+  "height": 824,
+  "bytes": 1048576,
+  "target": { "handle": 123456, "title": "Notepad", "...": "..." }
+}
+```
+
+`start` returns `{ "recording": true, "fps": 5, "target": { ... } }`. Errors use the
+existing `error` string (e.g. ambiguous/no target, already-recording, disabled gate).
+
+## Encoding
+
+No new dependency: each captured frame is quantized + LZW-compressed to a single-frame GIF
+by GDI+ (`Bitmap.Save(..., ImageFormat.Gif)`), and `GifEncoder` stitches those frames into
+one GIF89a — global header, a Netscape looping extension, and a per-frame Graphic Control
+Extension carrying the inter-frame delay (`1000/fps` → centiseconds). Each frame keeps its
+own color table as a local color table, so per-frame palettes survive.
+
+## Limits (anti-footgun)
+
+So an agent cannot accidentally create an unbounded file, the recorder clamps to operator
+settings (with built-in defaults):
+
+- `AgentRecordMaxFps` (default 30)
+- `AgentRecordMaxDurationMs` (default 60000 — 60 s)
+- `AgentRecordMaxFrames` (default 600)
+- `AgentRecordMaxWidth` (default 1280; frames are downscaled to fit)
+
+Requests above a limit are clamped (not failed), and the clamp is audited.
+
+## Security & privacy
+
+- **Disabled by default**, behind the *same* `AgentCommandsEnabled` opt-in as `capture`,
+  plus the per-command `Enabled` gate in `mcec.commands` (fail-closed) — honoring #74.
+- Every `start` / `stop` / write emits an `AGENT-AUDIT:` line with target, duration, fps,
+  and output path.
+- Docs warn that GIF recording can capture **sensitive on-screen content** for the whole
+  duration — louder than a single still `capture`.
+
+## In-product guidance
+
+`AgentServer.Instructions` gains a line on *when* to record vs. still-`capture`: prefer
+`capture` for a single state check; use `record` only to show change over time (an
+animation, a repro of a transient/flicker), and keep it short.
+
+## Acceptance criteria mapping
+
+- ✅ Command/MCP surface to record a GIF from a window, foreground window, or region.
+- ✅ Record part of a session via explicit `start`/`stop` or bounded `durationMs`.
+- ✅ Structured JSON: success/error, output path, frame count, duration, dimensions, bytes.
+- ✅ Docs + built-in MCP guidance on GIF-record vs still-`capture`.
+- ✅ Tests for argument validation and the disabled gate; an opt-in manual desktop test for
+  real capture.
+</content>
+</invoke>

--- a/docs/hero-gif.md
+++ b/docs/hero-gif.md
@@ -1,0 +1,62 @@
+# Recreating the hero GIF (`docs/hero.gif`)
+
+`docs/hero.gif` is the hero image shown at the top of [`README.md`](../README.md) and the docs
+home page ([`docs/index.md`](index.md), served at `https://tig.github.io/mcec/hero.gif`). It is
+MCEC dogfooding itself: a **headless controller** (`mcec.exe --mcp`) drives a **second MCEC** through
+its whole life — launch → **Help ▸ About** → **File ▸ Settings** → **File ▸ Exit** — and records the
+session to an animated GIF with the agent [`record`](agent-server.md#record--capturing-change-over-time)
+tool added in #80. No external screen-recorder is involved.
+
+## One-shot regeneration
+
+On an interactive Windows session you can leave alone for ~20 seconds (it drives the real mouse,
+keyboard, and launches an app):
+
+```powershell
+pwsh -NoProfile -File scripts/Generate-HeroGif.ps1        # add -Config Release to use a Release build
+```
+
+The script builds if needed, produces `docs/hero.gif`, and cleans up after itself. Review the result;
+if it looks good, commit `docs/hero.gif`.
+
+## What the script does (and why)
+
+It is the executable form of these decisions — replicate them if reproducing by hand:
+
+1. **Separate subject copy in its own directory.** The controlled MCEC is a *copy* of the build
+   output in `%TEMP%\mcec-hero-subject`, launched from there. `Program.ConfigPath` is the exe's own
+   folder, so the subject reads a **co-located `mcec.settings`** — isolated from the controller and
+   from your installed MCEC. (A shared dir is a trap: a GUI MCEC rewrites `mcec.settings` on exit.)
+2. **Subject config disables the server.** `ActAsServer=false` (its default is `true`). Otherwise the
+   subject binds a listening socket on `IPAddress.Any:5150`, which triggers the first-run **Windows
+   Defender Firewall** prompt — that prompt steals focus and derails the menu automation. Also
+   `DisableUpdatePopup=true`, and `WindowLocation`/`WindowSize` are **pinned** so the recorded region
+   is deterministic.
+3. **Controller config enables the agent surface.** The `--mcp` controller's co-located config sets
+   `AgentCommandsEnabled=true` and enables `capture`/`query`/`record`/`mouse` and the keystroke
+   commands in `mcec.commands`. (The `--mcp` controller has no `MainWindow`, so it never starts the
+   socket server and never prompts.)
+4. **Clean backdrop.** All desktop windows are minimized (`Shell.Application.MinimizeAll()`) before
+   recording, and the region is **cropped to the pinned window** (the About/Settings dialogs are
+   `CenterParent`, so they fall inside it) — so the hero is just the app, no wallpaper, and compact.
+5. **Record.** `record action:start` over the window region at a low fps, then drive the menus, then
+   `record action:stop file:docs/hero.gif`.
+
+## Manual MCP equivalent (no script)
+
+Connect to the controller (`mcec.exe --mcp`) and, after the subject is launched and its window is up:
+
+| Step | Tool call |
+|------|-----------|
+| Start | `record` `{ action:"start", x, y, width, height, fps:4, maxWidth:680 }` (region = the subject window) |
+| About | `query` the window → click the **Help** menu item's rect (`send_command` `mouse:mt,…` + `mouse:lbc`) → send `A` |
+| Settings | dismiss About (`Esc`) → click **File** → send `S` |
+| Exit | dismiss Settings (`Esc`) → click **File** → send `X` |
+| Stop | `record` `{ action:"stop", file:"docs/hero.gif" }` |
+
+## Tuning size
+
+The GIF encoder writes full (non-diffed) frames, so **file size ≈ frame count × frame area**. To
+shrink the hero, lower `fps`, lower `maxWidth`, or trim the per-dialog dwell `Start-Sleep`s in the
+script. The committed asset targets ≈4 MB at 680 px wide, 4 fps.
+</content>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # MCEC
 
-![MCEC](mainwindow.png)
+![MCEC](hero.gif)
 
 **MCEC** (Model Context Environment Controller) is eyes, hands, and a safe front door for agents on Windows — and the same battle-tested remote control for smart-home systems.
 

--- a/scripts/Generate-HeroGif.ps1
+++ b/scripts/Generate-HeroGif.ps1
@@ -1,0 +1,189 @@
+#requires -version 7
+<#
+.SYNOPSIS
+  Regenerates the MCEC hero GIF (docs/hero.gif): one MCEC instance drives another through
+  launch -> Help > About -> File > Settings -> File > Exit, recording it with the agent `record` tool.
+
+.DESCRIPTION
+  Dogfoods the #80 `record` feature. A headless controller (`mcec.exe --mcp`) runs from the repo
+  build dir; the *controlled* subject is a SEPARATE COPY of the build in its own directory so it reads
+  a co-located config (Program.ConfigPath == the exe's own folder). The subject's config sets
+  ActAsServer=false (so it never binds IPAddress.Any:5150 and never triggers the Windows Firewall
+  prompt that would steal focus) and pins the window location/size so the recorded region is
+  deterministic. All desktop windows are minimized first for a clean backdrop.
+
+  This drives the REAL desktop (mouse, keystrokes, launching an app) for ~20s. Run it on an
+  interactive session you can leave alone.
+
+.PARAMETER Config
+  Build configuration to use (Debug or Release). Default: Debug.
+#>
+[CmdletBinding()]
+param([ValidateSet('Debug', 'Release')][string]$Config = 'Debug')
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$ctrlDir = Join-Path $repoRoot "src\bin\$Config\net10.0-windows"
+$exe = Join-Path $ctrlDir 'mcec.exe'
+$outGif = Join-Path $repoRoot 'docs\hero.gif'
+$subjectDir = Join-Path $env:TEMP 'mcec-hero-subject'
+
+if (-not (Test-Path $exe)) {
+  Write-Host "Building ($Config)..."
+  dotnet build (Join-Path $repoRoot 'src\MCEControl.csproj') -c $Config | Out-Null
+}
+if (-not (Test-Path $exe)) { throw "mcec.exe not found at $exe" }
+
+Add-Type -Namespace Native -Name U32 -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("user32.dll")] public static extern int GetSystemMetrics(int n);
+[System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool SetProcessDPIAware();
+'@
+[Native.U32]::SetProcessDPIAware() | Out-Null
+$sw = [Native.U32]::GetSystemMetrics(0); $sh = [Native.U32]::GetSystemMetrics(1)
+
+# Pinned subject window geometry. The recorded region is exactly the window, so the hero is just the
+# app (the About/Settings dialogs center within it) on no wallpaper -> clean and compact.
+$winX = 130; $winY = 80; $winW = 900; $winH = 560
+$rx = $winX; $ry = $winY; $rw = $winW; $rh = $winH
+
+# ---- subject: a separate copy of the build with its own co-located config ----
+if (Test-Path $subjectDir) { Remove-Item $subjectDir -Recurse -Force }
+Copy-Item $ctrlDir $subjectDir -Recurse -Force
+$subjectExe = Join-Path $subjectDir 'mcec.exe'
+
+Set-Content -Encoding UTF8 -Path (Join-Path $subjectDir 'mcec.settings') -Value @"
+<?xml version="1.0" encoding="utf-8"?>
+<AppSettings>
+  <ActAsServer>false</ActAsServer>
+  <ActAsClient>false</ActAsClient>
+  <ActAsSerialServer>false</ActAsSerialServer>
+  <DisableUpdatePopup>true</DisableUpdatePopup>
+  <WindowLocation><X>$winX</X><Y>$winY</Y></WindowLocation>
+  <WindowSize><Width>$winW</Width><Height>$winH</Height></WindowSize>
+</AppSettings>
+"@
+
+# ---- controller: agent commands + the actions used to drive the subject ----
+$ctrlSettings = Join-Path $ctrlDir 'mcec.settings'
+$ctrlCommands = Join-Path $ctrlDir 'mcec.commands'
+$savedSettings = if (Test-Path $ctrlSettings) { Get-Content -Raw $ctrlSettings } else { $null }
+$savedCommands = if (Test-Path $ctrlCommands) { Get-Content -Raw $ctrlCommands } else { $null }
+
+Set-Content -Encoding UTF8 -Path $ctrlSettings -Value @'
+<?xml version="1.0" encoding="utf-8"?>
+<AppSettings>
+  <AgentCommandsEnabled>true</AgentCommandsEnabled>
+  <McpServerEnabled>false</McpServerEnabled>
+  <ActAsServer>false</ActAsServer>
+</AppSettings>
+'@
+
+Set-Content -Encoding UTF8 -Path $ctrlCommands -Value @'
+<?xml version="1.0" encoding="utf-8"?>
+<MCEController xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0.0">
+<Commands xmlns="http://www.kindel.com/products/mcecontroller">
+  <capture Cmd="capture" Enabled="true" />
+  <query   Cmd="query"   Enabled="true" />
+  <record  Cmd="record"  Enabled="true" />
+  <mouse   Cmd="mouse:"  Enabled="true" />
+  <sendinput Cmd="key_a" Vk="a" Enabled="true" />
+  <sendinput Cmd="key_s" Vk="s" Enabled="true" />
+  <sendinput Cmd="key_x" Vk="x" Enabled="true" />
+  <sendinput Cmd="key_esc" Vk="VK_ESCAPE" Enabled="true" />
+  <sendinput Cmd="enter" Vk="VK_RETURN" Enabled="true" />
+</Commands>
+</MCEController>
+'@
+
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = $exe; $psi.Arguments = '--mcp'; $psi.WorkingDirectory = $ctrlDir
+$psi.RedirectStandardInput = $true; $psi.RedirectStandardOutput = $true; $psi.RedirectStandardError = $true
+$psi.UseShellExecute = $false; $psi.StandardOutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$driver = [System.Diagnostics.Process]::Start($psi)
+$driver.BeginErrorReadLine()
+
+$script:id = 0
+function Rpc([string]$method, $prms) {
+  $script:id++
+  $req = @{ jsonrpc = '2.0'; id = $script:id; method = $method; params = $prms } | ConvertTo-Json -Depth 8 -Compress
+  $driver.StandardInput.WriteLine($req); $driver.StandardInput.Flush()
+  $line = $driver.StandardOutput.ReadLine()
+  if ($null -eq $line) { throw "no response for $method" }
+  return $line | ConvertFrom-Json
+}
+function Tool([string]$name, $toolArgs) { Rpc 'tools/call' @{ name = $name; arguments = $toolArgs } }
+function Cmd([string]$command) { Tool 'send_command' @{ command = $command } | Out-Null }
+function ClickAbs([int]$cx, [int]$cy) {
+  Cmd ("mouse:mt,{0},{1}" -f [int][math]::Round($cx * 65535.0 / ($sw - 1)), [int][math]::Round($cy * 65535.0 / ($sh - 1)))
+  Cmd 'mouse:lbc'
+}
+function Find($node, [scriptblock]$pred) {
+  if (& $pred $node) { return $node }
+  if ($node.children) { foreach ($c in $node.children) { $r = Find $c $pred; if ($r) { return $r } } }
+  return $null
+}
+function QueryTree([string]$window, [int]$depth = 5) {
+  foreach ($b in (Tool 'query' @{ window = $window; maxDepth = $depth }).result.content) {
+    if ($b.type -eq 'text') { try { return ($b.text | ConvertFrom-Json).data.tree } catch { return $null } }
+  }
+  return $null
+}
+
+try {
+  $init = Rpc 'initialize' @{}
+  Write-Host "controller: $($init.result.serverInfo.name) $($init.result.serverInfo.version)"
+
+  # Clean backdrop: minimize every window (controller console + this terminal included).
+  (New-Object -ComObject Shell.Application).MinimizeAll()
+  Start-Sleep -Milliseconds 800
+
+  # fps 4 + downscale to 680 keeps the hero compact (the encoder writes full frames, so frame
+  # count x width drive file size).
+  $rec = Tool 'record' @{ action = 'start'; x = $rx; y = $ry; width = $rw; height = $rh; fps = 4; maxWidth = 680 }
+  Write-Host "record start: $($rec.result.content[0].text)"
+  Start-Sleep -Milliseconds 500
+
+  $subject = Start-Process -FilePath $subjectExe -WorkingDirectory $subjectDir -PassThru
+  Write-Host "subject pid $($subject.Id)"
+
+  $tree = $null
+  for ($i = 0; $i -lt 25; $i++) { Start-Sleep -Milliseconds 600; $tree = QueryTree 'MCEC' 4; if ($tree) { break } }
+  if (-not $tree) { throw 'subject MCEC window never appeared' }
+  Write-Host 'subject window up'
+  Start-Sleep -Milliseconds 1200   # dwell on the freshly-started window
+  $tree = QueryTree 'MCEC' 5        # re-query so the menu bar is fully built before we locate it
+
+  $isMenu = { param($n) ($n.controlType -match 'MenuItem') }
+  $help = Find $tree { param($n) (& $isMenu $n) -and $n.name -eq 'Help' }
+  $file = Find $tree { param($n) (& $isMenu $n) -and $n.name -eq 'File' }
+  if (-not $help -or -not $file) { throw 'File/Help menu items not found' }
+
+  # Help > About
+  ClickAbs ([int]($help.x + $help.width / 2)) ([int]($help.y + $help.height / 2))
+  Start-Sleep -Milliseconds 600; Cmd 'key_a'; Start-Sleep -Milliseconds 1900
+  Cmd 'key_esc'; Start-Sleep -Milliseconds 1000
+
+  # File > Settings
+  ClickAbs ([int]($file.x + $file.width / 2)) ([int]($file.y + $file.height / 2))
+  Start-Sleep -Milliseconds 600; Cmd 'key_s'; Start-Sleep -Milliseconds 2100
+  Cmd 'key_esc'; Start-Sleep -Milliseconds 1000
+
+  # File > Exit
+  ClickAbs ([int]($file.x + $file.width / 2)) ([int]($file.y + $file.height / 2))
+  Start-Sleep -Milliseconds 600; Cmd 'key_x'; Start-Sleep -Milliseconds 1300
+  if (-not $subject.HasExited) { Cmd 'enter'; Start-Sleep -Milliseconds 1000 }
+
+  $stop = Tool 'record' @{ action = 'stop'; file = $outGif }
+  Write-Host "record stop: $($stop.result.content[0].text)"
+}
+finally {
+  try { $driver.StandardInput.Close() } catch {}
+  try { if (-not $driver.WaitForExit(3000)) { $driver.Kill($true) } } catch {}
+  $driver.Dispose()
+  foreach ($p in Get-Process -Name mcec -ErrorAction SilentlyContinue) { try { $p.Kill($true) } catch {} }
+  if ($null -ne $savedSettings) { Set-Content -Path $ctrlSettings -Value $savedSettings -Encoding UTF8 } else { Remove-Item $ctrlSettings -ErrorAction SilentlyContinue }
+  if ($null -ne $savedCommands) { Set-Content -Path $ctrlCommands -Value $savedCommands -Encoding UTF8 } else { Remove-Item $ctrlCommands -ErrorAction SilentlyContinue }
+  Remove-Item $subjectDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+Write-Host "Wrote $outGif"

--- a/src/Agent/GifEncoder.cs
+++ b/src/Agent/GifEncoder.cs
@@ -1,0 +1,216 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace MCEControl;
+
+/// <summary>
+/// Assembles a sequence of frames into a single animated GIF89a for the MCEC 3.0 agent "record"
+/// feature, with NO extra dependency. .NET's GDI+ GIF codec can quantize + LZW-compress one frame
+/// (<see cref="Image.Save(Stream, ImageFormat)"/>) but cannot author an animation (frame delays /
+/// looping). So we let GDI+ encode each frame to a standalone GIF, then stitch those together:
+/// a GIF89a header, a Netscape looping extension, and — per frame — a Graphic Control Extension
+/// carrying the inter-frame delay plus the frame's image data, with each frame's color table written
+/// as a Local Color Table so per-frame palettes survive.
+/// </summary>
+public static class GifEncoder {
+    /// <summary>
+    /// Encodes a single bitmap to standalone GIF bytes via GDI+ (quantizes to ≤256 colors and
+    /// LZW-compresses). This is the per-frame input to <see cref="Assemble"/>.
+    /// </summary>
+    public static byte[] EncodeFrame(Bitmap frame) {
+        ArgumentNullException.ThrowIfNull(frame);
+        using MemoryStream ms = new();
+        frame.Save(ms, ImageFormat.Gif);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Stitches the given standalone GIF frames (each produced by <see cref="EncodeFrame"/>) into one
+    /// animated GIF89a.
+    /// </summary>
+    /// <param name="gifFrames">Per-frame standalone GIF byte buffers, in order.</param>
+    /// <param name="delayMs">Delay between frames, in milliseconds (rounded to GIF centiseconds).</param>
+    /// <param name="loop">When true, the animation loops forever; otherwise it plays once.</param>
+    /// <returns>The animated GIF89a as a byte array.</returns>
+    /// <exception cref="ArgumentException">Thrown when there are no frames or a frame cannot be parsed.</exception>
+    public static byte[] Assemble(IReadOnlyList<byte[]> gifFrames, int delayMs, bool loop) {
+        ArgumentNullException.ThrowIfNull(gifFrames);
+        if (gifFrames.Count == 0) {
+            throw new ArgumentException("At least one frame is required.", nameof(gifFrames));
+        }
+
+        // GIF frame delay is expressed in centiseconds. Clamp to a minimum of 2 (20 ms): a 0 delay is
+        // interpreted by many viewers as "as fast as possible", which is not what an fps implies.
+        int delayCs = Math.Max(2, (int)Math.Round(delayMs / 10.0));
+
+        List<GifFrame> frames = [];
+        int width = 0;
+        int height = 0;
+        foreach (byte[] raw in gifFrames) {
+            GifFrame f = ParseFrame(raw);
+            frames.Add(f);
+            width = Math.Max(width, f.Width);
+            height = Math.Max(height, f.Height);
+        }
+
+        using MemoryStream output = new();
+
+        // --- Header + Logical Screen Descriptor (no Global Color Table; every frame carries its own
+        //     Local Color Table). ---
+        output.Write("GIF89a"u8);
+        WriteUInt16(output, (ushort)width);
+        WriteUInt16(output, (ushort)height);
+        output.WriteByte(0x00); // packed: no GCT
+        output.WriteByte(0x00); // background color index (unused without a GCT)
+        output.WriteByte(0x00); // pixel aspect ratio
+
+        // --- Netscape Application Extension: loop count (0 = forever). Omit it for play-once. ---
+        if (loop) {
+            output.WriteByte(0x21); // extension introducer
+            output.WriteByte(0xFF); // application extension label
+            output.WriteByte(0x0B); // block size (11)
+            output.Write("NETSCAPE2.0"u8);
+            output.WriteByte(0x03); // sub-block size
+            output.WriteByte(0x01); // sub-block id
+            WriteUInt16(output, 0); // loop count: 0 = infinite
+            output.WriteByte(0x00); // block terminator
+        }
+
+        // --- Per-frame: Graphic Control Extension (delay) + Image Descriptor + Local Color Table +
+        //     LZW image data. ---
+        foreach (GifFrame f in frames) {
+            output.WriteByte(0x21); // extension introducer
+            output.WriteByte(0xF9); // graphic control label
+            output.WriteByte(0x04); // block size (4)
+            output.WriteByte(0x04); // packed: disposal method 1 (do not dispose), no transparency
+            WriteUInt16(output, (ushort)delayCs);
+            output.WriteByte(0x00); // transparent color index (unused)
+            output.WriteByte(0x00); // block terminator
+
+            output.WriteByte(0x2C); // image separator
+            WriteUInt16(output, 0); // image left
+            WriteUInt16(output, 0); // image top
+            WriteUInt16(output, (ushort)f.Width);
+            WriteUInt16(output, (ushort)f.Height);
+            // packed: Local Color Table flag (0x80) | LCT size bits (N where table = 2^(N+1)).
+            output.WriteByte((byte)(0x80 | (f.ColorTableSizeBits & 0x07)));
+            output.Write(f.ColorTable, 0, f.ColorTable.Length);
+            output.Write(f.LzwData, 0, f.LzwData.Length); // min-code-size + sub-blocks + terminator
+        }
+
+        output.WriteByte(0x3B); // trailer
+        return output.ToArray();
+    }
+
+    /// <summary>
+    /// Parses one standalone GIF (as emitted by GDI+) far enough to extract the first image's
+    /// dimensions, color table, and LZW data block (min-code-size byte + data sub-blocks + the 0x00
+    /// terminator), so it can be re-emitted as one frame of an animation.
+    /// </summary>
+    private static GifFrame ParseFrame(byte[] b) {
+        if (b.Length < 13 || b[0] != (byte)'G' || b[1] != (byte)'I' || b[2] != (byte)'F') {
+            throw new ArgumentException("Not a GIF stream.");
+        }
+
+        // Logical Screen Descriptor packed byte at offset 10.
+        byte lsdPacked = b[10];
+        bool hasGct = (lsdPacked & 0x80) != 0;
+        int gctSizeBits = lsdPacked & 0x07;
+        int gctEntries = 1 << (gctSizeBits + 1);
+
+        int pos = 13;
+        byte[] globalTable = [];
+        if (hasGct) {
+            int len = 3 * gctEntries;
+            globalTable = Slice(b, pos, len);
+            pos += len;
+        }
+
+        // Walk blocks until the first Image Descriptor (skip any extensions GDI+ might emit).
+        while (pos < b.Length) {
+            byte sep = b[pos];
+            if (sep == 0x21) { // extension: introducer + label + sub-blocks
+                pos += 2;
+                pos = SkipSubBlocks(b, pos);
+            }
+            else if (sep == 0x2C) { // image descriptor (10 bytes incl. separator)
+                int w = b[pos + 5] | (b[pos + 6] << 8);
+                int h = b[pos + 7] | (b[pos + 8] << 8);
+                byte imgPacked = b[pos + 9];
+                pos += 10;
+
+                bool hasLct = (imgPacked & 0x80) != 0;
+                int lctSizeBits = imgPacked & 0x07;
+                byte[] colorTable;
+                int colorTableSizeBits;
+                if (hasLct) {
+                    int len = 3 * (1 << (lctSizeBits + 1));
+                    colorTable = Slice(b, pos, len);
+                    colorTableSizeBits = lctSizeBits;
+                    pos += len;
+                }
+                else {
+                    // GDI+ normally writes a Global Color Table and no LCT; reuse the GCT as this
+                    // frame's local table in the animation.
+                    colorTable = globalTable;
+                    colorTableSizeBits = gctSizeBits;
+                }
+
+                int lzwStart = pos;
+                pos++; // LZW minimum code size byte
+                pos = SkipSubBlocks(b, pos); // advances past data sub-blocks and the 0x00 terminator
+                byte[] lzw = Slice(b, lzwStart, pos - lzwStart);
+
+                return new GifFrame {
+                    Width = w,
+                    Height = h,
+                    ColorTable = colorTable,
+                    ColorTableSizeBits = colorTableSizeBits,
+                    LzwData = lzw,
+                };
+            }
+            else {
+                // Trailer (0x3B) or anything unexpected before an image: no image found.
+                break;
+            }
+        }
+
+        throw new ArgumentException("GIF frame has no image data.");
+    }
+
+    /// <summary>
+    /// Advances past a chain of GIF data sub-blocks starting at <paramref name="pos"/>, returning the
+    /// index just after the 0x00 block terminator.
+    /// </summary>
+    private static int SkipSubBlocks(byte[] b, int pos) {
+        while (pos < b.Length) {
+            int size = b[pos];
+            pos++;
+            if (size == 0) {
+                return pos; // terminator consumed
+            }
+            pos += size;
+        }
+        return pos;
+    }
+
+    private static byte[] Slice(byte[] src, int start, int length) {
+        if (start < 0 || length < 0 || start + length > src.Length) {
+            throw new ArgumentException("Malformed GIF: block extends past end of stream.");
+        }
+        byte[] dst = new byte[length];
+        Array.Copy(src, start, dst, 0, length);
+        return dst;
+    }
+
+    private static void WriteUInt16(Stream s, ushort value) {
+        s.WriteByte((byte)(value & 0xFF));
+        s.WriteByte((byte)((value >> 8) & 0xFF));
+    }
+}

--- a/src/Agent/GifFrame.cs
+++ b/src/Agent/GifFrame.cs
@@ -1,0 +1,17 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// A standalone GIF frame parsed by <see cref="GifEncoder"/>: its dimensions, color table, and raw
+/// LZW image-data block (the min-code-size byte + data sub-blocks + terminator), ready to be
+/// re-emitted as one frame of an animation.
+/// </summary>
+internal sealed class GifFrame {
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public byte[] ColorTable { get; init; } = [];
+    public int ColorTableSizeBits { get; init; }
+    public byte[] LzwData { get; init; } = [];
+}

--- a/src/Agent/GifRecorder.cs
+++ b/src/Agent/GifRecorder.cs
@@ -1,0 +1,210 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Text.Json.Nodes;
+using System.Threading;
+
+namespace MCEControl;
+
+/// <summary>
+/// Drives a GIF recording for the MCEC 3.0 agent <c>record</c> feature: a background thread grabs
+/// frames from a target (window or screen region) at a fixed fps, each frame is immediately encoded
+/// to a standalone GIF (keeping memory bounded — we never hold hundreds of raw bitmaps), and
+/// <see cref="Stop"/> stitches them into one animation via <see cref="GifEncoder"/>.
+///
+/// SECURITY/SAFETY: at most one recording runs at a time (a static singleton). The capture loop is
+/// hard-bounded by fps, max frames, max duration, and a max width (frames are downscaled) so an agent
+/// cannot create an unbounded file. The owning <see cref="RecordCommand"/> applies the security gate
+/// and audit; this type is the mechanism only.
+/// </summary>
+public sealed class GifRecorder {
+    private static readonly object Gate = new();
+    private static GifRecorder? _active;
+
+    private readonly Func<Bitmap> _grab;
+    private readonly int _fps;
+    private readonly int _maxFrames;
+    private readonly int _maxWidth;
+    private readonly long _maxDurationMs;
+    private readonly JsonNode? _target;
+    private readonly List<byte[]> _frames = [];
+    private readonly Stopwatch _clock = new();
+
+    private Thread? _thread;
+    private volatile bool _stopRequested;
+    private int _width;
+    private int _height;
+    private string? _error;
+
+    private GifRecorder(Func<Bitmap> grab, int fps, int maxFrames, int maxWidth, long maxDurationMs, JsonNode? target) {
+        _grab = grab;
+        _fps = fps;
+        _maxFrames = maxFrames;
+        _maxWidth = maxWidth;
+        _maxDurationMs = maxDurationMs;
+        _target = target;
+    }
+
+    /// <summary>True while a recording is in progress.</summary>
+    public static bool IsRecording {
+        get { lock (Gate) { return _active is not null; } }
+    }
+
+    /// <summary>The effective fps of the in-progress recording, or 0 when idle.</summary>
+    public static int ActiveFps {
+        get { lock (Gate) { return _active?._fps ?? 0; } }
+    }
+
+    /// <summary>The target descriptor of the in-progress recording, or null when idle.</summary>
+    public static JsonNode? ActiveTarget {
+        get { lock (Gate) { return _active?._target?.DeepClone(); } }
+    }
+
+    /// <summary>
+    /// Starts a recording. <paramref name="grab"/> is invoked once per frame and must return a fresh
+    /// bitmap the recorder will dispose. The caller has already clamped fps/limits to operator policy.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when a recording is already in progress.</exception>
+    public static void Start(Func<Bitmap> grab, int fps, int maxFrames, int maxWidth, long maxDurationMs, JsonNode? target) {
+        ArgumentNullException.ThrowIfNull(grab);
+        lock (Gate) {
+            if (_active is not null) {
+                throw new InvalidOperationException("A recording is already in progress.");
+            }
+            GifRecorder recorder = new(grab, Math.Max(1, fps), Math.Max(1, maxFrames), Math.Max(1, maxWidth), Math.Max(1, maxDurationMs), target);
+            recorder._thread = new Thread(recorder.CaptureLoop) {
+                IsBackground = true,
+                Name = "mcec-gif-recorder",
+            };
+            _active = recorder;
+            recorder._clock.Start();
+            recorder._thread.Start();
+        }
+    }
+
+    /// <summary>
+    /// Stops the in-progress recording, waits for the capture thread to drain, assembles the GIF, and
+    /// returns the result. Returns null when no recording is active.
+    /// </summary>
+    public static RecordingResult? Stop(bool loop = true) {
+        GifRecorder? recorder;
+        lock (Gate) {
+            recorder = _active;
+            _active = null;
+        }
+        if (recorder is null) {
+            return null;
+        }
+
+        recorder._stopRequested = true;
+        recorder._thread?.Join();
+        recorder._clock.Stop();
+
+        long durationMs = recorder._clock.ElapsedMilliseconds;
+        if (recorder._frames.Count == 0) {
+            return new RecordingResult {
+                Frames = 0,
+                Fps = recorder._fps,
+                DurationMs = durationMs,
+                Target = recorder._target,
+                Error = recorder._error ?? "No frames were captured.",
+            };
+        }
+
+        byte[] gif;
+        try {
+            gif = GifEncoder.Assemble(recorder._frames, 1000 / recorder._fps, loop);
+        }
+        catch (Exception e) {
+            return new RecordingResult {
+                Frames = recorder._frames.Count,
+                Fps = recorder._fps,
+                DurationMs = durationMs,
+                Target = recorder._target,
+                Error = $"GIF assembly failed: {e.Message}",
+            };
+        }
+
+        return new RecordingResult {
+            Gif = gif,
+            Frames = recorder._frames.Count,
+            Width = recorder._width,
+            Height = recorder._height,
+            Fps = recorder._fps,
+            DurationMs = durationMs,
+            Target = recorder._target,
+            Error = recorder._error, // a soft error (e.g. a dropped frame) is reported but the GIF still returns
+        };
+    }
+
+    /// <summary>Background capture loop: grab → downscale → encode, paced to fps, until stop or a limit.</summary>
+    private void CaptureLoop() {
+        double frameIntervalMs = 1000.0 / _fps;
+        while (!_stopRequested) {
+            long frameStart = _clock.ElapsedMilliseconds;
+
+            try {
+                using Bitmap raw = _grab();
+                Bitmap? scaled = null;
+                try {
+                    Bitmap toEncode = raw;
+                    if (_maxWidth > 0 && raw.Width > _maxWidth) {
+                        scaled = Downscale(raw, _maxWidth);
+                        toEncode = scaled;
+                    }
+                    _width = Math.Max(_width, toEncode.Width);
+                    _height = Math.Max(_height, toEncode.Height);
+                    _frames.Add(GifEncoder.EncodeFrame(toEncode));
+                }
+                finally {
+                    scaled?.Dispose();
+                }
+            }
+            catch (Exception e) {
+                // The target may have closed mid-record. Record the reason and stop; any frames so far
+                // are still assembled into a (shorter) GIF.
+                _error = e.Message;
+                break;
+            }
+
+            if (_frames.Count >= _maxFrames) {
+                break;
+            }
+            if (_clock.ElapsedMilliseconds >= _maxDurationMs) {
+                break;
+            }
+
+            // Pace to fps, but wake often enough to honor a stop request promptly.
+            long spent = _clock.ElapsedMilliseconds - frameStart;
+            int remaining = (int)(frameIntervalMs - spent);
+            while (remaining > 0 && !_stopRequested && _clock.ElapsedMilliseconds < _maxDurationMs) {
+                int slice = Math.Min(remaining, 50);
+                Thread.Sleep(slice);
+                remaining -= slice;
+            }
+        }
+    }
+
+    /// <summary>Scales a bitmap down so its width is <paramref name="maxWidth"/>, preserving aspect.</summary>
+    private static Bitmap Downscale(Bitmap src, int maxWidth) {
+        int newWidth = maxWidth;
+        int newHeight = Math.Max(1, (int)Math.Round(src.Height * (maxWidth / (double)src.Width)));
+        Bitmap dst = new(newWidth, newHeight);
+        try {
+            using Graphics g = Graphics.FromImage(dst);
+            g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+            g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+            g.DrawImage(src, 0, 0, newWidth, newHeight);
+        }
+        catch {
+            dst.Dispose();
+            throw;
+        }
+        return dst;
+    }
+}

--- a/src/Agent/RecordingResult.cs
+++ b/src/Agent/RecordingResult.cs
@@ -1,0 +1,37 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// The outcome of a finished GIF recording: the encoded animation plus the metadata an agent needs
+/// (frame count, dimensions, duration). Returned by <see cref="GifRecorder.Stop"/> and surfaced in
+/// the <c>record</c> command's structured result.
+/// </summary>
+public sealed class RecordingResult {
+    /// <summary>The assembled animated GIF89a bytes (empty when <see cref="Error"/> is set).</summary>
+    public byte[] Gif { get; init; } = [];
+
+    /// <summary>Number of frames captured.</summary>
+    public int Frames { get; init; }
+
+    /// <summary>Width of the animation in pixels (largest frame).</summary>
+    public int Width { get; init; }
+
+    /// <summary>Height of the animation in pixels (largest frame).</summary>
+    public int Height { get; init; }
+
+    /// <summary>The effective (clamped) frames-per-second the recording targeted.</summary>
+    public int Fps { get; init; }
+
+    /// <summary>Wall-clock duration of the capture loop, in milliseconds.</summary>
+    public long DurationMs { get; init; }
+
+    /// <summary>Descriptor of the recorded target (window metadata or region), for the result/audit.</summary>
+    public JsonNode? Target { get; init; }
+
+    /// <summary>Non-null when the recording failed (e.g. the target window disappeared mid-record).</summary>
+    public string? Error { get; init; }
+}

--- a/src/Agent/ScreenCapture.cs
+++ b/src/Agent/ScreenCapture.cs
@@ -24,6 +24,22 @@ public static class ScreenCapture {
     /// <returns>PNG-encoded image bytes.</returns>
     /// <exception cref="ArgumentException">Thrown when the window has no on-screen area.</exception>
     public static byte[] CaptureWindow(IntPtr hwnd) {
+        using Bitmap bmp = CaptureWindowBitmap(hwnd);
+        using MemoryStream ms = new();
+        bmp.Save(ms, ImageFormat.Png);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Captures a top-level window by handle into a <see cref="Bitmap"/> the caller owns (and must
+    /// dispose). Shared by <see cref="CaptureWindow"/> (still PNG) and the GIF recorder, which needs
+    /// the raw bitmap to feed many frames into one animation. Uses
+    /// <c>PrintWindow(PW_RENDERFULLCONTENT)</c>, falling back to an on-screen blit if that fails.
+    /// </summary>
+    /// <param name="hwnd">The window handle to capture.</param>
+    /// <returns>A new ARGB bitmap of the window; the caller owns and must dispose it.</returns>
+    /// <exception cref="ArgumentException">Thrown when the window has no on-screen area.</exception>
+    public static Bitmap CaptureWindowBitmap(IntPtr hwnd) {
         if (!AgentNativeMethods.GetWindowRect(hwnd, out NativeRect rect)) {
             throw new ArgumentException("Could not get window bounds.", nameof(hwnd));
         }
@@ -34,21 +50,24 @@ public static class ScreenCapture {
             throw new ArgumentException("Window has no on-screen area to capture.", nameof(hwnd));
         }
 
-        using Bitmap bmp = new(width, height, PixelFormat.Format32bppArgb);
-        using Graphics gfx = Graphics.FromImage(bmp);
+        Bitmap bmp = new(width, height, PixelFormat.Format32bppArgb);
+        try {
+            using Graphics gfx = Graphics.FromImage(bmp);
 
-        IntPtr hdc = gfx.GetHdc();
-        bool ok = AgentNativeMethods.PrintWindow(hwnd, hdc, AgentNativeMethods.PW_RENDERFULLCONTENT);
-        gfx.ReleaseHdc(hdc);
+            IntPtr hdc = gfx.GetHdc();
+            bool ok = AgentNativeMethods.PrintWindow(hwnd, hdc, AgentNativeMethods.PW_RENDERFULLCONTENT);
+            gfx.ReleaseHdc(hdc);
 
-        if (!ok) {
-            // Fallback: blit the corresponding screen region into the same bitmap.
-            gfx.CopyFromScreen(rect.Left, rect.Top, 0, 0, new Size(width, height));
+            if (!ok) {
+                // Fallback: blit the corresponding screen region into the same bitmap.
+                gfx.CopyFromScreen(rect.Left, rect.Top, 0, 0, new Size(width, height));
+            }
         }
-
-        using MemoryStream ms = new();
-        bmp.Save(ms, ImageFormat.Png);
-        return ms.ToArray();
+        catch {
+            bmp.Dispose();
+            throw;
+        }
+        return bmp;
     }
 
     /// <summary>
@@ -61,16 +80,36 @@ public static class ScreenCapture {
     /// <returns>PNG-encoded image bytes.</returns>
     /// <exception cref="ArgumentException">Thrown when the region has no area.</exception>
     public static byte[] CaptureRegion(int x, int y, int width, int height) {
+        using Bitmap bmp = CaptureRegionBitmap(x, y, width, height);
+        using MemoryStream ms = new();
+        bmp.Save(ms, ImageFormat.Png);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Captures an arbitrary screen region (screen coordinates) into a <see cref="Bitmap"/> the caller
+    /// owns (and must dispose). Shared by <see cref="CaptureRegion"/> and the GIF recorder.
+    /// </summary>
+    /// <param name="x">Left screen coordinate.</param>
+    /// <param name="y">Top screen coordinate.</param>
+    /// <param name="width">Region width in pixels.</param>
+    /// <param name="height">Region height in pixels.</param>
+    /// <returns>A new ARGB bitmap of the region; the caller owns and must dispose it.</returns>
+    /// <exception cref="ArgumentException">Thrown when the region has no area.</exception>
+    public static Bitmap CaptureRegionBitmap(int x, int y, int width, int height) {
         if (width <= 0 || height <= 0) {
             throw new ArgumentException("Region has no area to capture.", nameof(width));
         }
 
-        using Bitmap bmp = new(width, height, PixelFormat.Format32bppArgb);
-        using Graphics gfx = Graphics.FromImage(bmp);
-        gfx.CopyFromScreen(x, y, 0, 0, new Size(width, height));
-
-        using MemoryStream ms = new();
-        bmp.Save(ms, ImageFormat.Png);
-        return ms.ToArray();
+        Bitmap bmp = new(width, height, PixelFormat.Format32bppArgb);
+        try {
+            using Graphics gfx = Graphics.FromImage(bmp);
+            gfx.CopyFromScreen(x, y, 0, 0, new Size(width, height));
+        }
+        catch {
+            bmp.Dispose();
+            throw;
+        }
+        return bmp;
     }
 }

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -47,6 +47,7 @@ public abstract class Command : ICommand {
     [XmlElement("query", typeof(QueryCommand))]
     [XmlElement("find", typeof(FindCommand))]
     [XmlElement("invoke", typeof(InvokeCommand))]
+    [XmlElement("record", typeof(RecordCommand))]
     [XmlElement(typeof(Command))]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Serializable")]
     public List<Command> EmbeddedCommands { get; set; } = null!;

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -1,0 +1,262 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Xml.Serialization;
+
+namespace MCEControl;
+
+/// <summary>
+/// MCEC 3.0 agent <c>record</c> command: captures agent-driven desktop activity to an animated GIF —
+/// a whole short segment via explicit <c>start</c>/<c>stop</c>, or a bounded one-shot via
+/// <c>durationMs</c>. Reuses the same target model as <see cref="CaptureCommand"/> (window by
+/// handle/title/process/class/foreground, or an explicit region) and the same security gate.
+///
+/// SECURITY: gated behind <see cref="AgentRuntime.AgentCommandsEnabled"/> (a separate opt-in from
+/// actuation) and the per-command <c>Enabled</c> flag; every start/stop/write is audited via
+/// <see cref="AgentRuntime.Audit"/>. The capture loop is hard-bounded (fps/duration/frames/width) by
+/// the operator's <see cref="AppSettings"/> limits so an agent cannot create an unbounded file.
+///
+/// PRIVACY: a recording captures whatever is on screen for its whole duration — louder than a single
+/// still <c>capture</c>. See <c>docs/agent-server.md</c>.
+/// </summary>
+public class RecordCommand : Command {
+    [XmlAttribute("action")] public string Action { get; set; } = null!;
+    [XmlAttribute("window")] public string Window { get; set; } = null!;
+    [XmlAttribute("handle")] public long Handle { get; set; }
+    [XmlAttribute("process")] public string Process { get; set; } = null!;
+    [XmlAttribute("className")] public string ClassName { get; set; } = null!;
+    [XmlAttribute("foreground")] public bool Foreground { get; set; }
+    [XmlAttribute("x")] public int X { get; set; }
+    [XmlAttribute("y")] public int Y { get; set; }
+    [XmlAttribute("width")] public int Width { get; set; }
+    [XmlAttribute("height")] public int Height { get; set; }
+    [XmlAttribute("fps")] public int Fps { get; set; }
+    [XmlAttribute("durationMs")] public int DurationMs { get; set; }
+    [XmlAttribute("maxWidth")] public int MaxWidth { get; set; }
+    [XmlAttribute("file")] public string File { get; set; } = null!;
+
+    private const int DefaultFps = 5;
+
+    public static new List<Command> BuiltInCommands {
+        get => [new RecordCommand { Cmd = "record" }];
+    }
+
+    public RecordCommand() { }
+
+    public override ICommand Clone(Reply reply) => base.Clone(reply, new RecordCommand {
+        Action = Action,
+        Window = Window,
+        Handle = Handle,
+        Process = Process,
+        ClassName = ClassName,
+        Foreground = Foreground,
+        X = X,
+        Y = Y,
+        Width = Width,
+        Height = Height,
+        Fps = Fps,
+        DurationMs = DurationMs,
+        MaxWidth = MaxWidth,
+        File = File,
+    });
+
+    // ICommand:Execute
+    public override bool Execute() {
+        if (!base.Execute()) {
+            return false;
+        }
+
+        if (!AgentRuntime.AgentCommandsEnabled) {
+            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
+            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
+            return false;
+        }
+
+        // Default the action: `oneshot` when a duration is given, else `start`.
+        string action = string.IsNullOrWhiteSpace(Action)
+            ? (DurationMs > 0 ? "oneshot" : "start")
+            : Action.Trim().ToLowerInvariant();
+
+        try {
+            return action switch {
+                "stop" => DoStop(),
+                "start" => DoStart(oneshot: false),
+                "oneshot" => DoStart(oneshot: true),
+                _ => FailWith($"Unknown record action '{action}'. Use start, stop, or oneshot."),
+            };
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Error($"{GetType().Name}: record failed: {e.Message}");
+            Reply?.WriteLine(CommandResult.Fail(Cmd, $"Record failed: {e.Message}").ToJson());
+            return false;
+        }
+    }
+
+    /// <summary>Starts a recording; for a one-shot, also waits the duration and stops/encodes/writes.</summary>
+    private bool DoStart(bool oneshot) {
+        if (GifRecorder.IsRecording) {
+            return FailWith("A recording is already in progress. Stop it first (action=stop).");
+        }
+
+        RecordLimits limits = ResolveLimits(oneshot);
+
+        Func<Bitmap>? grab = BuildGrabber(out JsonNode? target, out string? error);
+        if (grab is null) {
+            AgentRuntime.Audit(Cmd, error ?? "no matching window");
+            return FailWith(error ?? "No matching window");
+        }
+
+        AgentRuntime.Audit(Cmd, $"start {DescribeTarget(target)} fps={limits.Fps} oneshot={oneshot} durationMs={(oneshot ? limits.LoopDurationMs : 0)}");
+        GifRecorder.Start(grab, limits.Fps, limits.MaxFrames, limits.MaxWidth, limits.LoopDurationMs, target);
+
+        if (!oneshot) {
+            JsonObject data = new() {
+                ["recording"] = true,
+                ["fps"] = limits.Fps,
+                ["maxDurationMs"] = limits.LoopDurationMs,
+                ["target"] = target?.DeepClone(),
+            };
+            Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
+            return true;
+        }
+
+        // One-shot: wait for the bounded loop to finish (it auto-stops at loopDurationMs), with a small
+        // grace so the final frame is captured, then stop + encode + write.
+        Thread.Sleep((int)Math.Min(limits.LoopDurationMs, int.MaxValue) + 200);
+        return DoStop();
+    }
+
+    /// <summary>Resolves and clamps fps/duration/frames/width against the operator's policy, auditing clamps.</summary>
+    private RecordLimits ResolveLimits(bool oneshot) {
+        AppSettings? settings = AgentRuntime.Settings;
+        int maxFps = settings?.AgentRecordMaxFps > 0 ? settings.AgentRecordMaxFps : 30;
+        int maxDurationMs = settings?.AgentRecordMaxDurationMs > 0 ? settings.AgentRecordMaxDurationMs : 60000;
+        int maxFrames = settings?.AgentRecordMaxFrames > 0 ? settings.AgentRecordMaxFrames : 600;
+        int settingsMaxWidth = settings?.AgentRecordMaxWidth > 0 ? settings.AgentRecordMaxWidth : 1280;
+
+        if (Fps > maxFps) {
+            AgentRuntime.Audit(Cmd, $"fps {Fps} clamped to limit {maxFps}");
+        }
+        if (oneshot && DurationMs > maxDurationMs) {
+            AgentRuntime.Audit(Cmd, $"durationMs {DurationMs} clamped to limit {maxDurationMs}");
+        }
+
+        // For a one-shot the requested duration bounds the loop; for an open start the operator's max
+        // duration is the safety auto-stop.
+        long loopDurationMs = oneshot
+            ? Clamp(DurationMs > 0 ? DurationMs : maxDurationMs, 1, maxDurationMs)
+            : maxDurationMs;
+
+        return new RecordLimits {
+            Fps = Clamp(Fps > 0 ? Fps : DefaultFps, 1, maxFps),
+            MaxFrames = maxFrames,
+            MaxWidth = Clamp(MaxWidth > 0 ? MaxWidth : settingsMaxWidth, 1, settingsMaxWidth),
+            LoopDurationMs = loopDurationMs,
+        };
+    }
+
+    /// <summary>
+    /// Builds the per-frame grabber for the requested target (explicit region, else resolved window).
+    /// Returns null with <paramref name="error"/> set when no window matches.
+    /// </summary>
+    private Func<Bitmap>? BuildGrabber(out JsonNode? target, out string? error) {
+        error = null;
+        bool hasWindowTarget = !string.IsNullOrEmpty(Window)
+            || Handle > 0
+            || !string.IsNullOrEmpty(Process)
+            || !string.IsNullOrEmpty(ClassName)
+            || Foreground;
+
+        if (Width > 0 && Height > 0 && !hasWindowTarget) {
+            int rx = X, ry = Y, rw = Width, rh = Height;
+            target = new JsonObject {
+                ["type"] = "region",
+                ["x"] = rx,
+                ["y"] = ry,
+                ["width"] = rw,
+                ["height"] = rh,
+            };
+            return () => ScreenCapture.CaptureRegionBitmap(rx, ry, rw, rh);
+        }
+
+        WindowInfo? win = WindowResolver.Resolve(
+            Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
+        if (win is null) {
+            target = null;
+            error = "No matching window";
+            return null;
+        }
+        IntPtr hwnd = new(win.Handle);
+        target = win.ToJsonObject();
+        return () => ScreenCapture.CaptureWindowBitmap(hwnd);
+    }
+
+    private static string DescribeTarget(JsonNode? target) {
+        if (target is not JsonObject obj) {
+            return "target";
+        }
+        if (obj["type"]?.GetValue<string>() == "region") {
+            return $"region ({obj["x"]},{obj["y"]}) {obj["width"]}x{obj["height"]}";
+        }
+        return $"window 0x{obj["handle"]?.GetValue<long>():X} \"{obj["title"]?.GetValue<string>()}\" ({obj["processName"]?.GetValue<string>()})";
+    }
+
+    /// <summary>Stops the active recording, encodes the GIF, writes it to disk, and replies metadata.</summary>
+    private bool DoStop() {
+        RecordingResult? result = GifRecorder.Stop();
+        if (result is null) {
+            return FailWith("No recording is in progress.");
+        }
+
+        if (result.Frames == 0 || result.Gif.Length == 0) {
+            AgentRuntime.Audit(Cmd, $"stop — no output ({result.Error})");
+            return FailWith(result.Error ?? "Recording produced no frames.");
+        }
+
+        string path = string.IsNullOrEmpty(File)
+            ? Path.Combine(Path.GetTempPath(), $"mcec-rec-{DateTime.Now:yyyyMMdd-HHmmss}.gif")
+            : File;
+
+        JsonObject data = new() {
+            ["frames"] = result.Frames,
+            ["durationMs"] = result.DurationMs,
+            ["fps"] = result.Fps,
+            ["width"] = result.Width,
+            ["height"] = result.Height,
+            ["bytes"] = result.Gif.Length,
+            ["target"] = result.Target?.DeepClone(),
+        };
+        if (result.Error is not null) {
+            data["warning"] = result.Error;
+        }
+
+        try {
+            System.IO.File.WriteAllBytes(path, result.Gif);
+            data["file"] = path;
+            AgentRuntime.Audit(Cmd, $"stop — wrote {result.Frames} frames, {result.Gif.Length} bytes, {result.Width}x{result.Height} to {path}");
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException) {
+            Logger.Instance.Log4.Error($"{GetType().Name}: could not write GIF to '{path}': {e.Message}");
+            data["fileError"] = e.Message;
+            AgentRuntime.Audit(Cmd, $"stop — encode ok but write failed: {e.Message}");
+        }
+
+        Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
+        return true;
+    }
+
+    private bool FailWith(string error) {
+        Reply?.WriteLine(CommandResult.Fail(Cmd, error).ToJson());
+        return false;
+    }
+
+    private static int Clamp(int value, int min, int max) => Math.Max(min, Math.Min(max, value));
+
+    private static long Clamp(long value, long min, long max) => Math.Max(min, Math.Min(max, value));
+}

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -238,15 +238,17 @@ public class RecordCommand : Command {
 
         try {
             System.IO.File.WriteAllBytes(path, result.Gif);
-            data["file"] = path;
-            AgentRuntime.Audit(Cmd, $"stop — wrote {result.Frames} frames, {result.Gif.Length} bytes, {result.Width}x{result.Height} to {path}");
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException) {
+            // Unlike `capture`, `record` does not return the bytes inline, so a failed write means there
+            // is no usable output — report failure rather than success-with-fileError.
             Logger.Instance.Log4.Error($"{GetType().Name}: could not write GIF to '{path}': {e.Message}");
-            data["fileError"] = e.Message;
-            AgentRuntime.Audit(Cmd, $"stop — encode ok but write failed: {e.Message}");
+            AgentRuntime.Audit(Cmd, $"stop — encode ok ({result.Frames} frames) but write failed: {e.Message}");
+            return FailWith($"Recorded {result.Frames} frames but could not write GIF to '{path}': {e.Message}");
         }
 
+        data["file"] = path;
+        AgentRuntime.Audit(Cmd, $"stop — wrote {result.Frames} frames, {result.Gif.Length} bytes, {result.Width}x{result.Height} to {path}");
         Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
         return true;
     }

--- a/src/Commands/RecordLimits.cs
+++ b/src/Commands/RecordLimits.cs
@@ -1,0 +1,15 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// The clamped, effective recording parameters <see cref="RecordCommand"/> hands to
+/// <see cref="GifRecorder"/> after applying the operator's <see cref="AppSettings"/> limits.
+/// </summary>
+internal sealed class RecordLimits {
+    public int Fps { get; init; }
+    public int MaxFrames { get; init; }
+    public int MaxWidth { get; init; }
+    public long LoopDurationMs { get; init; }
+}

--- a/src/Commands/SerializedCommands.cs
+++ b/src/Commands/SerializedCommands.cs
@@ -49,6 +49,7 @@ public class SerializedCommands {
     [XmlArrayItem("query", typeof(QueryCommand))]
     [XmlArrayItem("find", typeof(FindCommand))]
     [XmlArrayItem("invoke", typeof(InvokeCommand))]
+    [XmlArrayItem("record", typeof(RecordCommand))]
     [XmlArrayItem(typeof(Command))]
 
     // XmlSerialization does not work with List<>. Must use an array.

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -103,7 +103,12 @@ public static class AgentServer {
         "untitled popups are not enumerated by title/process — target them by handle or `foreground:true`.\n" +
         "2. OBSERVE: `query` dumps the UI Automation tree (controlType, name, automationId, bounds, " +
         "state, value) so you can pick a control instead of guessing pixels; `capture` returns a PNG " +
-        "of the window (works on composited WinUI/WPF surfaces).\n" +
+        "of the window (works on composited WinUI/WPF surfaces). Use `capture` for a single state " +
+        "check; use `record` ONLY to show CHANGE over time — an animated GIF of a sequence, or a repro " +
+        "of a transient/flicker. `record` either runs as a bounded one-shot (`durationMs`) or as " +
+        "`action:start` then `action:stop`; keep recordings short — fps/duration are capped and frames " +
+        "are downscaled so the file stays bounded. It captures whatever is on screen for the whole " +
+        "duration, so prefer a still `capture` when one frame answers the question.\n" +
         "3. ACT: prefer `invoke` (by name/automationId/classname; action invoke|toggle|setvalue|setfocus|" +
         "expand|collapse) over coordinate clicks — it is far more reliable. To click a menu item, first " +
         "`invoke` its parent menu with action `expand` (a closed menu's sub-items are not in the tree " +
@@ -114,7 +119,7 @@ public static class AgentServer {
         "control to appear before acting. " +
         "`send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
         "4. VERIFY with another `query` or `capture` — always confirm the act had the intended effect.\n" +
-        "SECURITY: observation tools (capture/query/find/invoke) only work when the operator has set " +
+        "SECURITY: observation tools (capture/query/find/invoke/record) only work when the operator has set " +
         "AgentCommandsEnabled=true; otherwise they return an error — surface that to the user rather " +
         "than retrying. Every action is audit-logged on the host.";
 
@@ -177,6 +182,20 @@ public static class AgentServer {
             "Drive a UI Automation element (Invoke/Toggle/Value/SetFocus) — more reliable than coordinate clicks.",
             invokeProps, ["value"]));
 
+        JsonObject recordProps = WindowTargetProps();
+        recordProps["x"] = PropSchema("integer", "Region left (use with width/height instead of a window)");
+        recordProps["y"] = PropSchema("integer", "Region top");
+        recordProps["width"] = PropSchema("integer", "Region width");
+        recordProps["height"] = PropSchema("integer", "Region height");
+        recordProps["action"] = PropSchema("string", "start | stop | oneshot (default: oneshot if durationMs given, else start)");
+        recordProps["fps"] = PropSchema("integer", "Frames per second (default 5, clamped to the operator limit)");
+        recordProps["durationMs"] = PropSchema("integer", "For a one-shot: how long to record (clamped to the operator limit)");
+        recordProps["maxWidth"] = PropSchema("integer", "Downscale frames so width fits this (default 1280)");
+        recordProps["file"] = PropSchema("string", "Output .gif path (a temp path is generated if omitted)");
+        tools.Add(Tool("record",
+            "Record a window or region to an animated GIF over time (start/stop or a bounded one-shot). Use only to show CHANGE over time; for a single state check use capture.",
+            recordProps, []));
+
         tools.Add(Tool("send_command",
             "Send any raw MCEC command string to the existing command core (e.g. actuation commands).",
             new JsonObject { ["command"] = PropSchema("string", "The MCEC command string to enqueue") },
@@ -207,7 +226,7 @@ public static class AgentServer {
             return RunSendCommand(args);
         }
 
-        if (name is "capture" or "query" or "find" or "wait-for" or "invoke") {
+        if (name is "capture" or "query" or "find" or "wait-for" or "invoke" or "record") {
             if (!AgentRuntime.AgentCommandsEnabled) {
                 AgentRuntime.Audit(name, "BLOCKED — agent commands disabled");
                 return ToolError($"Agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
@@ -252,6 +271,12 @@ public static class AgentServer {
                     ["isError"] = false,
                 };
             }
+        }
+        else if (name == "record") {
+            // `record` manages its own background capture thread; a one-shot blocks the caller for the
+            // whole recording duration. Do NOT hold ExecLock for that span or it would stall every
+            // other tool call. Frame grabbing runs off-lock on the recorder thread regardless.
+            cmd.Execute();
         }
         else {
             lock (ExecLock) {
@@ -383,6 +408,22 @@ public static class AgentServer {
             By = Str(args, "by") ?? "name",
             Value = Str(args, "value")!,
             Timeout = Int(args, "timeout"),
+        },
+        "record" => new RecordCommand {
+            Action = Str(args, "action")!,
+            Window = Str(args, "window")!,
+            Handle = Long(args, "handle"),
+            Process = Str(args, "process")!,
+            ClassName = Str(args, "className")!,
+            Foreground = Bool(args, "foreground"),
+            X = Int(args, "x"),
+            Y = Int(args, "y"),
+            Width = Int(args, "width"),
+            Height = Int(args, "height"),
+            Fps = Int(args, "fps"),
+            DurationMs = Int(args, "durationMs"),
+            MaxWidth = Int(args, "maxWidth"),
+            File = Str(args, "file")!,
         },
         _ => new InvokeCommand { // invoke
             Window = Str(args, "window")!,

--- a/src/Services/AppSettings.cs
+++ b/src/Services/AppSettings.cs
@@ -132,6 +132,18 @@ public class AppSettings : ICloneable {
     [SafeForTelemetryAttribute]
     public int McpHttpPort { get; set; } = 5151;
 
+    // --- GIF recording limits (issue #80) ---
+    // SECURITY/SAFETY: the agent `record` command is bounded by these so it cannot accidentally create
+    // an unbounded file. Requests above a limit are CLAMPED (not failed) and the clamp is audited.
+    [SafeForTelemetryAttribute]
+    public int AgentRecordMaxFps { get; set; } = 30;
+    [SafeForTelemetryAttribute]
+    public int AgentRecordMaxDurationMs { get; set; } = 60000;
+    [SafeForTelemetryAttribute]
+    public int AgentRecordMaxFrames { get; set; } = 600;
+    [SafeForTelemetryAttribute]
+    public int AgentRecordMaxWidth { get; set; } = 1280;
+
     #region ICloneable Members
 
     public object Clone() {

--- a/tests/MCEControl.xUnit/Agent/GifEncoderTests.cs
+++ b/tests/MCEControl.xUnit/Agent/GifEncoderTests.cs
@@ -1,0 +1,66 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Unit tests for the dependency-free animated-GIF assembler. These run anywhere GDI+ is available
+/// (no desktop capture needed): they synthesize bitmaps, encode them, and decode the result back with
+/// System.Drawing to prove the assembled stream is a valid multi-frame GIF89a.
+/// </summary>
+public class GifEncoderTests {
+    private static Bitmap SolidBitmap(int w, int h, Color color) {
+        Bitmap bmp = new(w, h);
+        using Graphics g = Graphics.FromImage(bmp);
+        g.Clear(color);
+        return bmp;
+    }
+
+    [Fact]
+    public void Assemble_TwoFrames_ProducesValidAnimatedGif89a() {
+        using Bitmap a = SolidBitmap(32, 24, Color.Red);
+        using Bitmap b = SolidBitmap(32, 24, Color.Blue);
+        List<byte[]> frames = [GifEncoder.EncodeFrame(a), GifEncoder.EncodeFrame(b)];
+
+        byte[] gif = GifEncoder.Assemble(frames, delayMs: 200, loop: true);
+
+        // GIF89a magic.
+        Assert.True(gif.Length > 6);
+        Assert.Equal("GIF89a", System.Text.Encoding.ASCII.GetString(gif, 0, 6));
+
+        // Decodes back to a 2-frame animation at the declared dimensions.
+        using MemoryStream ms = new(gif);
+        using Image img = Image.FromStream(ms);
+        FrameDimension time = new(img.FrameDimensionsList[0]);
+        Assert.Equal(2, img.GetFrameCount(time));
+        Assert.Equal(32, img.Width);
+        Assert.Equal(24, img.Height);
+    }
+
+    [Fact]
+    public void Assemble_DimensionsAreTheLargestFrame() {
+        using Bitmap small = SolidBitmap(10, 10, Color.Green);
+        using Bitmap big = SolidBitmap(40, 20, Color.Yellow);
+        List<byte[]> frames = [GifEncoder.EncodeFrame(small), GifEncoder.EncodeFrame(big)];
+
+        byte[] gif = GifEncoder.Assemble(frames, delayMs: 100, loop: false);
+
+        using MemoryStream ms = new(gif);
+        using Image img = Image.FromStream(ms);
+        Assert.Equal(40, img.Width);
+        Assert.Equal(20, img.Height);
+    }
+
+    [Fact]
+    public void Assemble_NoFrames_Throws() {
+        Assert.Throws<ArgumentException>(() => GifEncoder.Assemble([], delayMs: 100, loop: true));
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
@@ -1,0 +1,132 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+[Collection("AgentSerial")]
+public class RecordCommandTests {
+    [Fact]
+    public void Constructor_DisabledByDefault() {
+        RecordCommand cmd = new();
+
+        Assert.False(cmd.Enabled);
+    }
+
+    [Fact]
+    public void BuiltInCommands_NonEmpty_ContainsRecord() {
+        List<Command> builtIns = RecordCommand.BuiltInCommands;
+
+        Assert.NotEmpty(builtIns);
+        Assert.Contains(builtIns, c => c.Cmd == "record");
+    }
+
+    [Fact]
+    public void Clone_CopiesProperties_AndIsIndependent() {
+        RecordCommand original = new() {
+            Cmd = "record",
+            Enabled = true,
+            Action = "oneshot",
+            Window = "Notepad",
+            Handle = 42,
+            Process = "notepad",
+            ClassName = "Notepad",
+            Foreground = true,
+            X = 1, Y = 2, Width = 3, Height = 4,
+            Fps = 10,
+            DurationMs = 5000,
+            MaxWidth = 800,
+            File = "out.gif",
+        };
+
+        RecordCommand clone = (RecordCommand)original.Clone(null!);
+
+        Assert.NotSame(original, clone);
+        Assert.Equal("record", clone.Cmd);
+        Assert.True(clone.Enabled);
+        Assert.Equal("oneshot", clone.Action);
+        Assert.Equal("Notepad", clone.Window);
+        Assert.Equal(42, clone.Handle);
+        Assert.Equal("notepad", clone.Process);
+        Assert.Equal("Notepad", clone.ClassName);
+        Assert.True(clone.Foreground);
+        Assert.Equal(1, clone.X);
+        Assert.Equal(2, clone.Y);
+        Assert.Equal(3, clone.Width);
+        Assert.Equal(4, clone.Height);
+        Assert.Equal(10, clone.Fps);
+        Assert.Equal(5000, clone.DurationMs);
+        Assert.Equal(800, clone.MaxWidth);
+        Assert.Equal("out.gif", clone.File);
+
+        // Independence: mutating the clone must not bleed back into the original.
+        clone.Window = "Other";
+        clone.Fps = 99;
+        Assert.Equal("Notepad", original.Window);
+        Assert.Equal(10, original.Fps);
+    }
+
+    [Fact]
+    public void Execute_WhenAgentDisabled_ReturnsFalse_WritesFailureJson() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = null; // agent commands disabled
+        try {
+            CapturingReply reply = new();
+            RecordCommand cmd = new() { Cmd = "record", Enabled = true, Reply = reply, DurationMs = 200 };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_UnknownAction_FailsWithoutTouchingDesktop() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            RecordCommand cmd = new() { Cmd = "record", Enabled = true, Reply = reply, Action = "bogus" };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+            Assert.Contains("action", json["error"]!.GetValue<string>(), System.StringComparison.OrdinalIgnoreCase);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_StopWhenNotRecording_Fails() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            // Ensure no recording is in progress from a prior test.
+            GifRecorder.Stop();
+
+            CapturingReply reply = new();
+            RecordCommand cmd = new() { Cmd = "record", Enabled = true, Reply = reply, Action = "stop" };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
@@ -1,7 +1,10 @@
 // Copyright © Kindel, LLC - http://www.kindel.com
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
+using System.Drawing;
+using System.IO;
 using System.Text.Json.Nodes;
+using System.Threading;
 using Xunit;
 using MCEControl;
 
@@ -105,6 +108,37 @@ public class RecordCommandTests {
         }
         finally {
             AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_StopWriteFailure_ReturnsError() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        // A path whose parent is a FILE (not a directory) makes WriteAllBytes throw deterministically.
+        string fileAsDir = Path.GetTempFileName();
+        string badPath = Path.Combine(fileAsDir, "out.gif");
+        try {
+            GifRecorder.Stop(); // clear any prior recording
+            // Record a couple of synthetic frames (no desktop capture needed), then stop to a bad path.
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 10, maxFrames: 600, maxWidth: 64, maxDurationMs: 60000, target: null);
+            Thread.Sleep(350);
+
+            CapturingReply reply = new();
+            RecordCommand cmd = new() { Cmd = "record", Enabled = true, Reply = reply, Action = "stop", File = badPath };
+
+            bool result = cmd.Execute();
+
+            // No GIF bytes are returned inline, so a failed write means there is no usable output:
+            // the command must report failure rather than success-with-fileError.
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+        }
+        finally {
+            GifRecorder.Stop();
+            AgentRuntime.Settings = null;
+            File.Delete(fileAsDir);
         }
     }
 

--- a/tests/MCEControl.xUnit/Commands/SerializedCommandsTests.cs
+++ b/tests/MCEControl.xUnit/Commands/SerializedCommandsTests.cs
@@ -55,6 +55,67 @@ public class SerializedCommandsTests
     }
 
     [Fact]
+    public void SaveLoad_RoundTrip_RecordCommand_TopLevel()
+    {
+        string tempFile = Path.GetTempFileName();
+        File.Delete(tempFile);
+
+        var original = new SerializedCommands
+        {
+            commandArray =
+            [
+                new RecordCommand() { Cmd = "record", Action = "oneshot", Fps = 7, DurationMs = 3000, Enabled = true }
+            ]
+        };
+
+        SerializedCommands.SaveCommands(tempFile, original, "1.0.0.0");
+        var loaded = SerializedCommands.LoadCommands(tempFile, "1.0.0.0");
+
+        Assert.NotNull(loaded);
+        var rec = Assert.Single(loaded.commandArray) as RecordCommand;
+        Assert.NotNull(rec);
+        Assert.Equal("record", rec.Cmd);
+        Assert.Equal("oneshot", rec.Action);
+        Assert.Equal(7, rec.Fps);
+        Assert.True(rec.Enabled);
+
+        File.Delete(tempFile);
+    }
+
+    [Fact]
+    public void SaveLoad_RoundTrip_RecordCommand_Embedded()
+    {
+        string tempFile = Path.GetTempFileName();
+        File.Delete(tempFile);
+
+        var original = new SerializedCommands
+        {
+            commandArray =
+            [
+                new StartProcessCommand() {
+                    Cmd = "proc", File = "x.exe", Enabled = true,
+                    EmbeddedCommands = [ new RecordCommand() { Cmd = "record", Action = "start", Enabled = true } ],
+                }
+            ]
+        };
+
+        // Must serialize AND deserialize the nested <record> as a RecordCommand (the EmbeddedCommands
+        // polymorphic map must know the type, same as the top-level commandArray map).
+        SerializedCommands.SaveCommands(tempFile, original, "1.0.0.0");
+        var loaded = SerializedCommands.LoadCommands(tempFile, "1.0.0.0");
+
+        Assert.NotNull(loaded);
+        var proc = Assert.Single(loaded.commandArray) as StartProcessCommand;
+        Assert.NotNull(proc);
+        Assert.NotNull(proc.EmbeddedCommands);
+        var embedded = Assert.Single(proc.EmbeddedCommands) as RecordCommand;
+        Assert.NotNull(embedded);
+        Assert.Equal("start", embedded.Action);
+
+        File.Delete(tempFile);
+    }
+
+    [Fact]
     public void LoadCommands_NonExistentFile_ReturnsNull()
     {
         string tempFile = Path.GetTempFileName();

--- a/tests/MCEControl.xUnit/Integration/RecordDesktopTests.cs
+++ b/tests/MCEControl.xUnit/Integration/RecordDesktopTests.cs
@@ -1,0 +1,64 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.IO;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Integration;
+
+/// <summary>
+/// Opt-in, desktop-dependent test for real GIF recording: it captures a small live screen region for
+/// a bounded one-shot and proves a non-empty, valid animated GIF is written. It touches the real
+/// desktop (screen grab), so it is skipped unless <c>MCEC_DESKTOP_E2E=1</c> is set — a normal
+/// <c>dotnet test</c> / CI run never records the screen.
+/// Run it deliberately on an interactive session:
+///   <c>$env:MCEC_DESKTOP_E2E=1; dotnet test --filter Category=DesktopE2E</c>
+/// </summary>
+[Collection("AgentSerial")]
+public class RecordDesktopTests {
+    [Fact]
+    [Trait("Category", "DesktopE2E")]
+    public void Record_Oneshot_Region_WritesAnimatedGif() {
+        if (Environment.GetEnvironmentVariable("MCEC_DESKTOP_E2E") != "1") {
+            return; // gated off (CI / normal test runs do not capture the screen)
+        }
+
+        AgentTestSupport.EnsureTelemetry();
+        string outFile = Path.Combine(Path.GetTempPath(), $"mcec-rec-test-{Guid.NewGuid():N}.gif");
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            RecordCommand cmd = new() {
+                Cmd = "record",
+                Enabled = true,
+                Reply = reply,
+                X = 0, Y = 0, Width = 320, Height = 240,
+                Fps = 5,
+                DurationMs = 1000,
+                File = outFile,
+            };
+
+            bool ok = cmd.Execute();
+
+            Assert.True(ok);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.True(json["success"]!.GetValue<bool>(), reply.Captured);
+
+            JsonObject data = json["data"]!.AsObject();
+            Assert.True(data["frames"]!.GetValue<int>() >= 2);
+            Assert.Equal(outFile, data["file"]!.GetValue<string>());
+
+            Assert.True(File.Exists(outFile));
+            byte[] gif = File.ReadAllBytes(outFile);
+            Assert.True(gif.Length > 0);
+            Assert.Equal("GIF89a", System.Text.Encoding.ASCII.GetString(gif, 0, 6));
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            try { File.Delete(outFile); } catch (IOException) { /* best effort cleanup */ }
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -52,6 +52,7 @@ public class AgentServerTests {
         Assert.Contains("find", names);
         Assert.Contains("wait-for", names);
         Assert.Contains("invoke", names);
+        Assert.Contains("record", names);
         Assert.Contains("send_command", names);
     }
 


### PR DESCRIPTION
Closes #80.

Adds a `record` command / MCP tool that records agent-driven desktop activity as an animated GIF — a whole short segment (explicit `start`/`stop`) or a bounded one-shot — reusing the same target model and security gate as `capture`. Makes dogfooding, debugging, demos, and issue reports far easier.


## Mini-spec

### Surface

A single `record` command / MCP tool with three modes, selected by `action`:

| `action`  | Behavior |
| --------- | -------- |
| `start`   | Begin capturing the target at `fps` on a background thread; returns immediately. |
| `stop`    | Stop the in-progress recording, encode the GIF, write `file`, return metadata. |
| `oneshot` | `start`, capture for `durationMs`, then auto-stop/encode/write in one blocking call. |

`action` defaults to `oneshot` when `durationMs` is given, else `start`.

**Target** (same resolver as `capture`): `window` / `handle` / `process` / `className` / `foreground:true`, or an explicit region (`x`/`y`/`width`/`height`). Fixed at `start`; `stop` needs no target.

**Other args:** `fps` (default 5), `durationMs` (one-shot length / auto-stop cap), `file` (output `.gif`; temp path if omitted), `maxWidth` (downscale longest side, default 1280).

Only one recording active at a time.

### Result envelope

Shared `CommandResult` JSON. A successful `stop`/`oneshot` returns `data` with `file`, `frames`, `durationMs`, `fps`, `width`, `height`, `bytes`, and `target`.

### Encoding

No new dependency: each frame is quantized + LZW-compressed to a single-frame GIF by GDI+, and `GifEncoder` stitches them into one GIF89a (global header + Netscape loop extension + per-frame Graphic Control Extension delays). Each frame keeps its palette as a local color table.

### Limits (anti-footgun)

Clamped to operator settings with defaults: `AgentRecordMaxFps` (30), `AgentRecordMaxDurationMs` (60 s), `AgentRecordMaxFrames` (600), `AgentRecordMaxWidth` (1280). Over-limit requests are clamped and audited.

### Security & privacy

- Disabled by default, behind the same `AgentCommandsEnabled` opt-in as `capture`, plus the per-command `Enabled` gate in `mcec.commands` (fail-closed; honors #74).
- Every `start`/`stop`/write emits an `AGENT-AUDIT:` line (target, duration, fps, path).
- Docs warn that GIF recording can capture sensitive on-screen content for the whole duration.

### In-product guidance

`AgentServer.Instructions` gains a line on *when* to record vs. still-`capture`.

## Acceptance criteria

- [x] Command/MCP surface to record a GIF from a window, foreground window, or region
- [x] Record part of a session via `start`/`stop` or bounded `durationMs`
- [x] Structured JSON: success/error, path, frame count, duration, dimensions, bytes
- [x] Docs + built-in MCP guidance on GIF-record vs still-`capture`
- [x] Tests for argument validation and disabled-gate; opt-in manual desktop test

Full spec: `docs/design/gif-recording.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

