### PR TITLE
agent: server-side session store with sessionId + last-state tracking (#86 Phase 2)

### DIFF
--- a/src/Agent/AgentRuntime.cs
+++ b/src/Agent/AgentRuntime.cs
@@ -1,6 +1,9 @@
 // Copyright © Kindel, LLC - http://www.kindel.com
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
+using System;
+using System.IO;
+
 namespace MCEControl;
 
 /// <summary>
@@ -39,4 +42,63 @@ public static class AgentRuntime {
     /// </summary>
     public static void Audit(string action, string detail) =>
         Logger.Instance.Log4.Info($"AGENT-AUDIT: {action} — {detail}");
+
+    // -------------------------------------------------------------------------------------------
+    // Session runtime (#86)
+    // -------------------------------------------------------------------------------------------
+
+    private static readonly object SessionGate = new();
+    private static AgentSession? _session;
+    private static string? _artifactRoot;
+
+    /// <summary>
+    /// Root directory under which each session reserves its artifact subdirectory. Defaults to a
+    /// <c>sessions</c> folder beside MCEC's settings/logs (or a temp fallback if that can't be resolved);
+    /// overridable by the host or tests. Setting it clears the ambient session so the next one uses it.
+    /// </summary>
+    public static string ArtifactRoot {
+        get {
+            lock (SessionGate) {
+                return _artifactRoot ??= DefaultArtifactRoot();
+            }
+        }
+        set {
+            lock (SessionGate) {
+                _artifactRoot = value;
+                _session = null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The ambient agent session, created on first use. Phase 2 (#86) runs a single runner-owned session;
+    /// explicit <c>session/start|status|end</c> lifecycle and per-call routing arrive in Phase 3. The
+    /// session carries <c>sessionId</c> onto every result and the last target/observation/action/error
+    /// for debugging and replay.
+    /// </summary>
+    public static AgentSession Session {
+        get {
+            lock (SessionGate) {
+                return _session ??= AgentSession.Create(_artifactRoot ??= DefaultArtifactRoot());
+            }
+        }
+    }
+
+    /// <summary>Drops the ambient session so the next access starts a fresh one (used by tests and a future <c>session/end</c>).</summary>
+    public static void ResetSession() {
+        lock (SessionGate) {
+            _session = null;
+        }
+    }
+
+    private static string DefaultArtifactRoot() {
+        try {
+            string baseDir = AppSettings.GetSettingsPath(System.Windows.Forms.Application.StartupPath);
+            return Path.Combine(baseDir, "sessions");
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Warn($"AgentRuntime: falling back to temp artifact root: {e.Message}");
+            return Path.Combine(Path.GetTempPath(), "MCEC", "sessions");
+        }
+    }
 }

--- a/src/Agent/AgentSession.cs
+++ b/src/Agent/AgentSession.cs
@@ -108,6 +108,26 @@ public sealed class AgentSession {
         }
     }
 
+    /// <summary>
+    /// Records the outcome of a tool call: a successful <b>observation</b> (query/capture/find/wait-for)
+    /// updates <see cref="LastObservation"/> and, when the payload names a window, <see cref="ActiveTarget"/>;
+    /// a failure updates <see cref="LastError"/>. Actuation tools (invoke/send_command) don't record an
+    /// observation. Centralizing the decision keeps every observation tool — wait-for included — consistent.
+    /// </summary>
+    public void RecordToolOutcome(string toolName, AgentToolResult env) {
+        if (env.Ok) {
+            if (IsObservationTool(toolName)) {
+                RecordObservation(env.Result, env.Result?["window"] as JsonObject);
+            }
+        }
+        else if (env.Error is not null) {
+            RecordError(env.Error.ToJsonObject());
+        }
+    }
+
+    private static bool IsObservationTool(string toolName) =>
+        toolName is "query" or "capture" or "find" or "wait-for";
+
     /// <summary>Creates the per-session artifact directory if it does not yet exist and returns its path.</summary>
     public string EnsureArtifactDir() {
         string dir = ArtifactDir;

--- a/src/Agent/AgentSession.cs
+++ b/src/Agent/AgentSession.cs
@@ -1,0 +1,141 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.IO;
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// The server-side runtime state for one agent automation session (#86). Where the legacy
+/// <see cref="CommandResult"/> made every tool call stateless, a session gives the runtime an identity
+/// (<see cref="SessionId"/>), a per-session artifact directory, and a memory of the most recent
+/// target/observation/action/error so a multi-step task is one durable, debuggable record.
+///
+/// <para>Phase 2 (#86) introduces a single <b>ambient</b> session owned by
+/// <see cref="AgentRuntime.Session"/>; explicit <c>session/start|status|end</c> lifecycle tools and
+/// per-call session routing are Phase 3. The state recorded here is what feeds <c>sessionId</c> on
+/// every result, <c>error.lastObservation</c> on failures, and (later) #87's evidence bundle.</para>
+///
+/// All mutators are guarded by an internal lock because an <c>invoke</c> can finish on a background
+/// worker thread after the dispatching call has already returned.
+/// </summary>
+public sealed class AgentSession {
+    private readonly object _gate = new();
+    private readonly string _artifactRoot;
+    private string? _artifactDir;
+
+    private JsonObject? _activeTarget;
+    private JsonObject? _lastObservation;
+    private string? _lastAction;
+    private JsonObject? _lastError;
+
+    private AgentSession(string sessionId, DateTime startedAtUtc, string artifactRoot) {
+        SessionId = sessionId;
+        StartedAtUtc = startedAtUtc;
+        _artifactRoot = artifactRoot;
+    }
+
+    /// <summary>
+    /// Creates a session with a fresh 12-hex-char id (matching the evidence harness'
+    /// <c>New-McecSession</c> format) and a reserved — not yet created — artifact directory path under
+    /// <paramref name="artifactRoot"/>.
+    /// </summary>
+    public static AgentSession Create(string artifactRoot) =>
+        new(Guid.NewGuid().ToString("N")[..12], DateTime.UtcNow, artifactRoot);
+
+    /// <summary>Stable identifier carried on every result that ran inside this session.</summary>
+    public string SessionId { get; }
+
+    /// <summary>When the session was created (UTC).</summary>
+    public DateTime StartedAtUtc { get; }
+
+    /// <summary>The window the session is currently operating on, or null before the first target resolves.</summary>
+    public JsonObject? ActiveTarget {
+        get { lock (_gate) { return _activeTarget?.DeepClone() as JsonObject; } }
+    }
+
+    /// <summary>The most recent good observation (a query/capture/find payload), or null.</summary>
+    public JsonObject? LastObservation {
+        get { lock (_gate) { return _lastObservation?.DeepClone() as JsonObject; } }
+    }
+
+    /// <summary>The name of the most recently dispatched tool, or null.</summary>
+    public string? LastAction {
+        get { lock (_gate) { return _lastAction; } }
+    }
+
+    /// <summary>The most recent error envelope (its <c>error</c> object), or null.</summary>
+    public JsonObject? LastError {
+        get { lock (_gate) { return _lastError?.DeepClone() as JsonObject; } }
+    }
+
+    /// <summary>The reserved per-session artifact directory path (created on demand by <see cref="EnsureArtifactDir"/>).</summary>
+    public string ArtifactDir {
+        get {
+            lock (_gate) {
+                return _artifactDir ??= Path.Combine(
+                    _artifactRoot,
+                    $"{StartedAtUtc.ToString("yyyyMMdd-HHmmss", System.Globalization.CultureInfo.InvariantCulture)}-{SessionId}");
+            }
+        }
+    }
+
+    /// <summary>Records a successful observation and, when present, the target window it concerns.</summary>
+    public void RecordObservation(JsonObject? observation, JsonObject? target = null) {
+        lock (_gate) {
+            if (observation is not null) {
+                _lastObservation = observation.DeepClone() as JsonObject;
+            }
+            if (target is not null) {
+                _activeTarget = target.DeepClone() as JsonObject;
+            }
+        }
+    }
+
+    /// <summary>Records the name of the tool just dispatched.</summary>
+    public void RecordAction(string action) {
+        lock (_gate) {
+            _lastAction = action;
+        }
+    }
+
+    /// <summary>Records the most recent failure's error object.</summary>
+    public void RecordError(JsonObject error) {
+        lock (_gate) {
+            _lastError = error.DeepClone() as JsonObject;
+        }
+    }
+
+    /// <summary>Creates the per-session artifact directory if it does not yet exist and returns its path.</summary>
+    public string EnsureArtifactDir() {
+        string dir = ArtifactDir;
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>A debug/replay snapshot of the session's current state (the basis for <c>session/status</c>, Phase 3).</summary>
+    public JsonObject ToStatusJson() {
+        lock (_gate) {
+            JsonObject obj = new() {
+                ["sessionId"] = SessionId,
+                ["startedAt"] = StartedAtUtc.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
+                ["artifactDir"] = ArtifactDir,
+            };
+            if (_activeTarget is not null) {
+                obj["activeTarget"] = _activeTarget.DeepClone();
+            }
+            if (_lastAction is not null) {
+                obj["lastAction"] = _lastAction;
+            }
+            if (_lastObservation is not null) {
+                obj["lastObservation"] = _lastObservation.DeepClone();
+            }
+            if (_lastError is not null) {
+                obj["lastError"] = _lastError.DeepClone();
+            }
+            return obj;
+        }
+    }
+}

--- a/src/Agent/AgentToolResult.cs
+++ b/src/Agent/AgentToolResult.cs
@@ -64,21 +64,23 @@ public sealed class AgentToolResult {
     /// Translates a legacy <see cref="CommandResult"/> JSON object (<c>{ success, command, error, data }</c>)
     /// — what each agent command writes to its reply today — into the #101 envelope. Success carries
     /// <c>data</c> forward as <see cref="Result"/>; failure maps the free-text error onto the closed
-    /// taxonomy via <see cref="Categorize"/>.
+    /// taxonomy via <see cref="Categorize"/>. When a failure has no observation of its own,
+    /// <paramref name="lastObservation"/> (the session's last good state before this call) is attached to
+    /// <c>error.lastObservation</c> so the failure is debuggable without rerunning it.
     ///
     /// <para>One success is reclassified as a failure: <see cref="FindCommand"/> writes
     /// <c>Ok{found:false}</c> when a <c>wait-for</c> exhausts its timeout, but an agent branches on
     /// <c>ok</c> — so a wait that never resolved must surface as a <c>timeout</c> failure, not
     /// <c>ok:true</c>. A one-shot <c>find</c> miss stays a success ("a miss is not an error").</para>
     /// </summary>
-    public static AgentToolResult FromLegacy(JsonObject legacy, string toolName, string? sessionId = null) {
+    public static AgentToolResult FromLegacy(JsonObject legacy, string toolName, string? sessionId = null, JsonObject? lastObservation = null) {
         bool success = legacy["success"] is JsonValue sv && sv.TryGetValue(out bool b) && b;
         if (success) {
             JsonObject? data = (legacy["data"] as JsonObject)?.DeepClone() as JsonObject;
             if (IsWaitForMiss(toolName, data)) {
                 return Failure(
                     new AgentError("wait-condition-timeout", AgentErrorCategory.Timeout,
-                        "wait-for exhausted its timeout before the element appeared."),
+                        "wait-for exhausted its timeout before the element appeared.", lastObservation),
                     sessionId);
             }
             return Success(data, sessionId);
@@ -87,7 +89,11 @@ public sealed class AgentToolResult {
         string message = legacy["error"] is JsonValue ev && ev.TryGetValue(out string? s) && s is not null
             ? s
             : "The command failed without a message.";
-        return Failure(Categorize(toolName, message), sessionId);
+        AgentError error = Categorize(toolName, message);
+        if (lastObservation is not null) {
+            error = new AgentError(error.Code, error.Category, error.Detail, lastObservation);
+        }
+        return Failure(error, sessionId);
     }
 
     /// <summary>True when a <c>wait-for</c> returned <c>found:false</c> — i.e. it timed out.</summary>

--- a/src/Commands/FindCommand.cs
+++ b/src/Commands/FindCommand.cs
@@ -69,6 +69,9 @@ public class FindCommand : Command {
         JsonObject data = new() {
             ["found"] = found,
             ["element"] = info?.ToJsonObject(),
+            // Echo the resolved window so the session can record it as the active target (a find/wait-for
+            // that establishes the current control feeds error.lastObservation for a later failing action).
+            ["window"] = win.ToJsonObject(),
         };
         Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
         return true;

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -298,15 +298,9 @@ public static class AgentServer {
         // MCP image blocks) still get the bytes, as the result contract requires.
         JsonObject? image = name == "capture" && env.Ok ? CaptureContent.TryBuildImageBlock(env.Result) : null;
 
-        // Record this call's outcome so the next call's sessionId/lastObservation reflect it.
-        if (env.Ok) {
-            if (name is "query" or "capture" or "find") {
-                session.RecordObservation(env.Result, env.Result?["window"] as JsonObject);
-            }
-        }
-        else if (env.Error is not null) {
-            session.RecordError(env.Error.ToJsonObject());
-        }
+        // Record this call's outcome so the next call's sessionId/lastObservation reflect it. Every
+        // observation tool (wait-for included) records its observation + the resolved window as the target.
+        session.RecordToolOutcome(name, env);
 
         return McpResult(env, image);
     }

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -249,6 +249,13 @@ public static class AgentServer {
 
         AgentRuntime.Audit(name, args.ToJsonString(AgentJson.Options));
 
+        // The ambient session (#86) carries sessionId onto this result and remembers the target/
+        // observation/action/error. Snapshot the prior observation now, before this call records its own,
+        // so a failure can carry the last good state into error.lastObservation.
+        AgentSession session = AgentRuntime.Session;
+        JsonObject? priorObservation = session.LastObservation;
+        session.RecordAction(name);
+
         // `invoke` can activate a control that opens a MODAL dialog (About, Settings, message/file
         // dialogs). The UIA Invoke runs the control's click handler synchronously, so the call would
         // otherwise block — and hold ExecLock — for the dialog's whole lifetime, deadlocking every
@@ -261,7 +268,7 @@ public static class AgentServer {
         if (name == "invoke") {
             if (!TryRunInvokeWithModalGrace(cmd)) {
                 AgentRuntime.Audit(name, "dispatched; a modal dialog appears to be open — returning without blocking");
-                return McpResult(AgentToolResult.Success(InvokeModalPendingResult()));
+                return McpResult(AgentToolResult.Success(InvokeModalPendingResult(), session.SessionId));
             }
         }
         else {
@@ -273,21 +280,33 @@ public static class AgentServer {
         // Translate the legacy CommandResult the command wrote into its reply into the #101 envelope.
         string captured = reply.Captured.Trim();
         if (string.IsNullOrEmpty(captured)) {
-            return McpResult(AgentToolResult.Failure("no-output", AgentErrorCategory.Internal, $"The '{name}' command produced no output."));
+            AgentError noOutput = new("no-output", AgentErrorCategory.Internal, $"The '{name}' command produced no output.", priorObservation);
+            session.RecordError(noOutput.ToJsonObject());
+            return McpResult(AgentToolResult.Failure(noOutput, session.SessionId));
         }
 
         if (TryParse(captured) is not JsonObject legacy) {
             // An agent command always emits CommandResult JSON; a non-JSON reply is unexpected. Carry the
             // raw text forward rather than fabricating a structured error.
-            return McpResult(AgentToolResult.Success(new JsonObject { ["output"] = captured }));
+            return McpResult(AgentToolResult.Success(new JsonObject { ["output"] = captured }, session.SessionId));
         }
 
-        AgentToolResult env = AgentToolResult.FromLegacy(legacy, name);
+        AgentToolResult env = AgentToolResult.FromLegacy(legacy, name, session.SessionId, priorObservation);
 
         // For capture, additionally surface the PNG as an MCP image content block so image-aware clients
         // render it. The base64 stays in the envelope's result so text-only agents (which do not consume
         // MCP image blocks) still get the bytes, as the result contract requires.
         JsonObject? image = name == "capture" && env.Ok ? CaptureContent.TryBuildImageBlock(env.Result) : null;
+
+        // Record this call's outcome so the next call's sessionId/lastObservation reflect it.
+        if (env.Ok) {
+            if (name is "query" or "capture" or "find") {
+                session.RecordObservation(env.Result, env.Result?["window"] as JsonObject);
+            }
+        }
+        else if (env.Error is not null) {
+            session.RecordError(env.Error.ToJsonObject());
+        }
 
         return McpResult(env, image);
     }
@@ -344,11 +363,14 @@ public static class AgentServer {
             invoker.ExecuteNext();
         }
 
+        AgentSession session = AgentRuntime.Session;
+        session.RecordAction("send_command");
+
         // The legacy command path returns opaque text, not a CommandResult; carry it forward as the
         // success payload. (Native success/failure detection for send_command is out of Phase 1 scope.)
         string captured = reply.Captured.Trim();
         JsonObject result = new() { ["output"] = string.IsNullOrEmpty(captured) ? "ok" : captured };
-        return McpResult(AgentToolResult.Success(result));
+        return McpResult(AgentToolResult.Success(result, session.SessionId));
     }
 
     /// <summary>Builds and populates an agent command instance from MCP tool arguments.</summary>
@@ -576,10 +598,11 @@ public static class AgentServer {
     /// <summary>
     /// A tool-level failure (a security gate or a bad request) reported as the #101 envelope. These are
     /// MCEC-side refusals the agent cannot recover from on its own, so they map to the <c>internal</c>
-    /// category; <paramref name="code"/> distinguishes the specific cause.
+    /// category; <paramref name="code"/> distinguishes the specific cause. The ambient session's id is
+    /// attached so even a refused call tells the agent which session it belonged to.
     /// </summary>
     private static JsonObject ToolError(string message, string code = "internal-error") =>
-        McpResult(AgentToolResult.Failure(code, AgentErrorCategory.Internal, message));
+        McpResult(AgentToolResult.Failure(new AgentError(code, AgentErrorCategory.Internal, message), AgentRuntime.Session.SessionId));
 
     private static JsonObject TextContent(string text) => new() {
         ["type"] = "text",

--- a/tests/MCEControl.xUnit/Agent/AgentSessionTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentSessionTests.cs
@@ -1,0 +1,96 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Unit tests for the #86 session store (<see cref="AgentSession"/>): id format, lazily-allocated
+/// per-session artifact directory, and the target/observation/action/error state an agent and the
+/// evidence bundle read back.
+/// </summary>
+public class AgentSessionTests {
+    private static string TempRoot() =>
+        Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+
+    [Fact]
+    public void Create_GeneratesTwelveHexCharId() {
+        AgentSession session = AgentSession.Create(TempRoot());
+
+        Assert.Matches(new Regex("^[0-9a-f]{12}$"), session.SessionId);
+    }
+
+    [Fact]
+    public void Create_GivesEachSessionADistinctId() {
+        string root = TempRoot();
+        Assert.NotEqual(AgentSession.Create(root).SessionId, AgentSession.Create(root).SessionId);
+    }
+
+    [Fact]
+    public void ArtifactDir_IsUnderRootAndCarriesId_ButIsNotCreatedUntilEnsured() {
+        string root = TempRoot();
+        AgentSession session = AgentSession.Create(root);
+
+        Assert.StartsWith(root, session.ArtifactDir);
+        Assert.Contains(session.SessionId, session.ArtifactDir);
+        Assert.False(Directory.Exists(session.ArtifactDir), "artifact dir must be reserved, not created, until needed");
+    }
+
+    [Fact]
+    public void EnsureArtifactDir_CreatesTheDirectory() {
+        string root = TempRoot();
+        AgentSession session = AgentSession.Create(root);
+        try {
+            string dir = session.EnsureArtifactDir();
+
+            Assert.True(Directory.Exists(dir));
+            Assert.Equal(session.ArtifactDir, dir);
+        }
+        finally {
+            if (Directory.Exists(root)) {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void RecordObservation_SetsLastObservationAndActiveTarget() {
+        AgentSession session = AgentSession.Create(TempRoot());
+        JsonObject window = new() { ["handle"] = 42 };
+
+        session.RecordObservation(new JsonObject { ["tree"] = "x", ["window"] = window.DeepClone() }, window);
+
+        Assert.Equal("x", session.LastObservation!["tree"]!.GetValue<string>());
+        Assert.Equal(42, session.ActiveTarget!["handle"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void Getters_ReturnCopies_SoCallersCannotMutateSessionState() {
+        AgentSession session = AgentSession.Create(TempRoot());
+        session.RecordObservation(new JsonObject { ["tree"] = "x" });
+
+        session.LastObservation!["tree"] = "mutated";
+
+        Assert.Equal("x", session.LastObservation!["tree"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void RecordActionAndError_AreReflectedInStatus() {
+        AgentSession session = AgentSession.Create(TempRoot());
+        session.RecordAction("query");
+        session.RecordError(new JsonObject { ["category"] = "no-target", ["code"] = "window-not-found" });
+
+        JsonObject status = session.ToStatusJson();
+
+        Assert.Equal(session.SessionId, status["sessionId"]!.GetValue<string>());
+        Assert.Equal("query", status["lastAction"]!.GetValue<string>());
+        Assert.Equal("no-target", status["lastError"]!["category"]!.GetValue<string>());
+        Assert.False(string.IsNullOrEmpty(status["artifactDir"]!.GetValue<string>()));
+        Assert.False(string.IsNullOrEmpty(status["startedAt"]!.GetValue<string>()));
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/AgentSessionTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentSessionTests.cs
@@ -93,4 +93,43 @@ public class AgentSessionTests {
         Assert.False(string.IsNullOrEmpty(status["artifactDir"]!.GetValue<string>()));
         Assert.False(string.IsNullOrEmpty(status["startedAt"]!.GetValue<string>()));
     }
+
+    [Theory]
+    [InlineData("query")]
+    [InlineData("capture")]
+    [InlineData("find")]
+    [InlineData("wait-for")]
+    public void RecordToolOutcome_Success_RecordsObservationAndTargetForEveryObservationTool(string tool) {
+        // The Codex P2 on #116: wait-for was skipped and find/wait-for passed a null target. Each
+        // observation tool that resolves a window must record both the observation and the active target.
+        AgentSession session = AgentSession.Create(TempRoot());
+        JsonObject result = new() { ["found"] = true, ["window"] = new JsonObject { ["handle"] = 7 } };
+
+        session.RecordToolOutcome(tool, AgentToolResult.Success(result));
+
+        Assert.NotNull(session.LastObservation);
+        Assert.Equal(7, session.ActiveTarget!["handle"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void RecordToolOutcome_Action_DoesNotRecordObservation() {
+        AgentSession session = AgentSession.Create(TempRoot());
+
+        session.RecordToolOutcome("invoke", AgentToolResult.Success(new JsonObject { ["invoked"] = true }));
+
+        Assert.Null(session.LastObservation);
+        Assert.Null(session.ActiveTarget);
+    }
+
+    [Fact]
+    public void RecordToolOutcome_Failure_RecordsErrorNotObservation() {
+        AgentSession session = AgentSession.Create(TempRoot());
+        AgentToolResult failure = AgentToolResult.Failure(
+            new AgentError("window-not-found", AgentErrorCategory.NoTarget, "no window"));
+
+        session.RecordToolOutcome("query", failure);
+
+        Assert.Null(session.LastObservation);
+        Assert.Equal("no-target", session.LastError!["category"]!.GetValue<string>());
+    }
 }

--- a/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
@@ -204,6 +204,18 @@ public class AgentToolResultTests {
     }
 
     [Fact]
+    public void FromLegacy_Failure_AttachesSessionIdAndPriorObservation() {
+        JsonObject legacy = CommandResult.Fail("invoke", "No matching window").ToJsonObject();
+        JsonObject prior = new() { ["window"] = "About" };
+
+        JsonObject env = AgentToolResult.FromLegacy(legacy, "invoke", "s-1234", prior).ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.Equal("s-1234", env["sessionId"]!.GetValue<string>());
+        Assert.Equal("About", env["error"]!["lastObservation"]!["window"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void Envelope_IsCamelCaseAndOmitsNulls() {
         string json = AgentToolResult.Success(new JsonObject { ["found"] = false }).ToJson();
 

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Xunit;
@@ -110,6 +111,30 @@ public class AgentServerTests {
         }
         finally {
             AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Dispatch_ToolsCall_ResultCarriesAmbientSessionId() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = null; // exercise the disabled path; it still rides a session
+        AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+        AgentRuntime.ResetSession();
+        try {
+            JsonObject prms = new() {
+                ["name"] = "capture",
+                ["arguments"] = new JsonObject(),
+            };
+
+            JsonObject resp = AgentServer.Dispatch(Request(5, "tools/call", prms))!;
+            JsonObject envelope = JsonNode.Parse(FirstTextBlock(resp["result"]!.AsObject()))!.AsObject();
+
+            // Every result — even a refused one — names the session it ran inside (#86).
+            Assert.Equal(AgentRuntime.Session.SessionId, envelope["sessionId"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
         }
     }
 


### PR DESCRIPTION
## What

Phase 2 of the **session-runtime epic (#86)**: promote the runner-owned session into the product. Until now the C# runtime had no session awareness — every tool call was stateless and `sessionId` was always `null`. This adds a server-side **ambient session** that gives the runtime identity and a memory of the most recent target/observation/action/error across calls. Builds on Phase 1's envelope (#115).

## How

- **`AgentSession`** — a 12-hex-char `sessionId` (matching the evidence harness' `New-McecSession` format), a **lazily-created** per-session artifact directory under a configurable root (reserved as a path; `mkdir` only on `EnsureArtifactDir()`), and the `activeTarget` / `lastObservation` / `lastAction` / `lastError`. All mutators are lock-guarded because an `invoke` can finish on a background worker after its call returned. Getters return copies so callers can't mutate session state. `ToStatusJson()` is the basis for `session/status` (Phase 3).
- **`AgentRuntime`** — exposes a lazily-created ambient `Session`, an overridable `ArtifactRoot` (defaults to a `sessions` folder beside settings/logs, temp fallback), and `ResetSession()`.
- **`AgentServer` wiring** — every tool now threads the session:
  - results carry a **real `sessionId`** (observation tools, `send_command`, the invoke modal-pending path, and gate refusals);
  - a successful `query`/`capture`/`find` records the observation + active target;
  - a failure records the error **and** carries the prior good observation into **`error.lastObservation`** (via `FromLegacy`), so a failed call is debuggable without rerunning it.

## Scope boundaries

- One **ambient** session for now; explicit `session/start|status|end` lifecycle tools and per-call session routing are **Phase 3**.
- `error.lastObservation` is populated from the session's prior observation; per-tool native observations remain owned by the tool epics (#87–#91).

## Tests

- `AgentSession`: id format, reserved-then-created artifact dir, observation/action/error recording, status snapshot, copy-on-read isolation.
- `AgentToolResult.FromLegacy`: attaches `sessionId` and the prior `lastObservation` to a failure.
- `AgentServer`: results carry the ambient `sessionId` (even a refused call).
- Full suite green: **178 passed, 22 skipped** (+18).

Refs #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
