### PR TITLE
agent: fix two Codex P2 findings in the result envelope (#115 follow-up)

### DIFF
--- a/src/Agent/AgentToolResult.cs
+++ b/src/Agent/AgentToolResult.cs
@@ -65,11 +65,22 @@ public sealed class AgentToolResult {
     /// — what each agent command writes to its reply today — into the #101 envelope. Success carries
     /// <c>data</c> forward as <see cref="Result"/>; failure maps the free-text error onto the closed
     /// taxonomy via <see cref="Categorize"/>.
+    ///
+    /// <para>One success is reclassified as a failure: <see cref="FindCommand"/> writes
+    /// <c>Ok{found:false}</c> when a <c>wait-for</c> exhausts its timeout, but an agent branches on
+    /// <c>ok</c> — so a wait that never resolved must surface as a <c>timeout</c> failure, not
+    /// <c>ok:true</c>. A one-shot <c>find</c> miss stays a success ("a miss is not an error").</para>
     /// </summary>
     public static AgentToolResult FromLegacy(JsonObject legacy, string toolName, string? sessionId = null) {
         bool success = legacy["success"] is JsonValue sv && sv.TryGetValue(out bool b) && b;
         if (success) {
             JsonObject? data = (legacy["data"] as JsonObject)?.DeepClone() as JsonObject;
+            if (IsWaitForMiss(toolName, data)) {
+                return Failure(
+                    new AgentError("wait-condition-timeout", AgentErrorCategory.Timeout,
+                        "wait-for exhausted its timeout before the element appeared."),
+                    sessionId);
+            }
             return Success(data, sessionId);
         }
 
@@ -78,6 +89,11 @@ public sealed class AgentToolResult {
             : "The command failed without a message.";
         return Failure(Categorize(toolName, message), sessionId);
     }
+
+    /// <summary>True when a <c>wait-for</c> returned <c>found:false</c> — i.e. it timed out.</summary>
+    private static bool IsWaitForMiss(string toolName, JsonObject? data) =>
+        string.Equals(toolName, "wait-for", StringComparison.OrdinalIgnoreCase)
+        && data?["found"] is JsonValue fv && fv.TryGetValue(out bool found) && !found;
 
     /// <summary>
     /// Maps a legacy free-text command error onto the closed <see cref="AgentErrorCategory"/> taxonomy.

--- a/src/Agent/CaptureContent.cs
+++ b/src/Agent/CaptureContent.cs
@@ -1,0 +1,29 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// Bridges a <c>capture</c> result payload to the MCP image content transport. Per the result contract,
+/// the PNG is <b>additionally</b> emitted as an MCP <c>image</c> content block (so image-aware clients
+/// render it) while the same bytes stay referenced from the envelope's <c>result</c> for text-only
+/// agents — so this builds the image block but does <b>not</b> strip <c>base64</c> from the result.
+/// </summary>
+public static class CaptureContent {
+    /// <summary>
+    /// Returns an MCP image content block for <paramref name="result"/> when it carries a base64 PNG, or
+    /// null otherwise. The <paramref name="result"/> object is left unmodified.
+    /// </summary>
+    public static JsonObject? TryBuildImageBlock(JsonObject? result) {
+        if (result?["base64"] is JsonValue v && v.TryGetValue(out string? data) && data is not null) {
+            return new JsonObject {
+                ["type"] = "image",
+                ["data"] = data,
+                ["mimeType"] = "image/png",
+            };
+        }
+        return null;
+    }
+}

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -284,17 +284,10 @@ public static class AgentServer {
 
         AgentToolResult env = AgentToolResult.FromLegacy(legacy, name);
 
-        // For capture, surface the PNG as an MCP image content block in addition to the JSON envelope,
-        // and drop the (potentially multi-MB) base64 from the envelope text so it is not duplicated.
-        JsonObject? image = null;
-        if (name == "capture" && env.Ok && env.Result?["base64"] is JsonValue b64) {
-            image = new JsonObject {
-                ["type"] = "image",
-                ["data"] = b64.GetValue<string>(),
-                ["mimeType"] = "image/png",
-            };
-            env.Result.Remove("base64");
-        }
+        // For capture, additionally surface the PNG as an MCP image content block so image-aware clients
+        // render it. The base64 stays in the envelope's result so text-only agents (which do not consume
+        // MCP image blocks) still get the bytes, as the result contract requires.
+        JsonObject? image = name == "capture" && env.Ok ? CaptureContent.TryBuildImageBlock(env.Result) : null;
 
         return McpResult(env, image);
     }

--- a/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
@@ -166,6 +166,44 @@ public class AgentToolResultTests {
     }
 
     [Fact]
+    public void FromLegacy_WaitForMiss_BecomesTimeoutFailure() {
+        // FindCommand writes Ok{found:false} when a wait-for exhausts its timeout. An agent branches on
+        // `ok`, so that must surface as a timeout failure, not ok:true (Codex P2 on #115).
+        JsonObject legacy = CommandResult.Ok("wait-for", new JsonObject { ["found"] = false, ["element"] = null }).ToJsonObject();
+
+        JsonObject env = AgentToolResult.FromLegacy(legacy, "wait-for").ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.False(env["ok"]!.GetValue<bool>());
+        Assert.Equal("timeout", env["error"]!["category"]!.GetValue<string>());
+        Assert.Equal("wait-condition-timeout", env["error"]!["code"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void FromLegacy_WaitForHit_StaysSuccess() {
+        JsonObject legacy = CommandResult.Ok("wait-for",
+            new JsonObject { ["found"] = true, ["element"] = new JsonObject { ["name"] = "OK" } }).ToJsonObject();
+
+        JsonObject env = AgentToolResult.FromLegacy(legacy, "wait-for").ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.True(env["ok"]!.GetValue<bool>());
+        Assert.True(env["result"]!["found"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void FromLegacy_FindMiss_StaysSuccess() {
+        // A one-shot `find` miss is not an error ("a miss is not an error"); only a timed-out wait-for is.
+        JsonObject legacy = CommandResult.Ok("find", new JsonObject { ["found"] = false }).ToJsonObject();
+
+        JsonObject env = AgentToolResult.FromLegacy(legacy, "find").ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.True(env["ok"]!.GetValue<bool>());
+        Assert.False(env["result"]!["found"]!.GetValue<bool>());
+    }
+
+    [Fact]
     public void Envelope_IsCamelCaseAndOmitsNulls() {
         string json = AgentToolResult.Success(new JsonObject { ["found"] = false }).ToJson();
 

--- a/tests/MCEControl.xUnit/Agent/CaptureContentTests.cs
+++ b/tests/MCEControl.xUnit/Agent/CaptureContentTests.cs
@@ -1,0 +1,38 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Tests for <see cref="CaptureContent"/>: building the MCP image content block for a capture result
+/// WITHOUT stripping the base64 bytes from the envelope's <c>result</c>. The contract says the PNG is
+/// "additionally" emitted as an image block while "the same image is referenced from result for
+/// text-only agents" — so clients that parse the envelope text but ignore MCP image blocks must still
+/// get the bytes (Codex P2 on #115).
+/// </summary>
+public class CaptureContentTests {
+    [Fact]
+    public void TryBuildImageBlock_BuildsImageBlock_AndLeavesBase64InResult() {
+        JsonObject result = new() { ["width"] = 10, ["base64"] = "QUJD" };
+
+        JsonObject? block = CaptureContent.TryBuildImageBlock(result);
+
+        Assert.NotNull(block);
+        Assert.Equal("image", block!["type"]!.GetValue<string>());
+        Assert.Equal("QUJD", block["data"]!.GetValue<string>());
+        Assert.Equal("image/png", block["mimeType"]!.GetValue<string>());
+
+        // The bytes remain reachable from the result for text-only agents.
+        Assert.Equal("QUJD", result["base64"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void TryBuildImageBlock_ReturnsNull_WhenNoBase64() {
+        Assert.Null(CaptureContent.TryBuildImageBlock(new JsonObject { ["width"] = 10 }));
+        Assert.Null(CaptureContent.TryBuildImageBlock(null));
+    }
+}


### PR DESCRIPTION
## What

Test-first fixes for the two **Codex P2 findings** on merged PR #115 (the result-envelope work).

### 1. `wait-for` timeout no longer reads as success
`FindCommand` writes `Ok{found:false}` when a `wait-for` exhausts its timeout. The Phase 1 mapping translated that to **`ok:true`**, so an agent — which `AgentServer.Instructions` tells to branch on `ok` before acting — would sail past a control that never appeared instead of recovering via `error.category:"timeout"`.

`FromLegacy` now reclassifies a `wait-for` miss as an `ok:false` **`timeout`** failure (`code:"wait-condition-timeout"`). A one-shot **`find`** miss still stays `ok:true` — "a miss is not an error" — so only the timed-out wait flips.

### 2. `capture` keeps the PNG reachable from `result`
The boundary copied `base64` into the MCP image content block and then **removed it from the envelope's `result`**. Clients that parse the envelope text but don't consume MCP image blocks (text-only agents) lost the screenshot bytes. The contract says the image block is *additional* and "the same image is referenced from `result` for text-only agents."

New `CaptureContent.TryBuildImageBlock` builds the image block **without** stripping `base64` from `result`. (Tradeoff: the bytes now ride in both the image block and the result text; that duplication is what the contract asks for so neither client class is starved.)

## Tests (written first)

- `AgentToolResultTests`: `wait-for` miss → timeout failure; `wait-for` hit → success; `find` miss → success.
- `CaptureContentTests`: image block shape + `base64` retained in `result`; null when no image.
- Confirmed red before the fix (the timeout test failed against current behavior), green after. Full suite: **174 passed, 22 skipped**.

Refs #86, #101. Follows #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
