### PR TITLE
docs: deeper hero GIF — settings-tab tour, mouse resize + title-bar drag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,10 @@ in sync. In short:
 >    setfocus) over coordinate clicks. `invoke` **fast-fails** if the control isn't present (it does not
 >    wait), so `find`/`wait-for` the control first; an `invoke` that returns `no-target` means it hasn't
 >    appeared yet — `wait-for` it rather than retrying blindly. `send_command` sends any raw MCEC command
->    (keystrokes, mouse, launch).
+>    (keystrokes, mouse, launch). To **drag** — resize a window by its sizing border, move one by its
+>    title bar, or drag a slider/handle (no `invoke` for these) — send a press-move-release sequence:
+>    `mouse:mt,x,y` to the start, `mouse:lbd`, a stream of `mouse:mt,x,y` along the path, then `mouse:lbu`
+>    (absolute screen pixels; pause briefly between moves). Re-`query` after — bounds have moved.
 > 4. **Verify** with another `query`/`capture`.
 
 ## Security (do not regress)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 By Tig Kindel ([@tigkindel on Twitter](http://www.twitter.com/ckindel)) - Copyright © [Kindel](http://www.kindel.com), LLC.
 
-![mcec](https://tig.github.io/mcec/hero.gif "MCEC — one agent driving another: launch, Help ▸ About, File ▸ Settings, File ▸ Exit, recorded with MCEC's own agent tools")
+![mcec](https://tig.github.io/mcec/hero.gif "MCEC — one agent driving another: launch, File ▸ Settings (every tab), mouse-resize, drag the title bar in circles, Help ▸ About, recorded with MCEC's own agent tools")
 
 **MCEC** (Model Context Environment Controller) is eyes, hands, and a safe front door for agents on Windows; and the same battle-tested remote control for smart-home systems.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 By Tig Kindel ([@tigkindel on Twitter](http://www.twitter.com/ckindel)) - Copyright © [Kindel](http://www.kindel.com), LLC.
 
-![mcec](https://tig.github.io/mcec/hero.gif "MCEC — one agent driving another: launch, File ▸ Settings (every tab), mouse-resize, drag the title bar in circles, Help ▸ About, recorded with MCEC's own agent tools")
+![mcec](docs/hero.gif "MCEC — one agent driving another: launch, File ▸ Settings (every tab), mouse-resize, drag the title bar in circles, Help ▸ About, recorded with MCEC's own agent tools")
 
 **MCEC** (Model Context Environment Controller) is eyes, hands, and a safe front door for agents on Windows; and the same battle-tested remote control for smart-home systems.
 

--- a/docs/hero-gif.md
+++ b/docs/hero-gif.md
@@ -65,4 +65,29 @@ Connect to the controller (`mcec.exe --mcp`) and, after the subject is launched 
 The GIF encoder writes full (non-diffed) frames, so **file size ≈ frame count × frame area**. The
 deeper tour is tuned to ~13 s → ~42 frames → ≈2 MB at 440 px wide, 4 fps. To shrink it further, lower
 `fps`, lower `maxWidth`, or trim the per-step dwell `Start-Sleep`s; to make it richer, raise them.
+
+## Toward script-free recreation
+
+The point of MCEC is that an **agent** drives complex GUI tasks easily — so the goal is that an agent
+reads *this file* and recreates the hero with **nothing but `mcec.exe`**, no `.ps1`. The script is a
+stopgap for the steps MCEC can't yet express as agent tool calls. What it does outside the agent
+surface, and the capability that would remove each (tracking issues):
+
+| Script does (not via MCEC) | Needed capability | Issue |
+|---|---|---|
+| `GetSystemMetrics`/`SetProcessDPIAware`, then normalizes every pixel to `mouse:mt`'s 0–65535 space | pixel-/element-relative mouse targeting + a `displays` query (the keystone — `query` gives pixels, `mouse` wants normalized) | #122 |
+| `mouse:lbd` + a stream of `mouse:mt` + `mouse:lbu` for the resize and the circular move | a first-class `drag` action | #123 |
+| Resize 25% / move by dragging the chrome; pins `WindowLocation`/`WindowSize`; `Shell.MinimizeAll()` | window-management actions (move/resize/min/max/foreground; clean-desktop) | #124 |
+| Clicks each Settings tab header by computed pixel center | a `select` action (SelectionItem) — `invoke` is a no-op on tabs | #125 |
+| `Start-Process` to launch the subject | a gated launch action | #126 |
+| Computes a fixed `{x,y,w,h}` record region | `record { handle }`, optionally following the window | #127 |
+| Polls `query` for the subject window / Settings dialog to appear | wait-for-**window** predicate | #112 |
+
+Menus **are** already script-free in principle (`invoke … action:expand` then `invoke` the item), but
+the tour still opens Settings with a keystroke because invoking a menu item that opens a **modal**
+dialog currently wedges later UIA queries of that dialog (#128) — needed here to read the tab bounds.
+
+Deliberately **out of scope** for the agent: provisioning the isolated subject and enabling the
+actuation gates (`AgentCommandsEnabled`, per-command `Enabled`). An agent enabling its own input would
+defeat the security model, so an operator does that first; the agent's recipe begins after.
 </content>

--- a/docs/hero-gif.md
+++ b/docs/hero-gif.md
@@ -3,13 +3,16 @@
 `docs/hero.gif` is the hero image shown at the top of [`README.md`](../README.md) and the docs
 home page ([`docs/index.md`](index.md), served at `https://tig.github.io/mcec/hero.gif`). It is
 MCEC dogfooding itself: a **headless controller** (`mcec.exe --mcp`) drives a **second MCEC** through
-its whole life — launch → **Help ▸ About** → **File ▸ Settings** → **File ▸ Exit** — and records the
-session to an animated GIF with the agent [`record`](agent-server.md#record--capturing-change-over-time)
-tool added in #80. No external screen-recorder is involved.
+a guided tour — launch → **File ▸ Settings** (visit every tab) → **mouse-resize** the window ~25%
+smaller by dragging its sizing border → **drag the title bar in small circles** → **Help ▸ About** →
+pause — and records the session to an animated GIF with the agent
+[`record`](agent-server.md#record--capturing-change-over-time) tool added in #80. The resize and move
+exercise the mouse-drag input path (button-down → a stream of absolute moves → button-up), not just
+clicks. No external screen-recorder is involved.
 
 ## One-shot regeneration
 
-On an interactive Windows session you can leave alone for ~20 seconds (it drives the real mouse,
+On an interactive Windows session you can leave alone for ~30 seconds (it drives the real mouse,
 keyboard, and launches an app):
 
 ```powershell
@@ -36,11 +39,12 @@ It is the executable form of these decisions — replicate them if reproducing b
    `AgentCommandsEnabled=true` and enables `capture`/`query`/`record`/`mouse` and the keystroke
    commands in `mcec.commands`. (The `--mcp` controller has no `MainWindow`, so it never starts the
    socket server and never prompts.)
-4. **Clean backdrop.** All desktop windows are minimized (`Shell.Application.MinimizeAll()`) before
-   recording, and the region is **cropped to the pinned window** (the About/Settings dialogs are
-   `CenterParent`, so they fall inside it) — so the hero is just the app, no wallpaper, and compact.
-5. **Record.** `record action:start` over the window region at a low fps, then drive the menus, then
-   `record action:stop file:docs/hero.gif`.
+4. **Backdrop.** All desktop windows are minimized (`Shell.Application.MinimizeAll()`) before
+   recording. The recorded region is the window's **original** pinned rect; once the tour resizes and
+   moves the window, the desktop wallpaper shows through the freed area, so a **solid-color wallpaper**
+   gives the cleanest hero. (The Settings/About dialogs are `CenterParent`, so they stay in frame.)
+5. **Record.** `record action:start` over the window region at a low fps, then drive the tour (settings
+   tabs, resize-drag, title-bar circles, About), then `record action:stop file:docs/hero.gif`.
 
 ## Manual MCP equivalent (no script)
 
@@ -48,15 +52,16 @@ Connect to the controller (`mcec.exe --mcp`) and, after the subject is launched 
 
 | Step | Tool call |
 |------|-----------|
-| Start | `record` `{ action:"start", x, y, width, height, fps:4, maxWidth:680 }` (region = the subject window) |
-| About | `query` the window → click the **Help** menu item's rect (`send_command` `mouse:mt,…` + `mouse:lbc`) → send `A` |
-| Settings | dismiss About (`Esc`) → click **File** → send `S` |
-| Exit | dismiss Settings (`Esc`) → click **File** → send `X` |
-| Stop | `record` `{ action:"stop", file:"docs/hero.gif" }` |
+| Start | `record` `{ action:"start", x, y, width, height, fps:4, maxWidth:680 }` (region = the subject window's pinned rect) |
+| Settings | click **File** → send `S` → `query` the **Settings** window → click each tab header's rect (`mouse:mt,…` + `mouse:lbc`) in turn → `Esc` |
+| Resize | drag the bottom-right sizing border inward: `mouse:mt` to the corner → `mouse:lbd` → a few `mouse:mt` moves → `mouse:lbu` |
+| Move | drag the title bar in circles: `mouse:mt` onto the title bar → `mouse:lbd` → `mouse:mt` around a small circle → `mouse:lbu` |
+| About | re-`query` the (moved) window → click the **Help** menu item's rect → send `A` |
+| Stop | pause on the About box → `record` `{ action:"stop", file:"docs/hero.gif" }` |
 
 ## Tuning size
 
-The GIF encoder writes full (non-diffed) frames, so **file size ≈ frame count × frame area**. To
-shrink the hero, lower `fps`, lower `maxWidth`, or trim the per-dialog dwell `Start-Sleep`s in the
-script. The committed asset targets ≈4 MB at 680 px wide, 4 fps.
+The GIF encoder writes full (non-diffed) frames, so **file size ≈ frame count × frame area**. The
+deeper tour runs ~23 s → ~70 frames → ≈8 MB at 680 px wide, 4 fps. To shrink the hero, lower `fps`,
+lower `maxWidth`, or trim the per-step dwell `Start-Sleep`s in the script.
 </content>

--- a/docs/hero-gif.md
+++ b/docs/hero-gif.md
@@ -41,8 +41,9 @@ It is the executable form of these decisions — replicate them if reproducing b
    socket server and never prompts.)
 4. **Backdrop.** All desktop windows are minimized (`Shell.Application.MinimizeAll()`) before
    recording. The recorded region is the window's **original** pinned rect; once the tour resizes and
-   moves the window, the desktop wallpaper shows through the freed area, so a **solid-color wallpaper**
-   gives the cleanest hero. (The Settings/About dialogs are `CenterParent`, so they stay in frame.)
+   moves the window, the desktop wallpaper shows through the freed area — so whatever wallpaper is set
+   becomes the hero's backdrop (a calm, low-detail one keeps the file smaller; a busy photo is fine but
+   costs bytes). (The Settings/About dialogs are `CenterParent`, so they stay in frame.)
 5. **Record.** `record action:start` over the window region at a low fps, then drive the tour (settings
    tabs, resize-drag, title-bar circles, About), then `record action:stop file:docs/hero.gif`.
 
@@ -52,7 +53,7 @@ Connect to the controller (`mcec.exe --mcp`) and, after the subject is launched 
 
 | Step | Tool call |
 |------|-----------|
-| Start | `record` `{ action:"start", x, y, width, height, fps:4, maxWidth:680 }` (region = the subject window's pinned rect) |
+| Start | `record` `{ action:"start", x, y, width, height, fps:4, maxWidth:600 }` (region = the subject window's pinned rect) |
 | Settings | click **File** → send `S` → `query` the **Settings** window → click each tab header's rect (`mouse:mt,…` + `mouse:lbc`) in turn → `Esc` |
 | Resize | drag the bottom-right sizing border inward: `mouse:mt` to the corner → `mouse:lbd` → a few `mouse:mt` moves → `mouse:lbu` |
 | Move | drag the title bar in circles: `mouse:mt` onto the title bar → `mouse:lbd` → `mouse:mt` around a small circle → `mouse:lbu` |
@@ -62,6 +63,6 @@ Connect to the controller (`mcec.exe --mcp`) and, after the subject is launched 
 ## Tuning size
 
 The GIF encoder writes full (non-diffed) frames, so **file size ≈ frame count × frame area**. The
-deeper tour runs ~23 s → ~70 frames → ≈8 MB at 680 px wide, 4 fps. To shrink the hero, lower `fps`,
-lower `maxWidth`, or trim the per-step dwell `Start-Sleep`s in the script.
+deeper tour is tuned to ~14 s → ~46 frames → ≈4 MB at 600 px wide, 4 fps. To shrink it further, lower
+`fps`, lower `maxWidth`, or trim the per-step dwell `Start-Sleep`s; to make it richer, raise them.
 </content>

--- a/docs/hero-gif.md
+++ b/docs/hero-gif.md
@@ -53,7 +53,7 @@ Connect to the controller (`mcec.exe --mcp`) and, after the subject is launched 
 
 | Step | Tool call |
 |------|-----------|
-| Start | `record` `{ action:"start", x, y, width, height, fps:4, maxWidth:600 }` (region = the subject window's pinned rect) |
+| Start | `record` `{ action:"start", x, y, width, height, fps:4, maxWidth:440 }` (region = the subject window's pinned rect) |
 | Settings | click **File** → send `S` → `query` the **Settings** window → click each tab header's rect (`mouse:mt,…` + `mouse:lbc`) in turn → `Esc` |
 | Resize | drag the bottom-right sizing border inward: `mouse:mt` to the corner → `mouse:lbd` → a few `mouse:mt` moves → `mouse:lbu` |
 | Move | drag the title bar in circles: `mouse:mt` onto the title bar → `mouse:lbd` → `mouse:mt` around a small circle → `mouse:lbu` |
@@ -63,6 +63,6 @@ Connect to the controller (`mcec.exe --mcp`) and, after the subject is launched 
 ## Tuning size
 
 The GIF encoder writes full (non-diffed) frames, so **file size ≈ frame count × frame area**. The
-deeper tour is tuned to ~14 s → ~46 frames → ≈4 MB at 600 px wide, 4 fps. To shrink it further, lower
+deeper tour is tuned to ~13 s → ~42 frames → ≈2 MB at 440 px wide, 4 fps. To shrink it further, lower
 `fps`, lower `maxWidth`, or trim the per-step dwell `Start-Sleep`s; to make it richer, raise them.
 </content>

--- a/scripts/Generate-HeroGif.ps1
+++ b/scripts/Generate-HeroGif.ps1
@@ -2,17 +2,21 @@
 <#
 .SYNOPSIS
   Regenerates the MCEC hero GIF (docs/hero.gif): one MCEC instance drives another through
-  launch -> Help > About -> File > Settings -> File > Exit, recording it with the agent `record` tool.
+  launch -> File > Settings (tour every tab) -> mouse-resize the window ~25% smaller ->
+  drag the title bar in small circles -> Help > About -> pause, recording it with the agent
+  `record` tool.
 
 .DESCRIPTION
-  Dogfoods the #80 `record` feature. A headless controller (`mcec.exe --mcp`) runs from the repo
-  build dir; the *controlled* subject is a SEPARATE COPY of the build in its own directory so it reads
-  a co-located config (Program.ConfigPath == the exe's own folder). The subject's config sets
-  ActAsServer=false (so it never binds IPAddress.Any:5150 and never triggers the Windows Firewall
-  prompt that would steal focus) and pins the window location/size so the recorded region is
-  deterministic. All desktop windows are minimized first for a clean backdrop.
+  Dogfoods the #80 `record` feature and exercises the mouse-drag input path (button-down,
+  a stream of absolute moves, button-up) for both a sizing-border resize and a title-bar move.
+  A headless controller (`mcec.exe --mcp`) runs from the repo build dir; the *controlled*
+  subject is a SEPARATE COPY of the build in its own directory so it reads a co-located config
+  (Program.ConfigPath == the exe's own folder). The subject's config sets ActAsServer=false (so
+  it never binds IPAddress.Any:5150 and never triggers the Windows Firewall prompt that would
+  steal focus) and pins the window location/size so the recorded region is deterministic. All
+  desktop windows are minimized first for a clean backdrop.
 
-  This drives the REAL desktop (mouse, keystrokes, launching an app) for ~20s. Run it on an
+  This drives the REAL desktop (mouse, keystrokes, launching an app) for ~30s. Run it on an
   interactive session you can leave alone.
 
 .PARAMETER Config
@@ -114,9 +118,18 @@ function Rpc([string]$method, $prms) {
 }
 function Tool([string]$name, $toolArgs) { Rpc 'tools/call' @{ name = $name; arguments = $toolArgs } }
 function Cmd([string]$command) { Tool 'send_command' @{ command = $command } | Out-Null }
-function ClickAbs([int]$cx, [int]$cy) {
+function MoveAbs([int]$cx, [int]$cy) {
   Cmd ("mouse:mt,{0},{1}" -f [int][math]::Round($cx * 65535.0 / ($sw - 1)), [int][math]::Round($cy * 65535.0 / ($sh - 1)))
-  Cmd 'mouse:lbc'
+}
+function ClickAbs([int]$cx, [int]$cy) { MoveAbs $cx $cy; Cmd 'mouse:lbc' }
+# Drag with the left button held down through a path of absolute screen points: button-down on
+# the first point, a move to each subsequent point (with a dwell so the 4fps recorder catches it),
+# button-up at the end. Used for both the sizing-border resize and the title-bar move.
+function Drag($points) {
+  MoveAbs $points[0][0] $points[0][1]; Start-Sleep -Milliseconds 150
+  Cmd 'mouse:lbd'; Start-Sleep -Milliseconds 200
+  foreach ($p in $points[1..($points.Count - 1)]) { MoveAbs $p[0] $p[1]; Start-Sleep -Milliseconds 130 }
+  Start-Sleep -Milliseconds 150; Cmd 'mouse:lbu'
 }
 function Find($node, [scriptblock]$pred) {
   if (& $pred $node) { return $node }
@@ -124,8 +137,10 @@ function Find($node, [scriptblock]$pred) {
   return $null
 }
 function QueryTree([string]$window, [int]$depth = 5) {
+  # The MCP text block holds the agent envelope { ok, sessionId, result:{ window, tree, ... } }
+  # (AgentToolResult.ToJsonObject). The UIA snapshot is at result.tree.
   foreach ($b in (Tool 'query' @{ window = $window; maxDepth = $depth }).result.content) {
-    if ($b.type -eq 'text') { try { return ($b.text | ConvertFrom-Json).data.tree } catch { return $null } }
+    if ($b.type -eq 'text') { try { return ($b.text | ConvertFrom-Json).result.tree } catch { return $null } }
   }
   return $null
 }
@@ -155,24 +170,64 @@ try {
   $tree = QueryTree 'MCEC' 5        # re-query so the menu bar is fully built before we locate it
 
   $isMenu = { param($n) ($n.controlType -match 'MenuItem') }
-  $help = Find $tree { param($n) (& $isMenu $n) -and $n.name -eq 'Help' }
   $file = Find $tree { param($n) (& $isMenu $n) -and $n.name -eq 'File' }
-  if (-not $help -or -not $file) { throw 'File/Help menu items not found' }
+  if (-not $file) { throw 'File menu item not found' }
 
-  # Help > About
+  # --- File > Settings, then tour every tab (click each header in order) ---
+  ClickAbs ([int]($file.x + $file.width / 2)) ([int]($file.y + $file.height / 2))
+  Start-Sleep -Milliseconds 600; Cmd 'key_s'      # 'S'ettings mnemonic on the open File menu
+
+  $stree = $null
+  for ($i = 0; $i -lt 20; $i++) { Start-Sleep -Milliseconds 300; $stree = QueryTree 'Settings' 8; if ($stree) { break } }
+  if (-not $stree) { throw 'Settings dialog never appeared' }
+  Write-Host 'settings dialog up'
+  foreach ($tn in @('General', 'Client', 'Server', 'Serial Server', 'Activity Monitor')) {
+    $tab = Find $stree { param($n) $n.name -eq $tn -and $n.controlType -match 'TabItem' }
+    if ($tab) {
+      ClickAbs ([int]($tab.x + $tab.width / 2)) ([int]($tab.y + $tab.height / 2))
+      Write-Host "  tab: $tn"; Start-Sleep -Milliseconds 1100
+    }
+    else { Write-Host "  (tab '$tn' not found in tree)" }
+  }
+  Cmd 'key_esc'; Start-Sleep -Milliseconds 1000   # close Settings (modal) before touching the main window
+
+  # --- Resize the main window ~25% smaller by dragging the bottom-right sizing border inward. ---
+  # The window is pinned at ($winX,$winY,$winW,$winH); the recorded region is that same rect, so the
+  # window shrinks toward its top-left corner and stays fully in frame.
+  $newW = [int]($winW * 0.75); $newH = [int]($winH * 0.75)
+  $corner0X = $winX + $winW - 2; $corner0Y = $winY + $winH - 2
+  $corner1X = $winX + $newW;     $corner1Y = $winY + $newH
+  Drag @(
+    , @($corner0X, $corner0Y)
+    , @([int](($corner0X + $corner1X) / 2), [int](($corner0Y + $corner1Y) / 2))
+    , @($corner1X, $corner1Y)
+  )
+  Start-Sleep -Milliseconds 1000
+
+  # --- Move the window by dragging its title bar in small circles. ---
+  # Grab the title bar (offset from the now-resized window's top-left), then walk the cursor around two
+  # small circles. The window follows by (cursor - grab-offset); the circle is sized/centered so the
+  # whole window stays inside the recorded region.
+  $grabX = $winX + [int]($newW / 2); $grabY = $winY + 12     # middle of the title bar
+  $offX = $grabX - $winX; $offY = $grabY - $winY             # cursor-to-window-top-left offset
+  $ccx = $winX + 90 + $offX; $ccy = $winY + 70 + $offY; $r = 55   # circle centre, in cursor space
+  $path = @(, @($grabX, $grabY))                            # button-down on the title bar
+  for ($a = 0; $a -le 720; $a += 30) {
+    $rad = [math]::PI * $a / 180.0
+    $path += , @([int]($ccx + $r * [math]::Cos($rad)), [int]($ccy + $r * [math]::Sin($rad)))
+  }
+  Drag $path
+  Start-Sleep -Milliseconds 1000
+
+  # --- Help > About (re-query: the window moved, so the menu bar is at fresh coordinates). ---
+  $tree = QueryTree 'MCEC' 5
+  $help = Find $tree { param($n) (& $isMenu $n) -and $n.name -eq 'Help' }
+  if (-not $help) { throw 'Help menu item not found after move' }
   ClickAbs ([int]($help.x + $help.width / 2)) ([int]($help.y + $help.height / 2))
-  Start-Sleep -Milliseconds 600; Cmd 'key_a'; Start-Sleep -Milliseconds 1900
-  Cmd 'key_esc'; Start-Sleep -Milliseconds 1000
+  Start-Sleep -Milliseconds 600; Cmd 'key_a'; Start-Sleep -Milliseconds 1800
 
-  # File > Settings
-  ClickAbs ([int]($file.x + $file.width / 2)) ([int]($file.y + $file.height / 2))
-  Start-Sleep -Milliseconds 600; Cmd 'key_s'; Start-Sleep -Milliseconds 2100
-  Cmd 'key_esc'; Start-Sleep -Milliseconds 1000
-
-  # File > Exit
-  ClickAbs ([int]($file.x + $file.width / 2)) ([int]($file.y + $file.height / 2))
-  Start-Sleep -Milliseconds 600; Cmd 'key_x'; Start-Sleep -Milliseconds 1300
-  if (-not $subject.HasExited) { Cmd 'enter'; Start-Sleep -Milliseconds 1000 }
+  # --- Pause on the About box, then stop. ---
+  Start-Sleep -Milliseconds 2500
 
   $stop = Tool 'record' @{ action = 'stop'; file = $outGif }
   Write-Host "record stop: $($stop.result.content[0].text)"

--- a/scripts/Generate-HeroGif.ps1
+++ b/scripts/Generate-HeroGif.ps1
@@ -153,9 +153,9 @@ try {
   (New-Object -ComObject Shell.Application).MinimizeAll()
   Start-Sleep -Milliseconds 800
 
-  # fps 4 + downscale to 600 keeps the hero compact (the encoder writes full frames, so frame
+  # fps 4 + downscale to 440 keeps the hero compact (the encoder writes full frames, so frame
   # count x width drive file size; the per-step dwells below are tuned to keep the tour short).
-  $rec = Tool 'record' @{ action = 'start'; x = $rx; y = $ry; width = $rw; height = $rh; fps = 4; maxWidth = 600 }
+  $rec = Tool 'record' @{ action = 'start'; x = $rx; y = $ry; width = $rw; height = $rh; fps = 4; maxWidth = 440 }
   Write-Host "record start: $($rec.result.content[0].text)"
   Start-Sleep -Milliseconds 500
 
@@ -212,7 +212,7 @@ try {
   $offX = $grabX - $winX; $offY = $grabY - $winY             # cursor-to-window-top-left offset
   $ccx = $winX + 90 + $offX; $ccy = $winY + 70 + $offY; $r = 55   # circle centre, in cursor space
   $path = @(, @($grabX, $grabY))                            # button-down on the title bar
-  for ($a = 0; $a -le 720; $a += 40) {
+  for ($a = 0; $a -le 720; $a += 50) {
     $rad = [math]::PI * $a / 180.0
     $path += , @([int]($ccx + $r * [math]::Cos($rad)), [int]($ccy + $r * [math]::Sin($rad)))
   }
@@ -224,10 +224,10 @@ try {
   $help = Find $tree { param($n) (& $isMenu $n) -and $n.name -eq 'Help' }
   if (-not $help) { throw 'Help menu item not found after move' }
   ClickAbs ([int]($help.x + $help.width / 2)) ([int]($help.y + $help.height / 2))
-  Start-Sleep -Milliseconds 500; Cmd 'key_a'; Start-Sleep -Milliseconds 1200
+  Start-Sleep -Milliseconds 500; Cmd 'key_a'; Start-Sleep -Milliseconds 1000
 
   # --- Pause on the About box, then stop. ---
-  Start-Sleep -Milliseconds 1500
+  Start-Sleep -Milliseconds 1000
 
   $stop = Tool 'record' @{ action = 'stop'; file = $outGif }
   Write-Host "record stop: $($stop.result.content[0].text)"

--- a/scripts/Generate-HeroGif.ps1
+++ b/scripts/Generate-HeroGif.ps1
@@ -128,7 +128,7 @@ function ClickAbs([int]$cx, [int]$cy) { MoveAbs $cx $cy; Cmd 'mouse:lbc' }
 function Drag($points) {
   MoveAbs $points[0][0] $points[0][1]; Start-Sleep -Milliseconds 150
   Cmd 'mouse:lbd'; Start-Sleep -Milliseconds 200
-  foreach ($p in $points[1..($points.Count - 1)]) { MoveAbs $p[0] $p[1]; Start-Sleep -Milliseconds 130 }
+  foreach ($p in $points[1..($points.Count - 1)]) { MoveAbs $p[0] $p[1]; Start-Sleep -Milliseconds 90 }
   Start-Sleep -Milliseconds 150; Cmd 'mouse:lbu'
 }
 function Find($node, [scriptblock]$pred) {
@@ -153,9 +153,9 @@ try {
   (New-Object -ComObject Shell.Application).MinimizeAll()
   Start-Sleep -Milliseconds 800
 
-  # fps 4 + downscale to 680 keeps the hero compact (the encoder writes full frames, so frame
-  # count x width drive file size).
-  $rec = Tool 'record' @{ action = 'start'; x = $rx; y = $ry; width = $rw; height = $rh; fps = 4; maxWidth = 680 }
+  # fps 4 + downscale to 600 keeps the hero compact (the encoder writes full frames, so frame
+  # count x width drive file size; the per-step dwells below are tuned to keep the tour short).
+  $rec = Tool 'record' @{ action = 'start'; x = $rx; y = $ry; width = $rw; height = $rh; fps = 4; maxWidth = 600 }
   Write-Host "record start: $($rec.result.content[0].text)"
   Start-Sleep -Milliseconds 500
 
@@ -166,7 +166,7 @@ try {
   for ($i = 0; $i -lt 25; $i++) { Start-Sleep -Milliseconds 600; $tree = QueryTree 'MCEC' 4; if ($tree) { break } }
   if (-not $tree) { throw 'subject MCEC window never appeared' }
   Write-Host 'subject window up'
-  Start-Sleep -Milliseconds 1200   # dwell on the freshly-started window
+  Start-Sleep -Milliseconds 600    # dwell on the freshly-started window
   $tree = QueryTree 'MCEC' 5        # re-query so the menu bar is fully built before we locate it
 
   $isMenu = { param($n) ($n.controlType -match 'MenuItem') }
@@ -185,11 +185,11 @@ try {
     $tab = Find $stree { param($n) $n.name -eq $tn -and $n.controlType -match 'TabItem' }
     if ($tab) {
       ClickAbs ([int]($tab.x + $tab.width / 2)) ([int]($tab.y + $tab.height / 2))
-      Write-Host "  tab: $tn"; Start-Sleep -Milliseconds 1100
+      Write-Host "  tab: $tn"; Start-Sleep -Milliseconds 600
     }
     else { Write-Host "  (tab '$tn' not found in tree)" }
   }
-  Cmd 'key_esc'; Start-Sleep -Milliseconds 1000   # close Settings (modal) before touching the main window
+  Cmd 'key_esc'; Start-Sleep -Milliseconds 500    # close Settings (modal) before touching the main window
 
   # --- Resize the main window ~25% smaller by dragging the bottom-right sizing border inward. ---
   # The window is pinned at ($winX,$winY,$winW,$winH); the recorded region is that same rect, so the
@@ -202,7 +202,7 @@ try {
     , @([int](($corner0X + $corner1X) / 2), [int](($corner0Y + $corner1Y) / 2))
     , @($corner1X, $corner1Y)
   )
-  Start-Sleep -Milliseconds 1000
+  Start-Sleep -Milliseconds 500
 
   # --- Move the window by dragging its title bar in small circles. ---
   # Grab the title bar (offset from the now-resized window's top-left), then walk the cursor around two
@@ -212,22 +212,22 @@ try {
   $offX = $grabX - $winX; $offY = $grabY - $winY             # cursor-to-window-top-left offset
   $ccx = $winX + 90 + $offX; $ccy = $winY + 70 + $offY; $r = 55   # circle centre, in cursor space
   $path = @(, @($grabX, $grabY))                            # button-down on the title bar
-  for ($a = 0; $a -le 720; $a += 30) {
+  for ($a = 0; $a -le 720; $a += 40) {
     $rad = [math]::PI * $a / 180.0
     $path += , @([int]($ccx + $r * [math]::Cos($rad)), [int]($ccy + $r * [math]::Sin($rad)))
   }
   Drag $path
-  Start-Sleep -Milliseconds 1000
+  Start-Sleep -Milliseconds 500
 
   # --- Help > About (re-query: the window moved, so the menu bar is at fresh coordinates). ---
   $tree = QueryTree 'MCEC' 5
   $help = Find $tree { param($n) (& $isMenu $n) -and $n.name -eq 'Help' }
   if (-not $help) { throw 'Help menu item not found after move' }
   ClickAbs ([int]($help.x + $help.width / 2)) ([int]($help.y + $help.height / 2))
-  Start-Sleep -Milliseconds 600; Cmd 'key_a'; Start-Sleep -Milliseconds 1800
+  Start-Sleep -Milliseconds 500; Cmd 'key_a'; Start-Sleep -Milliseconds 1200
 
   # --- Pause on the About box, then stop. ---
-  Start-Sleep -Milliseconds 2500
+  Start-Sleep -Milliseconds 1500
 
   $stop = Tool 'record' @{ action = 'stop'; file = $outGif }
   Write-Host "record stop: $($stop.result.content[0].text)"

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -102,7 +102,7 @@ public abstract class Command : ICommand {
     public virtual bool Execute() {
         if (!Enabled) {
             Logger.Instance.Log4.Info($"Command: Attempt to execute a disabled command ({Cmd})");
-            Logger.Instance.Log4.Info($"         As of MCE Controller v2.2.1 commands are disabled by default.");
+            Logger.Instance.Log4.Info($"         As of MCEC v2.2.1 commands are disabled by default.");
             Logger.Instance.Log4.Info($"         Edit mcec.commands to enable commands (change `Enabled=\"false\"' to 'Enabled=\"true\"').");
             return false;
         }

--- a/src/Dialogs/About.Designer.cs
+++ b/src/Dialogs/About.Designer.cs
@@ -93,7 +93,7 @@
             this._labelSummary.Name = "_labelSummary";
             this._labelSummary.Size = new System.Drawing.Size(408, 49);
             this._labelSummary.TabIndex = 2;
-            this._labelSummary.Text = "MCE Controller is distributed as freeware and published as open source under the " +
+            this._labelSummary.Text = "MCEC is distributed as freeware and published as open source under the " +
     "MIT License.";
             // 
             // _iconMcec

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -111,7 +111,7 @@ public partial class MainWindow : Form {
     }
 
     private void mainWindow_Load(object sender, EventArgs e) {
-        Logger.Instance.Log4.Info($"MCE Controller v{System.Windows.Forms.Application.ProductVersion}" +
+        Logger.Instance.Log4.Info($"MCEC v{System.Windows.Forms.Application.ProductVersion}" +
             $" - OS: {Environment.OSVersion.ToString()} on {(Environment.Is64BitProcess ? "x64" : "x86")}" +
             $" - .NET: {Environment.Version.ToString()}");
 

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -123,7 +123,12 @@ public static class AgentServer {
         "element isn't present yet — so `wait-for` (or `find` with a timeout) the control before acting; " +
         "an `invoke` that returns `error.category:no-target` means the control hasn't appeared yet, so " +
         "`wait-for` it rather than blindly retrying. " +
-        "`send_command` sends any raw MCEC command (keystrokes, mouse, launch).\n" +
+        "`send_command` sends any raw MCEC command (keystrokes, mouse, launch). To DRAG — resize a " +
+        "window by its sizing border, move one by its title bar, or drag a slider/handle (there is no " +
+        "`invoke` for these) — `send_command` a press-move-release sequence: `mouse:mt,x,y` to the start " +
+        "point, then `mouse:lbd` (button down), then a STREAM of `mouse:mt,x,y` along the path, then " +
+        "`mouse:lbu` (button up); coords are absolute screen pixels and a short pause between moves keeps " +
+        "the target tracking. Re-`query` afterward — a moved/resized window's controls are at new bounds.\n" +
         "4. VERIFY with another `query` or `capture` — always confirm the act had the intended effect.\n" +
         "RESULTS: every tool returns one envelope — `{ ok, result?, warnings?, error? }`. Branch on `ok` " +
         "first: on success read `result`; on failure read `error.category` (a closed set: timeout, " +


### PR DESCRIPTION
## What

Regenerates `docs/hero.gif` with a richer **MCEC-drives-MCEC** tour that, per request, reorders and deepens the demo to exercise the **mouse-drag input path** (not just menu clicks):

1. Launch the subject MCEC
2. **File ▸ Settings** — visit *every* tab (General → Client → Server → Serial Server → Activity Monitor)
3. **Mouse-resize** the window ~25% smaller by dragging the bottom-right sizing border
4. **Move** the window by dragging the title bar in small circles
5. **Help ▸ About**
6. Pause on the About box, then stop recording

Verified frame-by-frame: tabs tour, resize, title-bar move (Help menu re-located after the move), and the About box during the final pause all render correctly.

## Drive-by fix (script was broken on `develop`)

`Generate-HeroGif.ps1`'s `QueryTree` read the UIA snapshot from `.data.tree`, but the agent result envelope now nests it at `.result.tree` (`AgentToolResult.ToJsonObject`, #115/#116). The script could no longer find the subject window — the first run failed with *"subject MCEC window never appeared."* Fixed to `.result.tree`; added `MoveAbs`/`Drag` helpers (button-down → stream of absolute `mouse:mt` moves → button-up).

## Heads-up — file size & backdrop

- The resize + move **expose the desktop wallpaper** (the old GIF's window filled the whole fixed recording region, so it never did). A **solid-color wallpaper** gives the cleanest hero; doc updated to say so.
- Per-frame cost is unchanged (~110 KB); the longer tour is ~23 s / ~70 frames → **≈8 MB** (was 4.4 MB). Easy to trim via `fps`/`maxWidth`/dwell times if that's too heavy for the repo — say the word.

## Testing

Ran `scripts/Generate-HeroGif.ps1 -Config Debug` on a real Windows desktop end-to-end (record start → tour → stop wrote `docs/hero.gif`). No C#/test changes in this PR.

Docs: `README.md` hero caption and `docs/hero-gif.md` (sequence, manual MCP table, backdrop note, size note) updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)