### PR TITLE
agent/trace: fix Codex CR bugs #107, #109, #110

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,10 @@ in sync. In short:
 >    `tree-truncated` warning) hit the node cap — raise `maxNodes` or target a deeper window. `warnings`
 >    are non-fatal; `errorCategory` tells you how to recover. (Shape: `docs/design/agent-tool-result-contract.md`.)
 > 3. **Act** — prefer `invoke` (`by` name/automationId/classname; `action` invoke|toggle|setvalue|
->    setfocus) over coordinate clicks. Use `find`/`wait-for` to wait for a control. `send_command`
->    sends any raw MCEC command (keystrokes, mouse, launch).
+>    setfocus) over coordinate clicks. `invoke` **fast-fails** if the control isn't present (it does not
+>    wait), so `find`/`wait-for` the control first; an `invoke` that returns `no-target` means it hasn't
+>    appeared yet — `wait-for` it rather than retrying blindly. `send_command` sends any raw MCEC command
+>    (keystrokes, mouse, launch).
 > 4. **Verify** with another `query`/`capture`.
 
 ## Security (do not regress)

--- a/scripts/McecEvidence.psm1
+++ b/scripts/McecEvidence.psm1
@@ -62,8 +62,11 @@ function Write-McecToolCall {
     if ($Session.Truncated) { return }
     $entry = [ordered]@{ ts = (Get-Date).ToString("o"); sessionId = $Session.SessionId; direction = $Direction; method = $Method; payload = $Payload }
     $json = ($entry | ConvertTo-Json -Depth 20 -Compress)
-    # Privacy + size: keep image bytes out of the transcript — the PNG is a separate artifact.
-    $json = [regex]::Replace($json, '("(?:data|base64)"\s*:\s*")[A-Za-z0-9+/=]{200,}(")', '${1}<redacted base64>${2}')
+    # Privacy + size: keep image bytes out of the transcript — the PNG is a separate artifact. Redact by
+    # field (the capture `base64` value and an image content block's `data`) regardless of length: a small
+    # region capture can produce a PNG whose base64 is well under any length threshold, and a length gate
+    # would leak those screen bytes into the transcript (#110).
+    $json = [regex]::Replace($json, '("(?:data|base64)"\s*:\s*")[A-Za-z0-9+/=]+(")', '${1}<redacted base64>${2}')
     if ($Session.ToolCallBytes + $json.Length -gt $script:MaxToolCallBytes) {
         Add-Content -Path $Session.ToolCallLog -Value '{"truncated":"tool-call log size cap reached"}' -Encoding utf8
         $Session.Truncated = $true

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -3,6 +3,7 @@
 
 using System.Drawing;
 using System.Runtime.InteropServices;
+using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Conditions;
 using FlaUI.Core.Tools;
@@ -17,6 +18,16 @@ namespace MCEControl;
 /// or unsupported node must never abort the whole walk.
 /// </summary>
 public static class UiaService {
+    /// <summary>
+    /// Timeout for the element lookup an <c>invoke</c> performs before dispatching its action. It is kept
+    /// below <see cref="AgentServer.InvokeModalGraceMs"/> on purpose: the grace assumes that an invoke
+    /// still running afterward is blocked on a modal dialog, so the lookup itself must finish first — a
+    /// missing element must fail fast (no-target) rather than be misreported as a pending modal (#107).
+    /// Agents are instructed to <c>wait-for</c>/<c>find</c> a control before acting on it, so invoke does
+    /// not need a long implicit wait of its own.
+    /// </summary>
+    public const int InvokeFindTimeoutMs = 500;
+
     /// <summary>
     /// Snapshots the UIA tree rooted at <paramref name="hwnd"/> down to <paramref name="maxDepth"/>
     /// levels (depth 0 = the root node only) and at most <paramref name="maxNodes"/> nodes. The node
@@ -33,7 +44,11 @@ public static class UiaService {
             using UIA3Automation automation = new();
             AutomationElement root = automation.FromHandle(hwnd);
             UiaTreeBudget budget = new() { MaxNodes = maxNodes <= 0 ? int.MaxValue : maxNodes };
-            UiaElementInfo node = BuildNode(root, 0, maxDepth, budget);
+            // Walk children one at a time with the control-view walker rather than materializing every
+            // child up front: a container with thousands of immediate children must not be fully
+            // enumerated just to emit a handful before the node cap bites (#109).
+            ITreeWalker walker = automation.TreeWalkerFactory.GetControlViewWalker();
+            UiaElementInfo node = BuildNode(root, 0, maxDepth, budget, walker);
             return new UiaTreeResult(node, budget.Count, budget.Truncated);
         }
         catch (Exception e) {
@@ -87,7 +102,7 @@ public static class UiaService {
         try {
             using UIA3Automation automation = new();
             AutomationElement root = automation.FromHandle(hwnd);
-            AutomationElement? el = FindElement(root, by, value, 5000);
+            AutomationElement? el = FindElement(root, by, value, InvokeFindTimeoutMs);
             if (el is null) {
                 return false;
             }
@@ -115,33 +130,41 @@ public static class UiaService {
             _ => false,
         };
 
-    private static UiaElementInfo BuildNode(AutomationElement el, int depth, int maxDepth, UiaTreeBudget budget) {
+    private static UiaElementInfo BuildNode(AutomationElement el, int depth, int maxDepth, UiaTreeBudget budget, ITreeWalker walker) {
         budget.Count++;
         UiaElementInfo info = Describe(el);
         if (depth >= maxDepth) {
             return info;
         }
 
-        AutomationElement[] children;
+        AutomationElement? child;
         try {
-            children = el.FindAllChildren();
+            child = walker.GetFirstChild(el);
         }
         catch (COMException) {
             // Element went stale; return what we have so far.
             return info;
         }
 
-        foreach (AutomationElement child in children) {
+        while (child is not null) {
             if (budget.Count >= budget.MaxNodes) {
-                // Hit the node cap: stop expanding and flag it so the caller surfaces a warning.
+                // Hit the node cap: stop expanding and flag it so the caller surfaces a warning. Because
+                // we never materialized the remaining siblings, the cap also bounds the UIA enumeration.
                 budget.Truncated = true;
                 break;
             }
             try {
-                info.Children.Add(BuildNode(child, depth + 1, maxDepth, budget));
+                info.Children.Add(BuildNode(child, depth + 1, maxDepth, budget, walker));
             }
             catch (COMException) {
                 // Skip a node that went stale mid-walk; keep the rest of the tree.
+            }
+            try {
+                child = walker.GetNextSibling(child);
+            }
+            catch (COMException) {
+                // Can't advance past a stale node; stop this level with what we have.
+                break;
             }
         }
         return info;

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -116,8 +116,10 @@ public static class AgentServer {
         "until opened), then `invoke` the item. Invoking a control that opens a MODAL dialog (About, " +
         "Settings, message/file dialogs) returns promptly with `modalPending:true` — the action " +
         "completes when the dialog closes — so just `query`/`capture` the new window to read it, and " +
-        "`invoke` its buttons to dismiss it. Use `wait-for` (or `find` with a timeout) to wait for a " +
-        "control to appear before acting. " +
+        "`invoke` its buttons to dismiss it. `invoke` does NOT wait for a control — it fast-fails if the " +
+        "element isn't present yet — so `wait-for` (or `find` with a timeout) the control before acting; " +
+        "an `invoke` that returns `error.category:no-target` means the control hasn't appeared yet, so " +
+        "`wait-for` it rather than blindly retrying. " +
         "`send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
         "4. VERIFY with another `query` or `capture` — always confirm the act had the intended effect.\n" +
         "RESULTS: every tool returns one envelope — `{ ok, result?, warnings?, error? }`. Branch on `ok` " +

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -306,7 +306,9 @@ public static class AgentServer {
     }
 
     // Grace period for an `invoke` to complete before we assume it opened a modal dialog and return.
-    private const int InvokeModalGraceMs = 750;
+    // Must stay above UiaService.InvokeFindTimeoutMs so an invoke's element lookup always resolves within
+    // the grace — otherwise a missing element would be misreported as a pending modal (see #107).
+    public const int InvokeModalGraceMs = 750;
 
     private static JsonObject InvokeModalPendingResult() => new() {
         ["invoked"] = true,

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -138,6 +138,17 @@ public class AgentServerTests {
         }
     }
 
+    [Fact]
+    public void InvokeFindTimeout_StaysBelowModalGrace_SoMissesAreNotReportedAsPendingModals() {
+        // #107: invoke runs on a worker and is declared "modal pending" if it outlives the grace. If the
+        // element lookup could take longer than the grace, an ordinary lookup miss (misspelled name, menu
+        // not expanded) would be misreported as a pending modal success. The find must resolve within the
+        // grace, so a worker still running afterward can only be a genuinely blocking action.
+        Assert.True(
+            UiaService.InvokeFindTimeoutMs < AgentServer.InvokeModalGraceMs,
+            $"invoke find timeout ({UiaService.InvokeFindTimeoutMs}ms) must be < modal grace ({AgentServer.InvokeModalGraceMs}ms)");
+    }
+
     private static string FirstTextBlock(JsonObject toolResult) {
         foreach (JsonNode? block in toolResult["content"]!.AsArray()) {
             if (block?["type"]?.GetValue<string>() == "text") {


### PR DESCRIPTION
## What

Fixes the three remaining **Codex P2 findings** from the recent merged PRs (#105, #90, #87) — the ones outside the result-envelope work that #117 covered.

### #107 — invoke no longer reports absent controls as a pending modal
`invoke` runs on a worker and is declared `modalPending:true` if it outlives a 750 ms grace (so a modal opener doesn't deadlock later calls). But `UiaService.Invoke` looked the element up with a **5 s** timeout, so an ordinary lookup miss (misspelled name, an un-expanded menu) left the worker still in `FindElement` past the grace — and a **failed action was reported as success**, leaving the agent to continue from the wrong state.

Fix: the invoke find timeout is now `UiaService.InvokeFindTimeoutMs = 500`, kept **below** `AgentServer.InvokeModalGraceMs` (750). The lookup always resolves within the grace, so a worker still running afterward can only be a genuinely blocking action. A unit test pins the `find < grace` invariant. (Agents are already instructed to `wait-for`/`find` before acting, so invoke needs no long implicit wait.)

### #109 — UIA tree enumeration is bounded by the node cap
`BuildNode` called `FindAllChildren()`, materializing **every** immediate child of a container before the node cap was checked — so a container with thousands of children was fully enumerated just to emit a handful. It now walks children one at a time with the control-view `TreeWalker` (`GetFirstChild`/`GetNextSibling`), stopping at the budget, so the cap bounds the UIA enumeration itself, not just the serialized JSON.

### #110 — small capture PNGs no longer leak into the transcript
The evidence-bundle redactor only replaced base64 values **≥ 200 chars**, so a small-region capture (short base64) leaked screen bytes into `tool-calls.jsonl`, violating the bundle's "image bytes never enter the transcript" guarantee. Now redacts the `data`/`base64` field values by key regardless of length.

## Tests / verification

- **#107**: unit test asserts `InvokeFindTimeoutMs < InvokeModalGraceMs` — a regression guard for exactly this bug. Full xUnit suite green (**190 passed, 22 skipped**).
- **#109**: COM/FlaUI path (not unit-testable without a desktop); covered by the gated desktop E2E that drives a real `query`/`DumpTree`. Compiles against the FlaUI `ITreeWalker` API.
- **#110**: PowerShell (no Pester harness in-repo); verified the new regex redacts short base64 while leaving `mimeType` and ordinary string fields intact.

Refs #107, #109, #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
