### PR TITLE
agent: command-event pipeline for the on-screen command overlay (#119, foundation)

### DIFF
--- a/src/Agent/CommandEvent.cs
+++ b/src/Agent/CommandEvent.cs
@@ -1,0 +1,31 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// One structured "a command just ran" event, published on the <see cref="CommandEventHub"/> by the
+/// execution seam and consumed by the on-screen command overlay (#119). This is the dedicated event
+/// hook chosen for the overlay so it gets purpose-built terse text and fields (outcome, session) rather
+/// than re-parsing the GUI log view.
+/// </summary>
+public sealed class CommandEvent {
+    public CommandEvent(string command, string terseText, CommandOutcome outcome, string? sessionId = null) {
+        Command = command;
+        TerseText = terseText;
+        Outcome = outcome;
+        SessionId = sessionId;
+    }
+
+    /// <summary>The command/tool name (e.g. <c>capture</c>, <c>invoke</c>, <c>send_command</c>).</summary>
+    public string Command { get; }
+
+    /// <summary>The condensed one-line label the overlay shows (e.g. <c>invoke expand "Help"</c>).</summary>
+    public string TerseText { get; }
+
+    /// <summary>Whether the command succeeded, failed, is pending, or is informational.</summary>
+    public CommandOutcome Outcome { get; }
+
+    /// <summary>The owning agent session id (#86), or null for a non-session command.</summary>
+    public string? SessionId { get; }
+}

--- a/src/Agent/CommandEventHub.cs
+++ b/src/Agent/CommandEventHub.cs
@@ -1,0 +1,56 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+
+namespace MCEControl;
+
+/// <summary>
+/// Process-wide publish/subscribe hub for <see cref="CommandEvent"/>s — the dedicated command-event
+/// hook the on-screen overlay (#119) subscribes to. The execution seam (AgentServer for agent tools,
+/// later <c>CommandInvoker</c> for the home-automation path) <see cref="Publish"/>es; the overlay
+/// window subscribes. Static so the seam can publish without plumbing a reference through every command.
+///
+/// <para>Publishing is best-effort and decoupled from command execution: a throwing subscriber is
+/// caught and logged so a faulty overlay can never break a command. Thread-safe because an
+/// <c>invoke</c> can publish from a background worker thread.</para>
+/// </summary>
+public static class CommandEventHub {
+    private static readonly object Gate = new();
+    private static readonly List<Action<CommandEvent>> Subscribers = [];
+
+    /// <summary>Registers a handler to receive every subsequently-published <see cref="CommandEvent"/>.</summary>
+    public static void Subscribe(Action<CommandEvent> handler) {
+        ArgumentNullException.ThrowIfNull(handler);
+        lock (Gate) {
+            Subscribers.Add(handler);
+        }
+    }
+
+    /// <summary>Removes a previously-registered handler.</summary>
+    public static void Unsubscribe(Action<CommandEvent> handler) {
+        lock (Gate) {
+            Subscribers.Remove(handler);
+        }
+    }
+
+    /// <summary>Publishes an event to all current subscribers. Never throws; a faulty subscriber is logged.</summary>
+    public static void Publish(CommandEvent ev) {
+        if (ev is null) {
+            return;
+        }
+        Action<CommandEvent>[] snapshot;
+        lock (Gate) {
+            snapshot = [.. Subscribers];
+        }
+        foreach (Action<CommandEvent> handler in snapshot) {
+            try {
+                handler(ev);
+            }
+            catch (Exception e) {
+                Logger.Instance.Log4.Error($"CommandEventHub: subscriber threw, ignoring: {e.Message}");
+            }
+        }
+    }
+}

--- a/src/Agent/CommandOutcome.cs
+++ b/src/Agent/CommandOutcome.cs
@@ -1,0 +1,22 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// The outcome of a command for the on-screen command overlay (#119). The overlay renders this as
+/// colour/emphasis (e.g. a failed action stands out) in addition to the terse text.
+/// </summary>
+public enum CommandOutcome {
+    /// <summary>Dispatched but not yet resolved (e.g. an <c>invoke</c> that opened a modal dialog).</summary>
+    Pending,
+
+    /// <summary>The command achieved its goal.</summary>
+    Ok,
+
+    /// <summary>The command failed.</summary>
+    Failed,
+
+    /// <summary>An informational note with no success/failure semantics.</summary>
+    Info,
+}

--- a/src/Agent/CommandTersifier.cs
+++ b/src/Agent/CommandTersifier.cs
@@ -43,8 +43,18 @@ public static class CommandTersifier {
         return $"send {c}";
     }
 
-    /// <summary>The most specific target descriptor present, mirroring WindowResolver's precedence.</summary>
+    /// <summary>
+    /// The target descriptor the way <see cref="WindowResolver"/> actually resolves it: handle &gt;
+    /// foreground &gt; window &gt; process &gt; className. Showing the filter text first would mislabel a
+    /// call that reused a handle (or asked for foreground) with a stale title/process the resolver ignored.
+    /// </summary>
     private static string Target(JsonObject args) {
+        if (args["handle"] is JsonValue hv && hv.TryGetValue(out long handle) && handle > 0) {
+            return $"handle=0x{handle:X}";
+        }
+        if (args["foreground"] is JsonValue fv && fv.TryGetValue(out bool fg) && fg) {
+            return "foreground";
+        }
         string? window = Str(args, "window");
         if (window is not null) {
             return $"window=\"{window}\"";
@@ -56,12 +66,6 @@ public static class CommandTersifier {
         string? className = Str(args, "className");
         if (className is not null) {
             return $"class=\"{className}\"";
-        }
-        if (args["handle"] is JsonValue hv && hv.TryGetValue(out long handle) && handle > 0) {
-            return $"handle=0x{handle:X}";
-        }
-        if (args["foreground"] is JsonValue fv && fv.TryGetValue(out bool fg) && fg) {
-            return "foreground";
         }
         return "?";
     }

--- a/src/Agent/CommandTersifier.cs
+++ b/src/Agent/CommandTersifier.cs
@@ -1,0 +1,80 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// Builds the condensed one-line label the command overlay (#119) shows for a command — the "MainWindow
+/// log view, tersified" the issue asks for. Pure formatting so it is fully unit-testable; the overlay
+/// renders the <see cref="CommandOutcome"/> separately (colour/emphasis).
+/// </summary>
+public static class CommandTersifier {
+    /// <summary>
+    /// Terse label for an agent tool call, e.g. <c>capture window="About"</c>, <c>invoke expand "Help"</c>,
+    /// <c>wait-for "OK" → timeout</c>. <paramref name="detail"/> (e.g. an error category) is appended only
+    /// on a <see cref="CommandOutcome.Failed"/> outcome.
+    /// </summary>
+    public static string ForAgentTool(string tool, JsonObject args, CommandOutcome outcome, string? detail = null) {
+        string body = tool switch {
+            "capture" => $"capture {Target(args)}",
+            "query" => $"query {Target(args)}",
+            "find" or "wait-for" => $"{tool} {Selector(args)}",
+            "invoke" => $"invoke {Str(args, "action") ?? "invoke"} \"{Str(args, "value") ?? ""}\"",
+            _ => tool,
+        };
+        if (outcome == CommandOutcome.Pending) {
+            body += " …";
+        }
+        else if (outcome == CommandOutcome.Failed) {
+            body += detail is not null ? $" → {detail}" : " → failed";
+        }
+        return body;
+    }
+
+    /// <summary>Terse label for a raw <c>send_command</c> pass-through, e.g. <c>send winr</c> (long commands clipped).</summary>
+    public static string ForRawCommand(string command) {
+        string c = (command ?? string.Empty).Trim();
+        if (c.Length > 40) {
+            c = c[..40] + "…";
+        }
+        return $"send {c}";
+    }
+
+    /// <summary>The most specific target descriptor present, mirroring WindowResolver's precedence.</summary>
+    private static string Target(JsonObject args) {
+        string? window = Str(args, "window");
+        if (window is not null) {
+            return $"window=\"{window}\"";
+        }
+        string? process = Str(args, "process");
+        if (process is not null) {
+            return $"process=\"{process}\"";
+        }
+        string? className = Str(args, "className");
+        if (className is not null) {
+            return $"class=\"{className}\"";
+        }
+        if (args["handle"] is JsonValue hv && hv.TryGetValue(out long handle) && handle > 0) {
+            return $"handle=0x{handle:X}";
+        }
+        if (args["foreground"] is JsonValue fv && fv.TryGetValue(out bool fg) && fg) {
+            return "foreground";
+        }
+        return "?";
+    }
+
+    /// <summary>The element selector for find/wait-for/invoke: a bare quoted value for <c>by=name</c>, else <c>by="value"</c>.</summary>
+    private static string Selector(JsonObject args) {
+        string value = Str(args, "value") ?? "";
+        string by = Str(args, "by") ?? "name";
+        return by.Equals("name", StringComparison.OrdinalIgnoreCase)
+            ? $"\"{value}\""
+            : $"{by}=\"{value}\"";
+    }
+
+    private static string? Str(JsonObject args, string key) =>
+        args[key] is JsonValue v && v.TryGetValue(out string? s) && !string.IsNullOrEmpty(s) ? s : null;
+}

--- a/src/Agent/OverlayFeed.cs
+++ b/src/Agent/OverlayFeed.cs
@@ -1,0 +1,53 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MCEControl;
+
+/// <summary>
+/// The bounded, self-pruning buffer of recent <see cref="CommandEvent"/>s the overlay (#119) renders.
+/// It keeps at most <c>maxLines</c> entries and drops any older than <c>lifetime</c>, so the on-screen
+/// feed stays small and old lines fade out on their own (no scrollbars). Time is passed in (<c>nowUtc</c>)
+/// rather than read from the clock so aging is deterministic and unit-testable.
+/// </summary>
+public sealed class OverlayFeed {
+    private readonly int _maxLines;
+    private readonly TimeSpan _lifetime;
+    private readonly object _gate = new();
+    private readonly LinkedList<(DateTime At, CommandEvent Ev)> _items = new();
+
+    public OverlayFeed(int maxLines, TimeSpan lifetime) {
+        if (maxLines <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxLines));
+        }
+        if (lifetime <= TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(lifetime));
+        }
+        _maxLines = maxLines;
+        _lifetime = lifetime;
+    }
+
+    /// <summary>Appends an event at <paramref name="nowUtc"/>, evicting the oldest if over the line cap.</summary>
+    public void Add(CommandEvent ev, DateTime nowUtc) {
+        ArgumentNullException.ThrowIfNull(ev);
+        lock (_gate) {
+            _items.AddLast((nowUtc, ev));
+            while (_items.Count > _maxLines) {
+                _items.RemoveFirst();
+            }
+        }
+    }
+
+    /// <summary>The currently-visible events, oldest first, after pruning any older than the lifetime.</summary>
+    public IReadOnlyList<CommandEvent> Visible(DateTime nowUtc) {
+        lock (_gate) {
+            while (_items.First is not null && nowUtc - _items.First.Value.At > _lifetime) {
+                _items.RemoveFirst();
+            }
+            return _items.Select(e => e.Ev).ToList();
+        }
+    }
+}

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -287,6 +287,7 @@ public static class AgentServer {
         if (name == "invoke") {
             if (!TryRunInvokeWithModalGrace(cmd)) {
                 AgentRuntime.Audit(name, "dispatched; a modal dialog appears to be open — returning without blocking");
+                PublishOverlay(name, args, CommandOutcome.Pending, null, session.SessionId);
                 return McpResult(AgentToolResult.Success(InvokeModalPendingResult(), session.SessionId));
             }
         }
@@ -327,8 +328,17 @@ public static class AgentServer {
         // observation tool (wait-for included) records its observation + the resolved window as the target.
         session.RecordToolOutcome(name, env);
 
+        PublishOverlay(name, args, env.Ok ? CommandOutcome.Ok : CommandOutcome.Failed, env.Error?.CategoryWire, session.SessionId);
         return McpResult(env, image);
     }
+
+    /// <summary>
+    /// Publishes a command-event for the on-screen overlay (#119). Best-effort and decoupled — the hub
+    /// swallows subscriber faults — so it can never affect the tool result. The overlay window (and its
+    /// <c>CommandOverlayEnabled</c> gate) lives on the subscriber side.
+    /// </summary>
+    private static void PublishOverlay(string name, JsonObject args, CommandOutcome outcome, string? detail, string? sessionId) =>
+        CommandEventHub.Publish(new CommandEvent(name, CommandTersifier.ForAgentTool(name, args, outcome, detail), outcome, sessionId));
 
     // Grace period for an `invoke` to complete before we assume it opened a modal dialog and return.
     // Must stay above UiaService.InvokeFindTimeoutMs so an invoke's element lookup always resolves within
@@ -391,6 +401,7 @@ public static class AgentServer {
         // success payload. (Native success/failure detection for send_command is out of Phase 1 scope.)
         string captured = reply.Captured.Trim();
         JsonObject result = new() { ["output"] = string.IsNullOrEmpty(captured) ? "ok" : captured };
+        CommandEventHub.Publish(new CommandEvent("send_command", CommandTersifier.ForRawCommand(command), CommandOutcome.Ok, session.SessionId));
         return McpResult(AgentToolResult.Success(result, session.SessionId));
     }
 

--- a/src/Services/AppSettings.cs
+++ b/src/Services/AppSettings.cs
@@ -132,6 +132,13 @@ public class AppSettings : ICloneable {
     [SafeForTelemetryAttribute]
     public int McpHttpPort { get; set; } = 5151;
 
+    // --- On-screen command overlay (issue #119) ---
+    // ON by default: the overlay shows each command as it executes so anyone watching can see that MCEC
+    // is driving the machine (auditability), which also makes demos self-documenting. A settings file
+    // without this element deserializes to the initialized default (true).
+    [SafeForTelemetryAttribute]
+    public bool CommandOverlayEnabled { get; set; } = true;
+
     // --- GIF recording limits (issue #80) ---
     // SECURITY/SAFETY: the agent `record` command is bounded by these so it cannot accidentally create
     // an unbounded file. Requests above a limit are CLAMPED (not failed) and the clamp is audited.

--- a/tests/MCEControl.xUnit/Agent/CommandEventHubTests.cs
+++ b/tests/MCEControl.xUnit/Agent/CommandEventHubTests.cs
@@ -1,0 +1,55 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>Tests the #119 command-event hub: subscribers receive published events, unsubscribe works,
+/// and a throwing subscriber can't break publishing (commands must never fail because of the overlay).</summary>
+public class CommandEventHubTests {
+    private static CommandEvent Sample(string text = "capture window=\"About\"") =>
+        new("capture", text, CommandOutcome.Ok, "s-1");
+
+    [Fact]
+    public void Subscribe_ReceivesPublishedEvents_UntilUnsubscribed() {
+        List<CommandEvent> seen = [];
+        void Handler(CommandEvent e) => seen.Add(e);
+
+        CommandEventHub.Subscribe(Handler);
+        try {
+            CommandEventHub.Publish(Sample("one"));
+            CommandEventHub.Unsubscribe(Handler);
+            CommandEventHub.Publish(Sample("two"));
+        }
+        finally {
+            CommandEventHub.Unsubscribe(Handler);
+        }
+
+        Assert.Single(seen);
+        Assert.Equal("one", seen[0].TerseText);
+    }
+
+    [Fact]
+    public void Publish_IsBestEffort_AThrowingSubscriberDoesNotBreakOthersOrThrow() {
+        List<CommandEvent> seen = [];
+        void Throws(CommandEvent e) => throw new InvalidOperationException("boom");
+        void Records(CommandEvent e) => seen.Add(e);
+
+        CommandEventHub.Subscribe(Throws);
+        CommandEventHub.Subscribe(Records);
+        try {
+            CommandEventHub.Publish(Sample("survives")); // must not throw despite Throws
+        }
+        finally {
+            CommandEventHub.Unsubscribe(Throws);
+            CommandEventHub.Unsubscribe(Records);
+        }
+
+        Assert.Single(seen);
+        Assert.Equal("survives", seen[0].TerseText);
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/CommandTersifierTests.cs
+++ b/tests/MCEControl.xUnit/Agent/CommandTersifierTests.cs
@@ -1,0 +1,58 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>Tests the #119 tersifier: condensed, log-view-style one-liners for the overlay.</summary>
+public class CommandTersifierTests {
+    [Fact]
+    public void Capture_ShowsTarget() {
+        string s = CommandTersifier.ForAgentTool("capture", new JsonObject { ["window"] = "About" }, CommandOutcome.Ok);
+        Assert.Equal("capture window=\"About\"", s);
+    }
+
+    [Fact]
+    public void Query_FallsBackToProcessWhenNoWindow() {
+        string s = CommandTersifier.ForAgentTool("query", new JsonObject { ["process"] = "notepad" }, CommandOutcome.Ok);
+        Assert.Equal("query process=\"notepad\"", s);
+    }
+
+    [Fact]
+    public void Invoke_ShowsActionAndValue() {
+        JsonObject args = new() { ["action"] = "expand", ["value"] = "Help", ["by"] = "name" };
+        string s = CommandTersifier.ForAgentTool("invoke", args, CommandOutcome.Ok);
+        Assert.Equal("invoke expand \"Help\"", s);
+    }
+
+    [Fact]
+    public void WaitFor_Miss_AppendsFailureDetail() {
+        JsonObject args = new() { ["value"] = "OK", ["by"] = "name" };
+        string s = CommandTersifier.ForAgentTool("wait-for", args, CommandOutcome.Failed, "timeout");
+        Assert.Equal("wait-for \"OK\" → timeout", s);
+    }
+
+    [Fact]
+    public void Find_NonNameSelector_ShowsByEqualsValue() {
+        JsonObject args = new() { ["value"] = "saveBtn", ["by"] = "automationId" };
+        string s = CommandTersifier.ForAgentTool("find", args, CommandOutcome.Ok);
+        Assert.Equal("find automationId=\"saveBtn\"", s);
+    }
+
+    [Fact]
+    public void Invoke_Pending_AppendsEllipsis() {
+        JsonObject args = new() { ["value"] = "About", ["action"] = "invoke" };
+        string s = CommandTersifier.ForAgentTool("invoke", args, CommandOutcome.Pending);
+        Assert.Equal("invoke invoke \"About\" …", s);
+    }
+
+    [Fact]
+    public void RawCommand_PrefixesSend_AndClipsLongCommands() {
+        Assert.Equal("send winr", CommandTersifier.ForRawCommand("winr"));
+        Assert.StartsWith("send ", CommandTersifier.ForRawCommand(new string('x', 80)));
+        Assert.EndsWith("…", CommandTersifier.ForRawCommand(new string('x', 80)));
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/CommandTersifierTests.cs
+++ b/tests/MCEControl.xUnit/Agent/CommandTersifierTests.cs
@@ -22,6 +22,22 @@ public class CommandTersifierTests {
     }
 
     [Fact]
+    public void Target_PrefersHandleOverStaleWindowProcess_MatchingResolverPrecedence() {
+        // WindowResolver targets handle > foreground > filters, so when an agent reuses a handle the
+        // overlay must show the handle — not a stale window/process filter that didn't decide the target.
+        JsonObject args = new() { ["handle"] = 0x1234L, ["window"] = "Stale", ["process"] = "old" };
+        string s = CommandTersifier.ForAgentTool("capture", args, CommandOutcome.Ok);
+        Assert.Equal("capture handle=0x1234", s);
+    }
+
+    [Fact]
+    public void Target_PrefersForegroundOverFilters() {
+        JsonObject args = new() { ["foreground"] = true, ["process"] = "old" };
+        string s = CommandTersifier.ForAgentTool("capture", args, CommandOutcome.Ok);
+        Assert.Equal("capture foreground", s);
+    }
+
+    [Fact]
     public void Invoke_ShowsActionAndValue() {
         JsonObject args = new() { ["action"] = "expand", ["value"] = "Help", ["by"] = "name" };
         string s = CommandTersifier.ForAgentTool("invoke", args, CommandOutcome.Ok);

--- a/tests/MCEControl.xUnit/Agent/OverlayFeedTests.cs
+++ b/tests/MCEControl.xUnit/Agent/OverlayFeedTests.cs
@@ -1,0 +1,61 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>Tests the #119 overlay feed: bounded by line count and self-pruning by age (deterministic
+/// via injected time), so the on-screen feed stays small with no scrollbars.</summary>
+public class OverlayFeedTests {
+    private static readonly DateTime T0 = new(2026, 6, 30, 12, 0, 0, DateTimeKind.Utc);
+
+    private static CommandEvent Ev(string text) => new("capture", text, CommandOutcome.Ok);
+
+    [Fact]
+    public void Add_EvictsOldestBeyondLineCap() {
+        OverlayFeed feed = new(maxLines: 2, lifetime: TimeSpan.FromMinutes(10));
+
+        feed.Add(Ev("a"), T0);
+        feed.Add(Ev("b"), T0);
+        feed.Add(Ev("c"), T0);
+
+        var visible = feed.Visible(T0);
+        Assert.Equal(2, visible.Count);
+        Assert.Equal("b", visible[0].TerseText);
+        Assert.Equal("c", visible[1].TerseText);
+    }
+
+    [Fact]
+    public void Visible_DropsLinesOlderThanLifetime() {
+        OverlayFeed feed = new(maxLines: 10, lifetime: TimeSpan.FromSeconds(5));
+
+        feed.Add(Ev("old"), T0);
+        feed.Add(Ev("fresh"), T0.AddSeconds(4));
+
+        var visible = feed.Visible(T0.AddSeconds(6)); // old is 6s (expired), fresh is 2s
+        Assert.Single(visible);
+        Assert.Equal("fresh", visible[0].TerseText);
+    }
+
+    [Fact]
+    public void Visible_EmptyWhenAllExpired() {
+        OverlayFeed feed = new(maxLines: 10, lifetime: TimeSpan.FromSeconds(2));
+        feed.Add(Ev("x"), T0);
+
+        Assert.Empty(feed.Visible(T0.AddSeconds(3)));
+    }
+
+    [Fact]
+    public void Visible_ReturnsOldestFirst() {
+        OverlayFeed feed = new(maxLines: 10, lifetime: TimeSpan.FromMinutes(1));
+        feed.Add(Ev("1"), T0);
+        feed.Add(Ev("2"), T0.AddSeconds(1));
+
+        var visible = feed.Visible(T0.AddSeconds(2));
+        Assert.Equal("1", visible[0].TerseText);
+        Assert.Equal("2", visible[1].TerseText);
+    }
+}


### PR DESCRIPTION
## What

First slice of **[#119 — on-screen command overlay](https://github.com/tig/mcec/issues/119)**: the **dedicated command-event hook** the overlay subscribes to (the feed-source decision on the issue), plus the data model it will render. This is the testable spine; the transparent, click-through **overlay window** — adaptive readability + exclusion from agent observation — is the **next PR**.

## In this PR

- **`CommandEvent` / `CommandOutcome`** — one structured "a command just ran" event: `{ command, terseText, outcome, sessionId }`.
- **`CommandEventHub`** — process-wide publish/subscribe. Publishing is **best-effort and thread-safe**: a throwing or absent subscriber can never break command execution (an `invoke` can publish from its worker thread).
- **`CommandTersifier`** — the "log view, tersified" formatter: `capture window="About"`, `invoke expand "Help"`, `wait-for "OK" → timeout`, `send winr`.
- **`OverlayFeed`** — bounded, self-pruning buffer (by line count **and** age), deterministic via injected time, so the on-screen feed stays small and old lines fade with no scrollbars.
- **`AgentServer` wiring** — publishes an event for each agent tool outcome (success / failure-with-category / modal-pending) and for `send_command`.
- **`AppSettings.CommandOverlayEnabled`** — **on by default**; a settings file without the element deserializes to `true`.

## Scope boundaries

- The **overlay window** (layered/click-through rendering, adaptive contrast, primary-screen right ~30%, no border/scrollbars) and **observation-exclusion** (the overlay must not appear in `query`/`find`/`capture`/UIA) are the next PR.
- Home-automation path (`CommandInvoker.ExecuteNext`) publishing is deferred to that PR too; this one wires the agent path.

## Tests

- Test-first for the three behavioral pieces (13 tests): hub subscribe/unsubscribe + fault isolation; tersifier across capture/query/find/wait-for/invoke/raw; feed eviction-by-count, prune-by-age, ordering.
- The execution-seam wiring is exercised by the gated desktop E2E (publishing from a live tool call needs a desktop).
- Full suite green: **216 passed, 22 skipped**.

Refs #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
