### PR TITLE
agent: emit the #101 result envelope from every tool (#86 Phase 1)

### DIFF
--- a/src/Agent/AgentError.cs
+++ b/src/Agent/AgentError.cs
@@ -1,0 +1,61 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// The failure descriptor inside an <see cref="AgentToolResult"/> (present only when <c>ok</c> is
+/// false). Carries a fine-grained, open-ended <see cref="Code"/>, a coarse <see cref="Category"/> from
+/// the closed <see cref="AgentErrorCategory"/> taxonomy, a human-readable <see cref="Detail"/>, and an
+/// optional <see cref="LastObservation"/> (the last good state before the failure, for debugging and
+/// #87's failure-summary). See <c>docs/design/agent-tool-result-contract.md</c> (#101).
+/// </summary>
+public sealed class AgentError {
+    public AgentError(string code, AgentErrorCategory category, string detail, JsonObject? lastObservation = null) {
+        Code = code;
+        Category = category;
+        Detail = detail;
+        LastObservation = lastObservation;
+    }
+
+    /// <summary>Stable, fine-grained machine code (kebab-case); narrows <see cref="Category"/>.</summary>
+    public string Code { get; }
+
+    /// <summary>Coarse failure class from the closed taxonomy.</summary>
+    public AgentErrorCategory Category { get; }
+
+    /// <summary>Human-readable explanation of what failed and, where possible, how to recover.</summary>
+    public string Detail { get; }
+
+    /// <summary>The last good observation captured before the failure, or null when none exists.</summary>
+    public JsonObject? LastObservation { get; }
+
+    /// <summary>The kebab-case wire string for <see cref="Category"/> that goes into <c>error.category</c>.</summary>
+    public string CategoryWire => Category switch {
+        AgentErrorCategory.Timeout => "timeout",
+        AgentErrorCategory.AmbiguousSelector => "ambiguous-selector",
+        AgentErrorCategory.StaleElement => "stale-element",
+        AgentErrorCategory.NoTarget => "no-target",
+        AgentErrorCategory.CaptureBlank => "capture-blank",
+        AgentErrorCategory.Focus => "focus",
+        AgentErrorCategory.Elevation => "elevation",
+        AgentErrorCategory.Foreground => "foreground",
+        AgentErrorCategory.Internal => "internal",
+        _ => "internal",
+    };
+
+    public JsonObject ToJsonObject() {
+        JsonObject obj = new() {
+            ["code"] = Code,
+            ["category"] = CategoryWire,
+            ["detail"] = Detail,
+        };
+        if (LastObservation is not null) {
+            obj["lastObservation"] = LastObservation.DeepClone();
+        }
+        return obj;
+    }
+}

--- a/src/Agent/AgentErrorCategory.cs
+++ b/src/Agent/AgentErrorCategory.cs
@@ -1,0 +1,41 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// The <b>closed</b> failure taxonomy for every MCEC 3.0 agent tool result, owned by the contract in
+/// <c>docs/design/agent-tool-result-contract.md</c> (#101). An agent may branch exhaustively on this
+/// set; new failure modes are mapped onto an existing member rather than added ad hoc. The wire form
+/// (the kebab-case string that goes into <c>error.category</c>) is produced by
+/// <see cref="AgentError.CategoryWire"/>.
+/// </summary>
+public enum AgentErrorCategory {
+    /// <summary>A wait/poll (e.g. <c>wait-for</c>) expired before its condition held.</summary>
+    Timeout,
+
+    /// <summary>A selector matched more than one candidate and the tool refused to guess.</summary>
+    AmbiguousSelector,
+
+    /// <summary>A previously resolved element/handle is no longer valid (window closed, tree re-rendered).</summary>
+    StaleElement,
+
+    /// <summary>A selector matched nothing (no window/element).</summary>
+    NoTarget,
+
+    /// <summary>A screenshot was produced but detected as black/blank.</summary>
+    CaptureBlank,
+
+    /// <summary>An action required input focus that could not be set.</summary>
+    Focus,
+
+    /// <summary>The target runs at a higher integrity level (UAC) than MCEC and cannot be driven.</summary>
+    Elevation,
+
+    /// <summary>An action required the target to be foreground and it could not be brought forward.</summary>
+    Foreground,
+
+    /// <summary>An unexpected MCEC-side fault (bug, unhandled exception) or a policy refusal the agent
+    /// cannot recover from on its own.</summary>
+    Internal,
+}

--- a/src/Agent/AgentToolResult.cs
+++ b/src/Agent/AgentToolResult.cs
@@ -1,0 +1,136 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// The single result envelope every MCEC 3.0 agent tool returns, defined by
+/// <c>docs/design/agent-tool-result-contract.md</c> and <c>agent-tool-result.schema.json</c> (#101).
+/// One shape, one error vocabulary, so an agent can branch on success/failure uniformly across
+/// <c>capture</c>/<c>query</c>/<c>find</c>/<c>wait-for</c>/<c>invoke</c>/<c>send_command</c> and the
+/// session-lifecycle tools.
+///
+/// A result is <b>either</b> success (<c>ok:true</c>, <see cref="Result"/> present, no
+/// <see cref="Error"/>) <b>or</b> failure (<c>ok:false</c>, <see cref="Error"/> present, no
+/// <see cref="Result"/>) — never both. The factory methods enforce that invariant structurally.
+///
+/// <para>Phase 1 (#86) wires this in at the <see cref="AgentServer"/> boundary by translating the
+/// legacy <see cref="CommandResult"/> each command still emits (see <see cref="FromLegacy"/>). The
+/// per-tool epics (#87–#91) will have the commands emit native categories, warnings, and
+/// <c>lastObservation</c> directly. <see cref="SessionId"/> stays null until the session store lands
+/// (Phase 2/3).</para>
+/// </summary>
+public sealed class AgentToolResult {
+    private AgentToolResult(bool ok, JsonObject? result, AgentError? error, string? sessionId, IReadOnlyList<AgentWarning> warnings) {
+        Ok = ok;
+        Result = result;
+        Error = error;
+        SessionId = sessionId;
+        Warnings = warnings;
+    }
+
+    /// <summary>Owning session id, or null for a stateless one-shot call.</summary>
+    public string? SessionId { get; }
+
+    /// <summary>True when the tool achieved its goal — the field an agent branches on first.</summary>
+    public bool Ok { get; }
+
+    /// <summary>Tool-specific success payload (present when <see cref="Ok"/>); null on failure.</summary>
+    public JsonObject? Result { get; }
+
+    /// <summary>Non-fatal conditions surfaced alongside the result. May be present on success or failure.</summary>
+    public IReadOnlyList<AgentWarning> Warnings { get; }
+
+    /// <summary>The failure descriptor (present only when <see cref="Ok"/> is false).</summary>
+    public AgentError? Error { get; }
+
+    /// <summary>Builds a success envelope.</summary>
+    public static AgentToolResult Success(JsonObject? result, string? sessionId = null, IReadOnlyList<AgentWarning>? warnings = null) =>
+        new(true, result, null, sessionId, warnings ?? []);
+
+    /// <summary>Builds a failure envelope from an <see cref="AgentError"/>.</summary>
+    public static AgentToolResult Failure(AgentError error, string? sessionId = null, IReadOnlyList<AgentWarning>? warnings = null) =>
+        new(false, null, error ?? throw new ArgumentNullException(nameof(error)), sessionId, warnings ?? []);
+
+    /// <summary>Builds a failure envelope from its parts.</summary>
+    public static AgentToolResult Failure(string code, AgentErrorCategory category, string detail, string? sessionId = null) =>
+        Failure(new AgentError(code, category, detail), sessionId);
+
+    /// <summary>
+    /// Translates a legacy <see cref="CommandResult"/> JSON object (<c>{ success, command, error, data }</c>)
+    /// — what each agent command writes to its reply today — into the #101 envelope. Success carries
+    /// <c>data</c> forward as <see cref="Result"/>; failure maps the free-text error onto the closed
+    /// taxonomy via <see cref="Categorize"/>.
+    /// </summary>
+    public static AgentToolResult FromLegacy(JsonObject legacy, string toolName, string? sessionId = null) {
+        bool success = legacy["success"] is JsonValue sv && sv.TryGetValue(out bool b) && b;
+        if (success) {
+            JsonObject? data = (legacy["data"] as JsonObject)?.DeepClone() as JsonObject;
+            return Success(data, sessionId);
+        }
+
+        string message = legacy["error"] is JsonValue ev && ev.TryGetValue(out string? s) && s is not null
+            ? s
+            : "The command failed without a message.";
+        return Failure(Categorize(toolName, message), sessionId);
+    }
+
+    /// <summary>
+    /// Maps a legacy free-text command error onto the closed <see cref="AgentErrorCategory"/> taxonomy.
+    /// This is the Phase 1 translation shim: the known error strings are pinned by the command-level
+    /// tests, so the mapping is stable. Unrecognized messages fall back to <c>internal</c> (not
+    /// agent-recoverable; surface to the operator), per the contract's recovery guidance.
+    /// </summary>
+    public static AgentError Categorize(string toolName, string message) {
+        string m = message ?? "";
+
+        if (m.Contains("No matching window", StringComparison.OrdinalIgnoreCase)) {
+            return new AgentError("window-not-found", AgentErrorCategory.NoTarget, m);
+        }
+        if (m.Contains("Invoke failed", StringComparison.OrdinalIgnoreCase)) {
+            // The element was not found or its pattern is unsupported; agent recovery is to re-query/
+            // re-find a fresh target, which is exactly the no-target recovery path.
+            return new AgentError("element-not-found", AgentErrorCategory.NoTarget, m);
+        }
+        if (m.Contains("Capture failed", StringComparison.OrdinalIgnoreCase)) {
+            return new AgentError("capture-exception", AgentErrorCategory.Internal, m);
+        }
+        if (m.Contains("disabled", StringComparison.OrdinalIgnoreCase)) {
+            return new AgentError("agent-commands-disabled", AgentErrorCategory.Internal, m);
+        }
+        if (m.Contains("produced no output", StringComparison.OrdinalIgnoreCase)) {
+            return new AgentError("no-output", AgentErrorCategory.Internal, m);
+        }
+        return new AgentError("unhandled", AgentErrorCategory.Internal, m);
+    }
+
+    /// <summary>Serializes to the camelCase, nulls-omitted envelope object (per <see cref="AgentJson.Options"/>).</summary>
+    public JsonObject ToJsonObject() {
+        JsonObject obj = new() {
+            ["ok"] = Ok,
+        };
+        if (SessionId is not null) {
+            obj["sessionId"] = SessionId;
+        }
+        if (Ok && Result is not null) {
+            obj["result"] = Result.DeepClone();
+        }
+        if (Warnings.Count > 0) {
+            JsonArray warnings = [];
+            foreach (AgentWarning w in Warnings) {
+                warnings.Add(w.ToJsonObject());
+            }
+            obj["warnings"] = warnings;
+        }
+        if (!Ok && Error is not null) {
+            obj["error"] = Error.ToJsonObject();
+        }
+        return obj;
+    }
+
+    public string ToJson() => ToJsonObject().ToJsonString(AgentJson.Options);
+}

--- a/src/Agent/AgentWarning.cs
+++ b/src/Agent/AgentWarning.cs
@@ -1,0 +1,31 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// A non-fatal condition surfaced alongside an <see cref="AgentToolResult"/>: the call still succeeded
+/// (or failed for a different reason), but the agent should know something was adjusted, degraded, or
+/// assumed (e.g. <c>minimized-window</c>, <c>tree-truncated</c>, <c>region-clamped</c>). Same stability
+/// rules as error codes — kebab-case, branchable, tolerate unknowns. See
+/// <c>docs/design/agent-tool-result-contract.md</c> (#101).
+/// </summary>
+public sealed class AgentWarning {
+    public AgentWarning(string code, string detail) {
+        Code = code;
+        Detail = detail;
+    }
+
+    /// <summary>Stable, kebab-case machine code for the warning condition.</summary>
+    public string Code { get; }
+
+    /// <summary>Human-readable explanation of the warning.</summary>
+    public string Detail { get; }
+
+    public JsonObject ToJsonObject() => new() {
+        ["code"] = Code,
+        ["detail"] = Detail,
+    };
+}

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -114,6 +114,13 @@ public static class AgentServer {
         "control to appear before acting. " +
         "`send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
         "4. VERIFY with another `query` or `capture` — always confirm the act had the intended effect.\n" +
+        "RESULTS: every tool returns one envelope — `{ ok, result?, warnings?, error? }`. Branch on `ok` " +
+        "first: on success read `result`; on failure read `error.category` (a closed set: timeout, " +
+        "ambiguous-selector, stale-element, no-target, capture-blank, focus, elevation, foreground, " +
+        "internal) to choose recovery — e.g. `no-target` means broaden the selector or `query` to " +
+        "discover targets, `ambiguous-selector` means add `processName`/`className`/`automationId`, " +
+        "`stale-element` means re-`query`/`find` for a fresh handle. `error.detail` is human-readable and " +
+        "`error.lastObservation`, when present, is the last good state before the failure.\n" +
         "SECURITY: observation tools (capture/query/find/invoke) only work when the operator has set " +
         "AgentCommandsEnabled=true; otherwise they return an error — surface that to the user rather " +
         "than retrying. Every action is audit-logged on the host.";
@@ -210,12 +217,12 @@ public static class AgentServer {
         if (name is "capture" or "query" or "find" or "wait-for" or "invoke") {
             if (!AgentRuntime.AgentCommandsEnabled) {
                 AgentRuntime.Audit(name, "BLOCKED — agent commands disabled");
-                return ToolError($"Agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
+                return ToolError("Agent commands are disabled. Set AgentCommandsEnabled=true to opt in.", "agent-commands-disabled");
             }
             return RunAgentCommand(name, args);
         }
 
-        return ToolError($"Unknown tool: {name}");
+        return ToolError($"Unknown tool: {name}", "unknown-tool");
     }
 
     private static JsonObject RunAgentCommand(string name, JsonObject args) {
@@ -224,7 +231,7 @@ public static class AgentServer {
         // the operator opts in per-command via mcec.commands). Fail closed if the table/command is missing.
         if ((AgentRuntime.Invoker?[name] as Command)?.Enabled != true) {
             AgentRuntime.Audit(name, "BLOCKED — command is disabled in mcec.commands");
-            return ToolError($"The '{name}' command is disabled. Enable it in mcec.commands (set Enabled=\"true\").");
+            return ToolError($"The '{name}' command is disabled. Enable it in mcec.commands (set Enabled=\"true\").", "command-disabled");
         }
 
         Command cmd = BuildCommand(name, args);
@@ -247,10 +254,7 @@ public static class AgentServer {
         if (name == "invoke") {
             if (!TryRunInvokeWithModalGrace(cmd)) {
                 AgentRuntime.Audit(name, "dispatched; a modal dialog appears to be open — returning without blocking");
-                return new JsonObject {
-                    ["content"] = new JsonArray { TextContent(InvokeModalPendingJson) },
-                    ["isError"] = false,
-                };
+                return McpResult(AgentToolResult.Success(InvokeModalPendingResult()));
             }
         }
         else {
@@ -259,48 +263,44 @@ public static class AgentServer {
             }
         }
 
+        // Translate the legacy CommandResult the command wrote into its reply into the #101 envelope.
         string captured = reply.Captured.Trim();
-        JsonObject result = [];
-        JsonArray content = [];
-
-        // For capture, surface the PNG as MCP image content in addition to the JSON text.
-        bool isError = false;
-        if (!string.IsNullOrEmpty(captured)) {
-            string textJson = captured;
-            JsonNode? parsed = TryParse(captured);
-            if (parsed is JsonObject obj) {
-                isError = obj["success"] is JsonValue sv && sv.TryGetValue(out bool ok) && !ok;
-                if (name == "capture" && obj["data"] is JsonObject data && data["base64"] is JsonValue) {
-                    content.Add(new JsonObject {
-                        ["type"] = "image",
-                        ["data"] = data["base64"]!.GetValue<string>(),
-                        ["mimeType"] = "image/png",
-                    });
-                    // Avoid duplicating the (potentially multi-MB) PNG: drop base64 from the text block
-                    // now that it is carried by the image content above.
-                    data.Remove("base64");
-                    textJson = obj.ToJsonString(AgentJson.Options);
-                }
-            }
-            content.Add(TextContent(textJson));
-        }
-        else {
-            isError = true;
-            content.Add(TextContent($"{{\"success\":false,\"error\":\"command produced no output\"}}"));
+        if (string.IsNullOrEmpty(captured)) {
+            return McpResult(AgentToolResult.Failure("no-output", AgentErrorCategory.Internal, $"The '{name}' command produced no output."));
         }
 
-        result["content"] = content;
-        result["isError"] = isError;
-        return result;
+        if (TryParse(captured) is not JsonObject legacy) {
+            // An agent command always emits CommandResult JSON; a non-JSON reply is unexpected. Carry the
+            // raw text forward rather than fabricating a structured error.
+            return McpResult(AgentToolResult.Success(new JsonObject { ["output"] = captured }));
+        }
+
+        AgentToolResult env = AgentToolResult.FromLegacy(legacy, name);
+
+        // For capture, surface the PNG as an MCP image content block in addition to the JSON envelope,
+        // and drop the (potentially multi-MB) base64 from the envelope text so it is not duplicated.
+        JsonObject? image = null;
+        if (name == "capture" && env.Ok && env.Result?["base64"] is JsonValue b64) {
+            image = new JsonObject {
+                ["type"] = "image",
+                ["data"] = b64.GetValue<string>(),
+                ["mimeType"] = "image/png",
+            };
+            env.Result.Remove("base64");
+        }
+
+        return McpResult(env, image);
     }
 
     // Grace period for an `invoke` to complete before we assume it opened a modal dialog and return.
     private const int InvokeModalGraceMs = 750;
 
-    private const string InvokeModalPendingJson =
-        "{\"success\":true,\"command\":\"invoke\",\"data\":{\"invoked\":true,\"modalPending\":true," +
-        "\"note\":\"The invoke opened a modal dialog (or a long-running action); it completes when the " +
-        "dialog closes. Query or capture the new window to read or dismiss it.\"}}";
+    private static JsonObject InvokeModalPendingResult() => new() {
+        ["invoked"] = true,
+        ["modalPending"] = true,
+        ["note"] = "The invoke opened a modal dialog (or a long-running action); it completes when the " +
+            "dialog closes. Query or capture the new window to read or dismiss it.",
+    };
 
     /// <summary>
     /// Runs an <c>invoke</c> on a background worker and waits up to <see cref="InvokeModalGraceMs"/> ms.
@@ -329,12 +329,12 @@ public static class AgentServer {
     private static JsonObject RunSendCommand(JsonObject args) {
         string command = args["command"]?.GetValue<string>() ?? "";
         if (string.IsNullOrWhiteSpace(command)) {
-            return ToolError("send_command requires a non-empty 'command' argument.");
+            return ToolError("send_command requires a non-empty 'command' argument.", "bad-arguments");
         }
 
         CommandInvoker? invoker = AgentRuntime.Invoker;
         if (invoker is null) {
-            return ToolError("Command engine is not available.");
+            return ToolError("Command engine is not available.", "engine-unavailable");
         }
 
         AgentRuntime.Audit("send_command", command);
@@ -344,12 +344,11 @@ public static class AgentServer {
             invoker.ExecuteNext();
         }
 
+        // The legacy command path returns opaque text, not a CommandResult; carry it forward as the
+        // success payload. (Native success/failure detection for send_command is out of Phase 1 scope.)
         string captured = reply.Captured.Trim();
-        JsonObject result = new() {
-            ["content"] = new JsonArray { TextContent(string.IsNullOrEmpty(captured) ? "ok" : captured) },
-            ["isError"] = false,
-        };
-        return result;
+        JsonObject result = new() { ["output"] = string.IsNullOrEmpty(captured) ? "ok" : captured };
+        return McpResult(AgentToolResult.Success(result));
     }
 
     /// <summary>Builds and populates an agent command instance from MCP tool arguments.</summary>
@@ -556,13 +555,30 @@ public static class AgentServer {
         ["error"] = new JsonObject { ["code"] = code, ["message"] = message },
     };
 
-    private static JsonObject ToolError(string message) {
-        string json = new JsonObject { ["success"] = false, ["error"] = message }.ToJsonString(AgentJson.Options);
+    /// <summary>
+    /// Wraps an <see cref="AgentToolResult"/> envelope in the MCP <c>tools/call</c> transport: the
+    /// envelope rides in a text content block (preceded by an optional image block, e.g. capture's PNG),
+    /// and MCP <c>isError</c> mirrors the envelope (<c>isError = !ok</c>) per the #101 contract.
+    /// </summary>
+    private static JsonObject McpResult(AgentToolResult env, JsonObject? imageContent = null) {
+        JsonArray content = [];
+        if (imageContent is not null) {
+            content.Add(imageContent);
+        }
+        content.Add(TextContent(env.ToJson()));
         return new JsonObject {
-            ["content"] = new JsonArray { TextContent(json) },
-            ["isError"] = true,
+            ["content"] = content,
+            ["isError"] = !env.Ok,
         };
     }
+
+    /// <summary>
+    /// A tool-level failure (a security gate or a bad request) reported as the #101 envelope. These are
+    /// MCEC-side refusals the agent cannot recover from on its own, so they map to the <c>internal</c>
+    /// category; <paramref name="code"/> distinguishes the specific cause.
+    /// </summary>
+    private static JsonObject ToolError(string message, string code = "internal-error") =>
+        McpResult(AgentToolResult.Failure(code, AgentErrorCategory.Internal, message));
 
     private static JsonObject TextContent(string text) => new() {
         ["type"] = "text",

--- a/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
@@ -1,0 +1,176 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Validates the #101 result envelope (<see cref="AgentToolResult"/>) and the Phase 1 (#86) translation
+/// from the legacy <see cref="CommandResult"/>. There is no JSON-Schema validator package referenced, so
+/// these tests assert the schema's structural invariants directly (see
+/// <c>docs/design/agent-tool-result.schema.json</c>): <c>ok</c> required; <c>ok:false</c> ⟹ a complete
+/// <c>error</c>; <c>ok:true</c> ⟹ no <c>error</c>; <c>category</c> from the closed taxonomy.
+/// </summary>
+public class AgentToolResultTests {
+    private static readonly HashSet<string> CategoryEnum = [
+        "timeout", "ambiguous-selector", "stale-element", "no-target",
+        "capture-blank", "focus", "elevation", "foreground", "internal",
+    ];
+
+    /// <summary>Asserts an emitted envelope honors the schema's required-field and success/failure invariants.</summary>
+    private static void AssertValidEnvelope(JsonObject env) {
+        Assert.True(env["ok"]?.GetValueKind() is JsonValueKind.True or JsonValueKind.False, "envelope must carry a boolean 'ok'");
+        bool ok = env["ok"]!.GetValue<bool>();
+
+        if (ok) {
+            Assert.False(env.ContainsKey("error"), "a success envelope must not carry 'error'");
+        }
+        else {
+            JsonObject error = Assert.IsType<JsonObject>(env["error"]);
+            Assert.False(string.IsNullOrEmpty(error["code"]?.GetValue<string>()), "error.code is required");
+            Assert.False(string.IsNullOrEmpty(error["detail"]?.GetValue<string>()), "error.detail is required");
+            string category = error["category"]!.GetValue<string>();
+            Assert.Contains(category, CategoryEnum);
+            Assert.False(env.ContainsKey("result"), "a failure envelope must not carry 'result'");
+        }
+
+        if (env["warnings"] is JsonNode warnings) {
+            JsonArray arr = Assert.IsType<JsonArray>(warnings);
+            foreach (JsonNode? w in arr) {
+                JsonObject wo = Assert.IsType<JsonObject>(w);
+                Assert.False(string.IsNullOrEmpty(wo["code"]?.GetValue<string>()), "warning.code is required");
+                Assert.False(string.IsNullOrEmpty(wo["detail"]?.GetValue<string>()), "warning.detail is required");
+            }
+        }
+    }
+
+    [Fact]
+    public void Success_CarriesResult_OmitsError() {
+        JsonObject env = AgentToolResult.Success(new JsonObject { ["found"] = true }).ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.True(env["ok"]!.GetValue<bool>());
+        Assert.True(env["result"]!["found"]!.GetValue<bool>());
+        Assert.False(env.ContainsKey("error"));
+    }
+
+    [Fact]
+    public void Success_WithNoPayload_StillValid() {
+        JsonObject env = AgentToolResult.Success(null).ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.True(env["ok"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void Failure_CarriesErrorTriple_OmitsResult() {
+        JsonObject env = AgentToolResult
+            .Failure(new AgentError("wait-condition-timeout", AgentErrorCategory.Timeout, "timed out"))
+            .ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.False(env["ok"]!.GetValue<bool>());
+        Assert.Equal("wait-condition-timeout", env["error"]!["code"]!.GetValue<string>());
+        Assert.Equal("timeout", env["error"]!["category"]!.GetValue<string>());
+        Assert.False(env.ContainsKey("result"));
+    }
+
+    [Fact]
+    public void Failure_WithLastObservation_IncludesIt() {
+        JsonObject obs = new() { ["window"] = "About" };
+        JsonObject env = AgentToolResult
+            .Failure(new AgentError("element-not-found", AgentErrorCategory.NoTarget, "no element", obs))
+            .ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.Equal("About", env["error"]!["lastObservation"]!["window"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void SessionId_OmittedWhenNull_PresentWhenSet() {
+        JsonObject anon = AgentToolResult.Success(null).ToJsonObject();
+        Assert.False(anon.ContainsKey("sessionId"));
+
+        JsonObject scoped = AgentToolResult.Success(null, sessionId: "s-1234").ToJsonObject();
+        Assert.Equal("s-1234", scoped["sessionId"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Warnings_SerializeAsCodeDetailArray() {
+        AgentToolResult result = AgentToolResult.Success(
+            [],
+            warnings: [new AgentWarning("minimized-window", "Target was minimized; restored before capture.")]);
+
+        JsonObject env = result.ToJsonObject();
+        AssertValidEnvelope(env);
+        Assert.Equal("minimized-window", env["warnings"]![0]!["code"]!.GetValue<string>());
+    }
+
+    [Theory]
+    [InlineData(AgentErrorCategory.Timeout, "timeout")]
+    [InlineData(AgentErrorCategory.AmbiguousSelector, "ambiguous-selector")]
+    [InlineData(AgentErrorCategory.StaleElement, "stale-element")]
+    [InlineData(AgentErrorCategory.NoTarget, "no-target")]
+    [InlineData(AgentErrorCategory.CaptureBlank, "capture-blank")]
+    [InlineData(AgentErrorCategory.Focus, "focus")]
+    [InlineData(AgentErrorCategory.Elevation, "elevation")]
+    [InlineData(AgentErrorCategory.Foreground, "foreground")]
+    [InlineData(AgentErrorCategory.Internal, "internal")]
+    public void CategoryWire_MapsEveryCategoryToSchemaEnum(AgentErrorCategory category, string expected) {
+        string wire = new AgentError("c", category, "d").CategoryWire;
+        Assert.Equal(expected, wire);
+        Assert.Contains(wire, CategoryEnum);
+    }
+
+    [Theory]
+    [InlineData("No matching window", "no-target", "window-not-found")]
+    [InlineData("Invoke failed (element not found or pattern unsupported)", "no-target", "element-not-found")]
+    [InlineData("Capture failed: boom", "internal", "capture-exception")]
+    [InlineData("Agent commands are disabled (AgentCommandsEnabled=false).", "internal", "agent-commands-disabled")]
+    [InlineData("command produced no output", "internal", "no-output")]
+    [InlineData("something nobody mapped", "internal", "unhandled")]
+    public void Categorize_MapsKnownErrorStrings(string message, string category, string code) {
+        AgentError error = AgentToolResult.Categorize("invoke", message);
+
+        Assert.Equal(category, error.CategoryWire);
+        Assert.Equal(code, error.Code);
+        Assert.Equal(message, error.Detail);
+    }
+
+    [Fact]
+    public void FromLegacy_Success_MapsDataToResult() {
+        JsonObject legacy = CommandResult.Ok("query", new JsonObject { ["tree"] = "x" }).ToJsonObject();
+
+        JsonObject env = AgentToolResult.FromLegacy(legacy, "query").ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.True(env["ok"]!.GetValue<bool>());
+        Assert.Equal("x", env["result"]!["tree"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void FromLegacy_Failure_MapsErrorViaTaxonomy() {
+        JsonObject legacy = CommandResult.Fail("capture", "No matching window").ToJsonObject();
+
+        JsonObject env = AgentToolResult.FromLegacy(legacy, "capture").ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.False(env["ok"]!.GetValue<bool>());
+        Assert.Equal("no-target", env["error"]!["category"]!.GetValue<string>());
+        Assert.Equal("window-not-found", env["error"]!["code"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Envelope_IsCamelCaseAndOmitsNulls() {
+        string json = AgentToolResult.Success(new JsonObject { ["found"] = false }).ToJson();
+
+        Assert.Contains("\"ok\":true", json);
+        Assert.DoesNotContain("sessionId", json); // null -> omitted
+        Assert.DoesNotContain("\"error\"", json);
+    }
+}

--- a/tests/MCEControl.xUnit/Integration/AgentDesktopE2ETests.cs
+++ b/tests/MCEControl.xUnit/Integration/AgentDesktopE2ETests.cs
@@ -186,7 +186,7 @@ public class AgentDesktopE2ETests {
         return isError is not null && isError.GetValue<bool>();
     }
 
-    /// <summary>Parses the first text content block of a tools/call result into its CommandResult.data.</summary>
+    /// <summary>Parses the first text content block of a tools/call result into its envelope's result payload.</summary>
     private static JsonObject? PayloadData(JsonObject toolCallResponse) {
         if (toolCallResponse["result"]?["content"] is not JsonArray content) {
             return null;
@@ -194,7 +194,7 @@ public class AgentDesktopE2ETests {
         foreach (JsonNode? block in content) {
             if (block?["type"]?.GetValue<string>() == "text") {
                 try {
-                    return JsonNode.Parse(block["text"]!.GetValue<string>())?["data"] as JsonObject;
+                    return JsonNode.Parse(block["text"]!.GetValue<string>())?["result"] as JsonObject;
                 }
                 catch (System.Text.Json.JsonException) {
                     return null;

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -83,4 +83,43 @@ public class AgentServerTests {
             AgentRuntime.Settings = null;
         }
     }
+
+    [Fact]
+    public void Dispatch_ToolsCall_WhenAgentDisabled_EmitsEnvelopeInTextContent() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = null; // agent commands disabled
+        try {
+            JsonObject prms = new() {
+                ["name"] = "capture",
+                ["arguments"] = new JsonObject(),
+            };
+
+            JsonObject resp = AgentServer.Dispatch(Request(4, "tools/call", prms))!;
+            JsonObject result = resp["result"]!.AsObject();
+
+            // MCP isError mirrors the envelope (isError = !ok).
+            Assert.True(result["isError"]!.GetValue<bool>());
+
+            // The first text content block is the #101 envelope: ok:false + a complete error.
+            JsonObject envelope = JsonNode.Parse(FirstTextBlock(result))!.AsObject();
+            Assert.False(envelope["ok"]!.GetValue<bool>());
+            JsonObject error = envelope["error"]!.AsObject();
+            Assert.Equal("internal", error["category"]!.GetValue<string>());
+            Assert.Equal("agent-commands-disabled", error["code"]!.GetValue<string>());
+            Assert.False(envelope.ContainsKey("result"));
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    private static string FirstTextBlock(JsonObject toolResult) {
+        foreach (JsonNode? block in toolResult["content"]!.AsArray()) {
+            if (block?["type"]?.GetValue<string>() == "text") {
+                return block["text"]!.GetValue<string>();
+            }
+        }
+        Assert.Fail("no text content block in tool result");
+        return "";
+    }
 }


### PR DESCRIPTION
## What

Phase 1 of the **session-runtime epic (#86)**: land the shared agent tool **result & error envelope (#101)** in code. Until now every MCP tool returned the legacy `{ success, command, error, data }` shape; the envelope existed only as a design artifact. This makes every tool return the one envelope so an agent can branch on success/failure uniformly — the foundation the rest of #86 (and the tool epics #87–#91) build on.

Every tool now returns:

```json
{ "sessionId": null, "ok": true, "result": { ... }, "warnings": [ ... ],
  "error": { "code": "...", "category": "...", "detail": "...", "lastObservation": { ... } } }
```

## How

- **New types** (one top-level type per file, per the MCEC0001/0002 analyzer): `AgentToolResult` (envelope), `AgentError` (`code`/`category`/`detail`/`lastObservation`), `AgentWarning`, and the closed `AgentErrorCategory` taxonomy.
- **Boundary translation:** commands still emit `CommandResult`; `AgentServer` translates it into the envelope in `RunAgentCommand`/`RunSendCommand`/`ToolError` and the invoke modal-pending path. `isError` mirrors the envelope (`isError = !ok`). `capture`'s PNG still rides as an MCP image content block, with base64 dropped from the text envelope to avoid duplication.
- **Error mapping:** free-text command errors map onto the closed taxonomy via a documented Phase 1 shim (`Categorize`) — the known strings are pinned by the command-level tests.
- **In-product guidance:** added a `RESULTS:` section to `AgentServer.Instructions` so the model knows to branch on `ok` and recover by `error.category` (honors the "fold learnings into Instructions" rule — the result shape an agent reads changed).
- **Scope boundaries:** `sessionId` stays `null` until the session store lands (Phase 2/3); per-tool native categories, `warnings`, and `lastObservation` are owned by the tool epics (#87–#91).

## Tests

- New `AgentToolResultTests`: envelope invariants (`ok` required; `ok:false` ⟹ complete `error`; `ok:true` ⟹ no `error`; `category` ∈ closed enum), full categorizer coverage, `CategoryWire` for every category, and `FromLegacy` round-trips. Dependency-free (no JSON-Schema validator package).
- New `AgentServer` boundary test: the disabled path emits a valid envelope in the text content block with `isError:true`.
- Updated the gated desktop E2E payload reader (`data` → `result`).
- Full suite green: **160 passed, 22 skipped**.

Refs #86, #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
