### PR TITLE
feat(safety): emergency stop (#135) + isolated session provisioning (#138)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,19 @@ Three independent, **off-by-default** gates — see [`docs/agent-server.md`](doc
 `McpServerEnabled` (HTTP floor, localhost-bound). Every agent action is logged with an `AGENT-AUDIT:`
 line. An agent that hits "agent commands are disabled" should tell the user, not retry.
 
+Two safety features layer on top (see [`docs/safety-emergency-stop-and-provisioning.md`](docs/safety-emergency-stop-and-provisioning.md)):
+
+- **Emergency stop (#135)** — a global "dead man's switch" hotkey (default `Ctrl+Alt+Shift+S`) the operator
+  can hit from **any** window to instantly halt a session: it latches the actuation gate (every tool call is
+  refused with `emergency-stopped` until the operator re-arms), aborts in-flight actuation, and releases held
+  input. It reacts to **physical input only** (injected keys are ignored via `LLKHF_INJECTED`), so the agent
+  can never trip or defeat it. Do not weaken the injected-key filter or the latch.
+- **Isolated session provisioning (#138)** — agents must **not** enable/disable commands in the installed
+  instance (a crash leaks enabled gates). Instead, `provision-session` (gated by the operator's
+  `AllowSessionProvisioning` opt-in) hands the agent a disposable directory with its own agent-ready config;
+  teardown is deleting the directory, and MCEC reaps orphaned session dirs on launch. The installed config is
+  never touched.
+
 ## Dogfood — test MCEC using MCEC (mcec drives mcec)
 
 This is the proposal's success metric ("an MCP client mounts MCEC and completes a multi-step GUI

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -403,3 +403,16 @@ is not a general-purpose web API and is not exposed off-box by default.
   `Enabled`, and `McpServerEnabled` (localhost-bound).
 - Loud `AGENT-AUDIT:` logging for every agent action.
 - Fully additive — nothing about the existing HTPC behavior changes.
+
+## Agent safety features
+
+Two operator-safety features build on the gates above — see
+[`safety-emergency-stop-and-provisioning.md`](safety-emergency-stop-and-provisioning.md):
+
+- **Emergency stop (#135):** a global panic hotkey (default `Ctrl+Alt+Shift+S`, set via
+  `EmergencyStopHotkey`) that instantly halts a session from any window — latching the actuation gate
+  (`emergency-stopped` refusals until re-armed), aborting in-flight actuation, and releasing held input. It
+  reacts to physical input only, so the agent can never trip or defeat it.
+- **Isolated session provisioning (#138):** `provision-session` (gated by `AllowSessionProvisioning`) hands
+  an agent a disposable, isolated MCEC directory instead of it mutating the installed config; `end-session`
+  (or launch-time reaping) tears it down.

--- a/docs/safety-emergency-stop-and-provisioning.md
+++ b/docs/safety-emergency-stop-and-provisioning.md
@@ -1,0 +1,167 @@
+<!--
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+-->
+
+# Agent safety: Emergency Stop (#135) and Isolated Session Provisioning (#138)
+
+Two related safety features for MCEC's Agent Mode. When MCEC is agent-driving the desktop, the **target
+app has focus, not MCEC** — so the operator needs (a) a way to instantly intervene when a run goes wrong,
+and (b) assurance that a session can't leave the machine in an unsafe state. This document is the design
+of record for both; they ship together because both are about the operator staying in control.
+
+---
+
+## 1. Emergency Stop — a global dead-man's-switch hotkey (#135)
+
+### Goal
+
+A single keystroke, hittable from **any** focused window, that instantly halts the active agent session —
+the human override. The agent must not be able to trip it accidentally or defeat it deliberately.
+
+### The hotkey
+
+- **Default: `Ctrl+Alt+Shift+S`** (mnemonic **S**top) — a four-key chord no app uses and the agent never
+  synthesizes, so accidental triggering is near-zero.
+- **Configurable** via `AppSettings.EmergencyStopHotkey` (a `+`-separated spec, e.g. `Pause`, `Ctrl+Alt+Q`).
+  Parsed by [`EmergencyStopHotkey`](../src/Agent/EmergencyStopHotkey.cs); left/right modifier variants
+  collapse to `ctrl`/`alt`/`shift`/`win`.
+
+### What "stop" does
+
+Engaging the stop (`EmergencyStop.Trigger`):
+
+1. **Latches the actuation gate.** `AgentRuntime.EmergencyStopped` is set; `AgentServer.CallTool` refuses
+   **every** tool call (actuation, observation, and raw `send_command`) with the distinct
+   `emergency-stopped` error until re-armed.
+2. **Aborts in-flight actuation.** Any recording is stopped; an in-flight `drag` observes the latch between
+   waypoints and bails out (releasing the button). The `invoke` modal-grace worker runs a synchronous UIA
+   call that can't be safely aborted mid-flight, but the latch refuses every follow-up and the input release
+   neutralizes anything left held.
+3. **Releases held input.** All mouse buttons up; shift/ctrl/alt/win reset (the same reset `MainWindow`
+   runs on exit) — no stuck drag or chord.
+4. **Loud feedback.** A persistent red `⛔ STOPPED by operator` banner on the overlay (#119), an
+   `AGENT-AUDIT:` log line, a status-bar message, and a stamp into the `AgentSession` record.
+5. **Latches until re-armed.** The operator clicks the **⛔ Re-arm (Emergency Stop)** menu item (visible
+   only while stopped); the latch is never cleared automatically.
+
+### Why it can't be tripped or defeated by the agent
+
+MCEC's own agent actuation **injects** keystrokes and mouse input. Windows flags injected low-level events
+with `LLKHF_INJECTED`. The emergency stop reuses MCEC's existing global `WH_KEYBOARD_LL` hook
+([`HookManager`](../src/Gma.UserActivityMonitor/HookManager.cs)) and reacts to **physical input only** —
+injected key events never arm a modifier and never trigger. This is what makes the hotkey a true human
+override rather than something the agent could press or hold to defeat.
+
+### Design / where it lives
+
+| Concern | Location |
+| --- | --- |
+| Injected-flag surfaced on a physical-key event | `HookManager.Callbacks.cs` → `GlobalKeyEventArgs` (`KeyDownExt`/`KeyUpExt`) |
+| Chord state machine (pure, unit-tested) | [`EmergencyStopDetector`](../src/Agent/EmergencyStopDetector.cs) |
+| Hotkey parsing | [`EmergencyStopHotkey`](../src/Agent/EmergencyStopHotkey.cs) |
+| Hook wiring + trigger/re-arm orchestration | [`EmergencyStop`](../src/Agent/EmergencyStop.cs) |
+| The latch | `AgentRuntime.EmergencyStopped` |
+| Actuation-gate refusal | `AgentServer.CallTool` (`emergency-stopped`) |
+| Cooperative drag abort | `MouseCommand.PerformDrag` |
+| Overlay banner | `CommandOverlayWindow` |
+| Re-arm affordance + host lifecycle | `MainWindow` (`Start`/`Stop`, `SetUpEmergencyStopUi`) |
+
+Armed in the **GUI host** (the LL hook needs the message loop) whenever `EmergencyStopEnabled` and the
+agent front door could be driving (`McpServerEnabled || AgentCommandsEnabled`).
+
+### Limitations / follow-ups
+
+- **Elevated targets / secure desktop (UIPI).** A non-elevated MCEC's LL hook won't receive keys while an
+  **elevated** window is foreground, and never on the secure desktop (UAC/lock). If MCEC drives elevated
+  apps, run MCEC elevated too. Documented, not solved here.
+- **Headless `--mcp`** has no message loop, so the in-process hotkey isn't armed there; the operator halts a
+  headless session via its parent process. A headless e-stop channel is a follow-up.
+
+---
+
+## 2. Isolated session provisioning (#138)
+
+### Problem
+
+Historically an agent would `Start-Process` the **installed** MCEC, flip `AgentCommandsEnabled=true` and
+enable the commands it needs in the installed `mcec.commands`, then disable them at the end. That mutates
+the operator's config and — because "disable at the end" only runs on the happy path — **leaks enabled
+security gates** on any crash/timeout/kill. It also can't compose across concurrent sessions.
+
+### Solution
+
+MCEC owns the isolation. `provision-session` hands an authorized agent a fresh, disposable directory
+containing `mcec.exe` + dependencies and a **co-located, agent-ready config** (agent commands enabled
+**only** inside the copy). The agent runs from there and deletes it when done — so enabled state lives only
+in the throwaway copy, "cleanup" is `rm -rf <dir>`, and a crashed session leaves the real install untouched.
+
+### Flow
+
+1. Operator opts in once: `AppSettings.AllowSessionProvisioning = true` (the one thing that can't be
+   self-served, or the isolation is theater).
+2. Agent calls `provision-session` (optional `mcpServer`, `commands`). MCEC
+   ([`SessionProvisioner`](../src/Agent/SessionProvisioner.cs)):
+   - creates `%LOCALAPPDATA%\MCEC\sessions\<id>`,
+   - **copies the binaries** from the running exe's dir (excluding the installed `mcec.settings` /
+     `mcec.commands` / `*.log`),
+   - writes a co-located `mcec.settings` (`AgentCommandsEnabled=true`, `ActAsServer=false` to avoid the
+     firewall prompt, MCP bound to a free loopback port, `AllowSessionProvisioning=false` so it can't
+     re-provision) and a `mcec.commands` enabling the requested agent commands,
+   - returns `{ sessionId, directory, exePath, mcpEndpoint?, token, launch, teardown }`.
+3. Agent runs `mcec.exe` from `directory` and drives it.
+4. Agent calls `end-session { sessionId }` (after stopping the session's exe) → the directory is deleted.
+
+### Isolation approach: copy binaries
+
+We copy the binaries into the session directory (rather than a `--config-dir` redirect of the installed
+exe). Because the copy runs from a non-`Program Files` location, `Program.ConfigPath` resolves to the
+session directory itself, so it reads its own co-located config with no launch flags. This matches the
+existing manual practice (`scripts/Run-Customer0Skeleton.ps1`) and is isolated by construction.
+
+### Teardown & reaping
+
+- **Explicit:** `end-session` (or just deleting the directory).
+- **Belt-and-suspenders:** on every launch (`Program.Main`) and before each provision, MCEC reaps session
+  directories older than `AgentServer.SessionReapAgeHours` (12h). A **running** session's files are locked,
+  so a live session is never reaped; it's collected on a later launch after it exits.
+
+### Design / where it lives
+
+| Concern | Location |
+| --- | --- |
+| Provision / teardown / reap | [`SessionProvisioner`](../src/Agent/SessionProvisioner.cs) |
+| Handoff descriptor | [`ProvisionedSession`](../src/Agent/ProvisionedSession.cs) |
+| MCP tools + authorization gate | `AgentServer` (`provision-session`, `end-session`) |
+| Operator opt-in | `AppSettings.AllowSessionProvisioning` |
+| Reap on launch | `Program.Main` |
+
+### Limitations / follow-ups
+
+- **Authorization depth.** `AllowSessionProvisioning` is a single operator opt-in. A richer per-session
+  authorization / token-scoping model ties into epics #92 (safety UX) and #74 (per-command enable) — future work.
+- **Auto-launch.** `provision-session` returns a directory + how to launch; it does not spawn the process
+  (the caller/host does). An optional MCEC-side launch is a candidate follow-up.
+- **Artifacts** (#87) live under the session directory so teardown collects them.
+
+---
+
+## Acceptance criteria coverage
+
+**#135**
+
+- [x] Configured combo from any focused app instantly halts the session.
+- [x] In-flight command aborted, queue dropped, no actuation until re-armed (latch + gate + cooperative drag/record abort).
+- [x] No stuck input: mouse buttons + modifiers released.
+- [x] Fires on real physical input only; MCEC's injected keys never trigger it.
+- [x] Feedback on overlay + audit log + session record; tool calls refused with `emergency-stopped` until re-arm.
+- [x] Hotkey configurable; default easy, rare, not agent-synthesized.
+
+**#138**
+
+- [x] Documented tool that provisions an isolated instance and returns its path + connect info.
+- [x] Running a provisioned session never reads/writes the installed `mcec.commands` / settings.
+- [x] Agent commands enabled only within the provisioned instance.
+- [x] Teardown removes the dir; orphaned dirs are reaped; abnormal exit leaves no enabled state in the install.
+- [x] Provisioning gated behind an explicit operator authorization, not self-served.
+- [x] Agent guidance tells agents to provision + tear down rather than touching the installed instance.

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -77,13 +77,14 @@ call `provision-session` to get a fresh, disposable, isolated instance: it retur
 launch/connect (`exePath`, and an `mcpEndpoint` when the MCP server is enabled), and a `sessionId`. Run from
 that directory, do your work there, then call `end-session` with the `sessionId` (after stopping its
 mcec.exe) to delete it — teardown is just removing the directory, so a crash leaves the real install
-untouched. If `provision-session` returns `error.category:provisioning-not-authorized`, the operator has not
-opted in (AllowSessionProvisioning) — tell them, don't retry.
+untouched. If `provision-session` returns `error.code:provisioning-not-authorized` (these feature-specific
+refusals ride in `error.code`, while `error.category` stays `internal`), the operator has not opted in
+(AllowSessionProvisioning) — tell them, don't retry.
 
 EMERGENCY STOP: the operator has a global panic hotkey (default Ctrl+Alt+Shift+S) that instantly halts the
-session from any window. If ANY tool returns `error.category:emergency-stopped`, the operator has engaged it
-and deliberately halted you — STOP immediately, tell the user, and do NOT retry; nothing will actuate until
-they re-arm.
+session from any window. If ANY tool returns `error.code:emergency-stopped` (the code, not the category —
+`error.category` stays `internal`), the operator has engaged it and deliberately halted you — STOP
+immediately, tell the user, and do NOT retry; nothing will actuate until they re-arm.
 
 SECURITY: the agent tools (capture/query/displays/find/invoke/record/drag/click) only work when the operator has set
 AgentCommandsEnabled=true; otherwise they return an error — surface that to the user rather than retrying.

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -70,6 +70,22 @@ operator can see MCEC is driving. It is deliberately excluded from `query`/`find
 — you will never see or target it, and it is never a candidate window — but it DOES appear in
 full-screen/region `capture`s and `record`ings (not in window-targeted captures).
 
+PROVISION: do NOT drive the operator's installed MCEC by enabling agent commands in it and disabling them
+when done — an abnormal exit leaks those security gates enabled. Instead, when the operator has authorized it,
+call `provision-session` to get a fresh, disposable, isolated instance: it returns a `directory` containing
+`mcec.exe` plus an agent-ready co-located config (agent commands enabled ONLY inside that copy), how to
+launch/connect (`exePath`, and an `mcpEndpoint` when the MCP server is enabled), and a `sessionId`. Run from
+that directory, do your work there, then call `end-session` with the `sessionId` (after stopping its
+mcec.exe) to delete it — teardown is just removing the directory, so a crash leaves the real install
+untouched. If `provision-session` returns `error.category:provisioning-not-authorized`, the operator has not
+opted in (AllowSessionProvisioning) — tell them, don't retry.
+
+EMERGENCY STOP: the operator has a global panic hotkey (default Ctrl+Alt+Shift+S) that instantly halts the
+session from any window. If ANY tool returns `error.category:emergency-stopped`, the operator has engaged it
+and deliberately halted you — STOP immediately, tell the user, and do NOT retry; nothing will actuate until
+they re-arm.
+
 SECURITY: the agent tools (capture/query/displays/find/invoke/record/drag/click) only work when the operator has set
 AgentCommandsEnabled=true; otherwise they return an error — surface that to the user rather than retrying.
-Every action is audit-logged on the host.
+`provision-session` additionally requires AllowSessionProvisioning, and any tool is refused with
+`emergency-stopped` while the operator's emergency stop is engaged. Every action is audit-logged on the host.

--- a/src/Agent/AgentRuntime.cs
+++ b/src/Agent/AgentRuntime.cs
@@ -44,6 +44,24 @@ public static class AgentRuntime {
         Logger.Instance.Log4.Info($"AGENT-AUDIT: {action} — {detail}");
 
     // -------------------------------------------------------------------------------------------
+    // Emergency stop latch (#135)
+    // -------------------------------------------------------------------------------------------
+
+    private static volatile bool _emergencyStopped;
+
+    /// <summary>
+    /// True while the operator's emergency stop (#135) is engaged. It <b>latches</b>: once set, every
+    /// actuation dispatch is refused until the operator explicitly re-arms — the panic override must not be
+    /// silently cleared by the next tool call. The actuation gate checks this alongside
+    /// <see cref="AgentCommandsEnabled"/>; <see cref="EmergencyStop"/> sets and clears it. <c>volatile</c>
+    /// because it is read on the dispatch thread and written from the global-hook thread.
+    /// </summary>
+    public static bool EmergencyStopped => _emergencyStopped;
+
+    /// <summary>Sets the emergency-stop latch. Called only by <see cref="EmergencyStop"/>.</summary>
+    internal static void SetEmergencyStopped(bool value) => _emergencyStopped = value;
+
+    // -------------------------------------------------------------------------------------------
     // Session runtime (#86)
     // -------------------------------------------------------------------------------------------
 

--- a/src/Agent/AgentSession.cs
+++ b/src/Agent/AgentSession.cs
@@ -30,6 +30,8 @@ public sealed class AgentSession {
     private JsonObject? _lastObservation;
     private string? _lastAction;
     private JsonObject? _lastError;
+    private DateTime? _emergencyStopAtUtc;
+    private string? _emergencyStopSource;
 
     private AgentSession(string sessionId, DateTime startedAtUtc, string artifactRoot) {
         SessionId = sessionId;
@@ -109,6 +111,25 @@ public sealed class AgentSession {
     }
 
     /// <summary>
+    /// Stamps the operator emergency stop (#135) into the session — who/what triggered it and when — so a
+    /// run's evidence bundle shows that a human halted it. Only the first stop of a latched span is kept.
+    /// </summary>
+    public void RecordEmergencyStop(string source, DateTime atUtc) {
+        lock (_gate) {
+            _emergencyStopAtUtc ??= atUtc;
+            _emergencyStopSource ??= source;
+        }
+    }
+
+    /// <summary>Clears the recorded emergency stop when the operator re-arms.</summary>
+    public void ClearEmergencyStop() {
+        lock (_gate) {
+            _emergencyStopAtUtc = null;
+            _emergencyStopSource = null;
+        }
+    }
+
+    /// <summary>
     /// Records the outcome of a tool call: a successful <b>observation</b> (query/capture/find/wait-for)
     /// updates <see cref="LastObservation"/> and, when the payload names a window, <see cref="ActiveTarget"/>;
     /// a failure updates <see cref="LastError"/>. Actuation tools (invoke/send_command) don't record an
@@ -154,6 +175,12 @@ public sealed class AgentSession {
             }
             if (_lastError is not null) {
                 obj["lastError"] = _lastError.DeepClone();
+            }
+            if (_emergencyStopAtUtc is not null) {
+                obj["emergencyStop"] = new JsonObject {
+                    ["at"] = _emergencyStopAtUtc.Value.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
+                    ["source"] = _emergencyStopSource,
+                };
             }
             return obj;
         }

--- a/src/Agent/CommandOverlayWindow.cs
+++ b/src/Agent/CommandOverlayWindow.cs
@@ -31,10 +31,18 @@ public sealed class CommandOverlayWindow : Form {
     // The About box's brand orange (Color.FromArgb(192, 90, 36)) as the item background at ~30% alpha.
     private static readonly Color ItemBackground = Color.FromArgb(77, 192, 90, 36);
 
+    // Emergency stop (#135): a solid, high-contrast red for the persistent STOPPED banner (mostly opaque
+    // so it reads as an alarm, not a fading log line).
+    private static readonly Color StoppedBackground = Color.FromArgb(235, 176, 0, 0);
+
     private readonly OverlayFeed _feed = new(maxLines: 8, lifetime: TimeSpan.FromSeconds(8));
     private readonly Action<CommandEvent> _onEvent;
+    private readonly Action<bool> _onEmergencyStop;
     private readonly System.Windows.Forms.Timer _ageTimer;
     private readonly OverlayPosition _side;
+
+    // True while the operator's emergency stop is engaged; drives the persistent STOPPED banner.
+    private bool _stopped;
 
     // The handle currently registered as ignored, tracked so a WinForms handle recreation never leaves a
     // stale HWND in the resolver's ignore set (a recycled value could otherwise hide a real window).
@@ -52,9 +60,33 @@ public sealed class CommandOverlayWindow : Form {
         _onEvent = OnCommandEvent;
         CommandEventHub.Subscribe(_onEvent);
 
+        _stopped = EmergencyStop.IsStopped;
+        _onEmergencyStop = OnEmergencyStopStateChanged;
+        EmergencyStop.StateChanged += _onEmergencyStop;
+
         _ageTimer = new System.Windows.Forms.Timer { Interval = 300 };
         _ageTimer.Tick += (_, _) => Render();
         _ageTimer.Start();
+    }
+
+    private void OnEmergencyStopStateChanged(bool stopped) {
+        if (IsDisposed || !IsHandleCreated) {
+            return;
+        }
+        try {
+            if (InvokeRequired) {
+                BeginInvoke(_onEmergencyStop, stopped);
+                return;
+            }
+            _stopped = stopped;
+            Render();
+        }
+        catch (ObjectDisposedException) {
+            // Window closed between the check and the marshal; nothing to draw.
+        }
+        catch (InvalidOperationException) {
+            // Handle not ready; drop this update rather than throw on the hook thread.
+        }
     }
 
     /// <summary>Show without ever stealing focus from the app being driven.</summary>
@@ -122,6 +154,9 @@ public sealed class CommandOverlayWindow : Form {
             g.Clear(Color.Transparent);
             g.SmoothingMode = SmoothingMode.AntiAlias;
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+            if (_stopped) {
+                DrawStoppedBanner(g, w);
+            }
             DrawFeed(g, w, h);
         }
         PushLayered(bmp);
@@ -173,6 +208,28 @@ public sealed class CommandOverlayWindow : Form {
         }
     }
 
+    /// <summary>
+    /// Draws the persistent emergency-stop (#135) banner across the top of the overlay. Unlike the fading
+    /// command feed, it stays until the operator re-arms — a loud, unmissable "MCEC is halted" indicator.
+    /// </summary>
+    private void DrawStoppedBanner(Graphics g, int width) {
+        const int pad = 8;
+        using Font font = new("Consolas", 16F, FontStyle.Bold, GraphicsUnit.Point);
+        const string text = "⛔ STOPPED by operator — Re-arm to resume";
+        SizeF size = g.MeasureString(text, font, width - pad * 2);
+        float boxH = size.Height + pad * 1.5f;
+        using (SolidBrush bg = new(StoppedBackground))
+        using (GraphicsPath path = RoundedRect(new RectangleF(0, 0, width, boxH), 6f)) {
+            g.FillPath(bg, path);
+        }
+        using (SolidBrush shadow = new(Color.FromArgb(200, 0, 0, 0))) {
+            g.DrawString(text, font, shadow, pad + 1.2f, pad / 2f + 1.2f);
+        }
+        using (SolidBrush fg = new(Color.White)) {
+            g.DrawString(text, font, fg, pad, pad / 2f);
+        }
+    }
+
     /// <summary>Pushes a 32bpp ARGB bitmap to this layered window so its per-pixel alpha composites over the desktop.</summary>
     private void PushLayered(Bitmap bmp) {
         IntPtr screenDc = AgentNativeMethods.GetDC(IntPtr.Zero);
@@ -220,6 +277,7 @@ public sealed class CommandOverlayWindow : Form {
     protected override void Dispose(bool disposing) {
         if (disposing) {
             CommandEventHub.Unsubscribe(_onEvent);
+            EmergencyStop.StateChanged -= _onEmergencyStop;
             _ageTimer?.Dispose();
             // OnHandleDestroyed normally clears the registration; unregister defensively in case the
             // window is disposed without a handle-destroyed notification.

--- a/src/Agent/EmergencyStop.cs
+++ b/src/Agent/EmergencyStop.cs
@@ -1,0 +1,198 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using Gma.UserActivityMonitor;
+using WindowsInput;
+
+namespace MCEControl;
+
+/// <summary>
+/// The emergency stop (#135): a global "dead man's switch" that lets the operator instantly halt an agent
+/// session from ANY focused window. It reuses MCEC's existing low-level keyboard hook
+/// (<see cref="HookManager"/>) — reacting to <b>physical</b> input only (injected keys are ignored) so the
+/// agent can neither trip nor defeat it — and drives an <see cref="EmergencyStopDetector"/> for the chord.
+///
+/// <para>When the hotkey fires it: (1) <b>latches</b> the actuation gate (<see cref="AgentRuntime.EmergencyStopped"/>)
+/// so no further tool call actuates until the operator explicitly re-arms; (2) aborts in-flight actuation —
+/// stops any recording and signals a cooperative drag cancel; (3) releases held input (all mouse buttons up,
+/// modifiers reset) so a mid-drag or chord can't leave input stuck; and (4) reports loudly to the overlay,
+/// the <c>AGENT-AUDIT:</c> log, and the session record. It stays stopped until <see cref="Rearm"/>.</para>
+///
+/// <para>Independent of the WinForms message loop's focus — the hook fires regardless of MCEC's window
+/// state (including minimized to tray). It does require a message loop on the installing thread, so it is
+/// armed in the GUI host, not the headless <c>--mcp</c> process.</para>
+/// </summary>
+public static class EmergencyStop {
+    private static readonly object Gate = new();
+    private static EmergencyStopDetector? _detector;
+    private static EmergencyStopHotkey _hotkey = EmergencyStopHotkey.Default;
+    private static bool _armed;
+
+    /// <summary>Raised (on the hook thread) when the stopped state changes — the overlay/UI subscribe to reflect it.</summary>
+    public static event Action<bool>? StateChanged;
+
+    /// <summary>True while the stop is engaged (mirrors <see cref="AgentRuntime.EmergencyStopped"/>).</summary>
+    public static bool IsStopped => AgentRuntime.EmergencyStopped;
+
+    /// <summary>When the current stop was engaged (UTC), or null when not stopped.</summary>
+    public static DateTime? StoppedAtUtc { get; private set; }
+
+    /// <summary>A short description of what engaged the current stop (e.g. the hotkey), or null when not stopped.</summary>
+    public static string? StoppedReason { get; private set; }
+
+    /// <summary>The chord currently armed (for display in feedback and settings).</summary>
+    public static EmergencyStopHotkey Hotkey => _hotkey;
+
+    /// <summary>
+    /// Arms the global hotkey detector with <paramref name="hotkey"/>. Idempotent; re-arming with a new
+    /// hotkey swaps it in place. Safe to call from the UI thread during startup.
+    /// </summary>
+    public static void Start(EmergencyStopHotkey hotkey) {
+        ArgumentNullException.ThrowIfNull(hotkey);
+        lock (Gate) {
+            _hotkey = hotkey;
+            _detector = new EmergencyStopDetector(hotkey);
+            if (!_armed) {
+                HookManager.KeyDownExt += OnKeyDown;
+                HookManager.KeyUpExt += OnKeyUp;
+                _armed = true;
+            }
+        }
+        Logger.Instance.Log4.Info($"EmergencyStop: armed — operator panic hotkey is {hotkey.Display} (physical input only).");
+    }
+
+    /// <summary>Disarms the hotkey detector (on host shutdown / settings reload).</summary>
+    public static void Stop() {
+        lock (Gate) {
+            if (!_armed) {
+                return;
+            }
+            HookManager.KeyDownExt -= OnKeyDown;
+            HookManager.KeyUpExt -= OnKeyUp;
+            _armed = false;
+            _detector = null;
+        }
+        Logger.Instance.Log4.Info("EmergencyStop: disarmed.");
+    }
+
+    private static void OnKeyDown(object? sender, GlobalKeyEventArgs e) {
+        bool fire;
+        lock (Gate) {
+            fire = _detector?.OnKeyDown(e.KeyCode, e.Injected) ?? false;
+        }
+        if (fire) {
+            Trigger($"hotkey {_hotkey.Display}");
+        }
+    }
+
+    private static void OnKeyUp(object? sender, GlobalKeyEventArgs e) {
+        lock (Gate) {
+            _detector?.OnKeyUp(e.KeyCode, e.Injected);
+        }
+    }
+
+    /// <summary>
+    /// Engages the stop: latches the gate, aborts in-flight actuation, releases held input, and reports it.
+    /// Idempotent — a held-key auto-repeat or a second trigger while already stopped is a no-op. Callable
+    /// directly (e.g. from a UI panic button) as well as from the hotkey.
+    /// </summary>
+    public static void Trigger(string source) {
+        lock (Gate) {
+            if (AgentRuntime.EmergencyStopped) {
+                return; // already latched; ignore repeats until re-armed
+            }
+            AgentRuntime.SetEmergencyStopped(true);
+            StoppedAtUtc = DateTime.UtcNow;
+            StoppedReason = source;
+        }
+
+        AgentRuntime.Audit("emergency-stop", $"ENGAGED by operator ({source}) — halting actuation, dropping queue, releasing held input");
+
+        // Abort in-flight actuation. Recording stops cleanly here; an in-flight drag observes the latch and
+        // bails out of its move loop (see MouseCommand.PerformDrag). The invoke modal-grace worker runs a
+        // synchronous UIA call we cannot safely abort mid-flight, but the latch refuses every follow-up call
+        // and the input release below neutralizes anything it left held.
+        try {
+            if (GifRecorder.IsRecording) {
+                GifRecorder.Stop();
+            }
+        }
+        catch (Exception ex) {
+            Logger.Instance.Log4.Error($"EmergencyStop: stopping recording failed: {ex.Message}");
+        }
+
+        ReleaseHeldInput();
+
+        // Loud feedback: overlay (#119) STOPPED banner + session record. Audit already logged above.
+        try {
+            AgentSession session = AgentRuntime.Session;
+            session.RecordEmergencyStop(source, StoppedAtUtc ?? DateTime.UtcNow);
+            CommandEventHub.Publish(new CommandEvent("emergency-stop", "⛔ STOPPED by operator", CommandOutcome.Failed, session.SessionId));
+        }
+        catch (Exception ex) {
+            Logger.Instance.Log4.Error($"EmergencyStop: publishing stop feedback failed: {ex.Message}");
+        }
+
+        StateChanged?.Invoke(true);
+    }
+
+    /// <summary>
+    /// Re-arms after a stop: clears the latch so actuation is permitted again. This is the deliberate
+    /// operator action the latch waits for — it is never cleared automatically. No-op when not stopped.
+    /// </summary>
+    public static void Rearm() {
+        lock (Gate) {
+            if (!AgentRuntime.EmergencyStopped) {
+                return;
+            }
+            AgentRuntime.SetEmergencyStopped(false);
+            StoppedAtUtc = null;
+            StoppedReason = null;
+            // Drop any physically-held modifier state so a key still down from the panic press can't
+            // immediately re-fire the chord.
+            _detector?.Reset();
+        }
+
+        AgentRuntime.Audit("emergency-stop", "RE-ARMED by operator — actuation re-enabled");
+        try {
+            AgentSession session = AgentRuntime.Session;
+            session.ClearEmergencyStop();
+            CommandEventHub.Publish(new CommandEvent("emergency-stop", "✔ Re-armed — agent may resume", CommandOutcome.Info, session.SessionId));
+        }
+        catch (Exception ex) {
+            Logger.Instance.Log4.Error($"EmergencyStop: publishing re-arm feedback failed: {ex.Message}");
+        }
+
+        StateChanged?.Invoke(false);
+    }
+
+    /// <summary>
+    /// Releases any input the agent may have left held: lifts every mouse button and resets the shift /
+    /// ctrl / alt / win modifiers (the same reset <see cref="MainWindow"/> runs on exit). These are
+    /// injected events, so the hook flags them <c>LLKHF_INJECTED</c> and the detector ignores them — the
+    /// release can never re-trigger the stop.
+    /// </summary>
+    private static void ReleaseHeldInput() {
+        try {
+            InputSimulator sim = new();
+            sim.Mouse.LeftButtonUp();
+            sim.Mouse.RightButtonUp();
+            sim.Mouse.MiddleButtonUp();
+        }
+        catch (Exception ex) {
+            Logger.Instance.Log4.Error($"EmergencyStop: releasing mouse buttons failed: {ex.Message}");
+        }
+
+        try {
+            SendInputCommand.ShiftKey("shift", false);
+            SendInputCommand.ShiftKey("ctrl", false);
+            SendInputCommand.ShiftKey("alt", false);
+            SendInputCommand.ShiftKey("lwin", false);
+            SendInputCommand.ShiftKey("rwin", false);
+        }
+        catch (Exception ex) {
+            Logger.Instance.Log4.Error($"EmergencyStop: resetting modifiers failed: {ex.Message}");
+        }
+    }
+}

--- a/src/Agent/EmergencyStopDetector.cs
+++ b/src/Agent/EmergencyStopDetector.cs
@@ -1,0 +1,78 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace MCEControl;
+
+/// <summary>
+/// The pure state machine behind the emergency-stop (#135) hotkey: it tracks which modifier keys are
+/// <b>physically</b> held and reports when the configured chord's main key is pressed while all required
+/// modifiers are down. Kept free of any hook/UI/actuation dependency so the trigger logic is fully
+/// unit-testable; <see cref="EmergencyStop"/> owns the global-hook wiring and the actual stop.
+///
+/// <para>SECURITY: injected events (<see cref="GlobalKeyEventArgs.Injected"/>) are ignored entirely — they
+/// never arm a modifier and never trigger — so MCEC's own agent keystrokes can neither trip nor defeat the
+/// stop. Only real hardware input drives the machine, which is what makes the hotkey a true human override.</para>
+/// </summary>
+public sealed class EmergencyStopDetector {
+    private readonly EmergencyStopHotkey _hotkey;
+    private readonly HashSet<string> _heldModifiers = [];
+
+    public EmergencyStopDetector(EmergencyStopHotkey hotkey) {
+        _hotkey = hotkey;
+    }
+
+    /// <summary>
+    /// Feeds a key-down event. Returns true when it completes the chord (the main key pressed with every
+    /// required modifier physically held) and the stop should fire. Injected events return false and are
+    /// otherwise ignored.
+    /// </summary>
+    public bool OnKeyDown(Keys key, bool injected) {
+        if (injected) {
+            return false;
+        }
+
+        string? modifier = EmergencyStopHotkey.ModifierName(key);
+        if (modifier is not null) {
+            _heldModifiers.Add(modifier);
+            return false;
+        }
+
+        return NormalizeKey(key) == NormalizeKey(_hotkey.Key) && HasAllRequiredModifiers();
+    }
+
+    /// <summary>Feeds a key-up event so a released physical modifier no longer counts toward the chord.</summary>
+    public void OnKeyUp(Keys key, bool injected) {
+        if (injected) {
+            return;
+        }
+        string? modifier = EmergencyStopHotkey.ModifierName(key);
+        if (modifier is not null) {
+            _heldModifiers.Remove(modifier);
+        }
+    }
+
+    /// <summary>Clears held-modifier state (e.g. when re-arming, so a stale held key can't immediately re-fire).</summary>
+    public void Reset() => _heldModifiers.Clear();
+
+    private bool HasAllRequiredModifiers() {
+        foreach (string required in _hotkey.Modifiers) {
+            if (!_heldModifiers.Contains(required)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Collapse left/right modifier variants so a chord authored with a generic modifier as its main key
+    // (unusual, but valid) still matches; non-modifier keys pass through unchanged.
+    private static Keys NormalizeKey(Keys key) => EmergencyStopHotkey.ModifierName(key) switch {
+        "shift" => Keys.ShiftKey,
+        "ctrl" => Keys.ControlKey,
+        "alt" => Keys.Menu,
+        "win" => Keys.LWin,
+        _ => key,
+    };
+}

--- a/src/Agent/EmergencyStopHotkey.cs
+++ b/src/Agent/EmergencyStopHotkey.cs
@@ -1,0 +1,147 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace MCEControl;
+
+/// <summary>
+/// A parsed emergency-stop (#135) hotkey: a set of required modifier keys plus one main key. The
+/// operator configures it as a <c>+</c>-separated string (e.g. <c>Ctrl+Alt+Shift+S</c>) in
+/// <see cref="AppSettings.EmergencyStopHotkey"/>; the default is a four-key chord no application uses and
+/// the agent never synthesizes, so accidental triggering is near-zero.
+///
+/// <para>Modifier names are normalized to <c>ctrl</c>/<c>alt</c>/<c>shift</c>/<c>win</c> (left/right
+/// variants collapse together) so matching against the low-level hook's specific L/R virtual-key codes
+/// works regardless of which physical modifier the operator pressed.</para>
+/// </summary>
+public sealed class EmergencyStopHotkey {
+    /// <summary>The operator-recommended default: <c>Ctrl+Alt+Shift+S</c> (mnemonic: <b>S</b>top).</summary>
+    public const string DefaultSpec = "Ctrl+Alt+Shift+S";
+
+    private EmergencyStopHotkey(IReadOnlySet<string> modifiers, Keys key, string display) {
+        Modifiers = modifiers;
+        Key = key;
+        Display = display;
+    }
+
+    /// <summary>The set of required modifier names (a subset of <c>ctrl</c>/<c>alt</c>/<c>shift</c>/<c>win</c>).</summary>
+    public IReadOnlySet<string> Modifiers { get; }
+
+    /// <summary>The main (non-modifier) key that, pressed with all <see cref="Modifiers"/> held, fires the stop.</summary>
+    public Keys Key { get; }
+
+    /// <summary>A normalized human-readable rendering of the chord (e.g. <c>Ctrl+Alt+Shift+S</c>).</summary>
+    public string Display { get; }
+
+    /// <summary>The parsed default chord.</summary>
+    public static EmergencyStopHotkey Default => Parse(DefaultSpec)!;
+
+    /// <summary>
+    /// Parses a <c>+</c>-separated chord spec (e.g. <c>Ctrl+Alt+Shift+S</c>, <c>Pause</c>). Returns null
+    /// when the spec is empty, names no main key, or names an unrecognized key. Modifier-only specs are
+    /// rejected (a chord must have exactly one non-modifier key).
+    /// </summary>
+    public static EmergencyStopHotkey? Parse(string? spec) {
+        if (string.IsNullOrWhiteSpace(spec)) {
+            return null;
+        }
+
+        HashSet<string> modifiers = [];
+        Keys? mainKey = null;
+        foreach (string rawToken in spec.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)) {
+            string token = rawToken.ToLowerInvariant();
+            string? modifier = NormalizeModifier(token);
+            if (modifier is not null) {
+                modifiers.Add(modifier);
+                continue;
+            }
+            if (mainKey is not null) {
+                // More than one non-modifier key — not a supported single-key chord.
+                return null;
+            }
+            if (ParseKey(token) is not Keys k) {
+                return null;
+            }
+            mainKey = k;
+        }
+
+        if (mainKey is null) {
+            return null;
+        }
+
+        string display = string.Join("+",
+            OrderModifiers(modifiers).Select(Capitalize).Append(KeyDisplay(mainKey.Value)));
+        return new EmergencyStopHotkey(modifiers, mainKey.Value, display);
+    }
+
+    /// <summary>
+    /// The canonical modifier name for a <see cref="Keys"/> value, or null when it is not a modifier. Left
+    /// and right variants (and the generic form) collapse to one name so the low-level hook's specific
+    /// L/R codes match a chord authored with the generic modifier name.
+    /// </summary>
+    public static string? ModifierName(Keys key) => key switch {
+        Keys.ShiftKey or Keys.LShiftKey or Keys.RShiftKey => "shift",
+        Keys.ControlKey or Keys.LControlKey or Keys.RControlKey => "ctrl",
+        Keys.Menu or Keys.LMenu or Keys.RMenu => "alt",
+        Keys.LWin or Keys.RWin => "win",
+        _ => null,
+    };
+
+    private static string? NormalizeModifier(string token) => token switch {
+        "ctrl" or "control" or "ctl" => "ctrl",
+        "alt" or "menu" => "alt",
+        "shift" or "shft" => "shift",
+        "win" or "windows" or "lwin" or "rwin" or "super" or "meta" => "win",
+        _ => null,
+    };
+
+    private static Keys? ParseKey(string token) {
+        // A single letter or digit.
+        if (token.Length == 1) {
+            char c = char.ToUpperInvariant(token[0]);
+            if (c is >= 'A' and <= 'Z') {
+                return Enum.Parse<Keys>(c.ToString());
+            }
+            if (c is >= '0' and <= '9') {
+                return Enum.Parse<Keys>("D" + c);
+            }
+        }
+
+        // Common aliases, then a general Keys parse (covers F1..F24, named keys, etc.).
+        return token switch {
+            "esc" or "escape" => Keys.Escape,
+            "pause" or "break" => Keys.Pause,
+            "space" or "spacebar" => Keys.Space,
+            "enter" or "return" => Keys.Enter,
+            "del" or "delete" => Keys.Delete,
+            "ins" or "insert" => Keys.Insert,
+            "home" => Keys.Home,
+            "end" => Keys.End,
+            "tab" => Keys.Tab,
+            _ => Enum.TryParse(token, ignoreCase: true, out Keys parsed) && parsed != Keys.None ? parsed : null,
+        };
+    }
+
+    private static IEnumerable<string> OrderModifiers(IEnumerable<string> modifiers) {
+        // Stable, conventional order regardless of how the operator typed the spec.
+        string[] order = ["ctrl", "alt", "shift", "win"];
+        return order.Where(modifiers.Contains);
+    }
+
+    private static string Capitalize(string s) => s switch {
+        "ctrl" => "Ctrl",
+        "alt" => "Alt",
+        "shift" => "Shift",
+        "win" => "Win",
+        _ => s,
+    };
+
+    private static string KeyDisplay(Keys key) => key switch {
+        >= Keys.D0 and <= Keys.D9 => ((char)('0' + (key - Keys.D0))).ToString(),
+        _ => key.ToString(),
+    };
+}

--- a/src/Agent/ProvisionedSession.cs
+++ b/src/Agent/ProvisionedSession.cs
@@ -1,0 +1,55 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// The handoff descriptor returned by <see cref="SessionProvisioner.Provision"/> (#138): everything an
+/// authorized agent needs to run a fresh, disposable, isolated MCEC instance — where it lives, how to
+/// launch it, how to reach its MCP server, and the id/token to tear it down. The installed MCEC's config
+/// is never touched; all enabled state lives only inside <see cref="Directory"/>, so teardown is just
+/// deleting that directory.
+/// </summary>
+public sealed class ProvisionedSession {
+    public required string SessionId { get; init; }
+
+    /// <summary>The disposable session directory (contains mcec.exe + deps + co-located agent-ready config).</summary>
+    public required string Directory { get; init; }
+
+    /// <summary>Full path to the mcec.exe the agent should launch (inside <see cref="Directory"/>).</summary>
+    public required string ExePath { get; init; }
+
+    /// <summary>Whether the co-located config enabled the MCP/HTTP transport for this session.</summary>
+    public required bool McpServerEnabled { get; init; }
+
+    /// <summary>The localhost bind address the session's MCP HTTP server uses (when enabled).</summary>
+    public required string BindAddress { get; init; }
+
+    /// <summary>The TCP port the session's MCP HTTP server uses (when enabled).</summary>
+    public required int Port { get; init; }
+
+    /// <summary>An opaque token identifying this provisioning (returned for symmetry with teardown/audit).</summary>
+    public required string Token { get; init; }
+
+    /// <summary>The MCP result payload the agent consumes: path, launch, connect, and teardown details.</summary>
+    public JsonObject ToJsonObject() {
+        JsonObject obj = new() {
+            ["sessionId"] = SessionId,
+            ["directory"] = Directory,
+            ["exePath"] = ExePath,
+            ["workingDir"] = Directory,
+            ["token"] = Token,
+            ["launch"] = $"Run \"{ExePath}\" --mcp from workingDir \"{Directory}\" (stdio MCP), or launch it and POST JSON-RPC to the HTTP endpoint below.",
+            ["mcpServerEnabled"] = McpServerEnabled,
+            ["teardown"] = "Call the end-session tool with this sessionId when finished (or just delete the directory); MCEC also reaps stale session dirs on launch.",
+        };
+        if (McpServerEnabled) {
+            obj["bindAddress"] = BindAddress;
+            obj["port"] = Port;
+            obj["mcpEndpoint"] = $"http://{BindAddress}:{Port}/mcp";
+        }
+        return obj;
+    }
+}

--- a/src/Agent/SessionProvisioner.cs
+++ b/src/Agent/SessionProvisioner.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Text.RegularExpressions;
 
 namespace MCEControl;
 
@@ -28,6 +29,12 @@ public static class SessionProvisioner {
     /// <summary>The agent observation/action commands enabled in a provisioned session's co-located command table.</summary>
     public static readonly string[] DefaultCommands =
         ["capture", "query", "displays", "find", "wait-for", "invoke", "drag", "click", "record"];
+
+    // A provisioned session id is a bare 12-char lowercase-hex token (Guid "N"[..12]). end-session accepts
+    // ONLY this shape so a caller can never pass a path/traversal token (e.g. ".." or "a/b") that would make
+    // Teardown delete something outside the sessions root. end-session is exposed over MCP and is not behind
+    // the provisioning-authorization gate, so this validation is the security boundary.
+    private static readonly Regex SessionIdPattern = new("^[0-9a-f]{12}$", RegexOptions.Compiled);
 
     private static string? _sessionsRoot;
 
@@ -108,15 +115,27 @@ public static class SessionProvisioner {
         if (string.IsNullOrWhiteSpace(sessionId)) {
             return false;
         }
-        // Guard against path traversal: a session id is a bare token, never a path.
-        string safeId = Path.GetFileName(sessionId.Trim());
-        string dir = Path.Combine(SessionsRoot, safeId);
+        // Guard against path traversal: only a well-formed session id (bare 12-hex token) is accepted, so a
+        // caller can never point Teardown at a directory outside the sessions root (e.g. "..", "a/b", rooted paths).
+        string id = sessionId.Trim();
+        if (!SessionIdPattern.IsMatch(id)) {
+            AgentRuntime.Audit("end-session", $"REJECTED — '{id}' is not a valid session id (expected 12 hex chars)");
+            return false;
+        }
+        string dir = Path.Combine(SessionsRoot, id);
+        // Defense in depth: confirm the resolved path really is inside the sessions root before deleting.
+        string fullRoot = Path.GetFullPath(SessionsRoot).TrimEnd(Path.DirectorySeparatorChar);
+        string fullDir = Path.GetFullPath(dir);
+        if (!fullDir.StartsWith(fullRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)) {
+            AgentRuntime.Audit("end-session", $"REJECTED — '{id}' resolves outside the sessions root");
+            return false;
+        }
         if (!Directory.Exists(dir)) {
-            AgentRuntime.Audit("end-session", $"{safeId} — directory already gone");
+            AgentRuntime.Audit("end-session", $"{id} — directory already gone");
             return true;
         }
         bool ok = TryDeleteDirectory(dir);
-        AgentRuntime.Audit("end-session", ok ? $"{safeId} — torn down ({dir})" : $"{safeId} — could not delete (in use?) {dir}");
+        AgentRuntime.Audit("end-session", ok ? $"{id} — torn down ({dir})" : $"{id} — could not delete (in use?) {dir}");
         return ok;
     }
 

--- a/src/Agent/SessionProvisioner.cs
+++ b/src/Agent/SessionProvisioner.cs
@@ -1,0 +1,268 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
+namespace MCEControl;
+
+/// <summary>
+/// Provisions a fresh, disposable, isolated MCEC instance (#138). Instead of an agent mutating the
+/// operator's <b>installed</b> config — flipping <c>AgentCommandsEnabled</c> / per-command <c>Enabled</c>
+/// and hoping best-effort cleanup runs — MCEC hands the agent a throwaway directory containing
+/// <c>mcec.exe</c> + dependencies and a <b>co-located</b>, agent-ready config. All enabled state lives only
+/// inside that copy, so a crashed or abandoned session leaves the real install untouched and "cleanup" is
+/// just deleting the directory. Concurrent sessions get separate directories and never fight over one file.
+///
+/// <para>SECURITY: provisioning itself is gated behind <see cref="AppSettings.AllowSessionProvisioning"/> —
+/// the one thing that cannot be self-served, or the isolation is theater. The co-located config disables
+/// <c>ActAsServer</c> (no firewall prompt) and <c>AllowSessionProvisioning</c> (a provisioned session can't
+/// re-provision), and binds the MCP server to localhost. The installed <c>mcec.settings</c> /
+/// <c>mcec.commands</c> are never read or written.</para>
+/// </summary>
+public static class SessionProvisioner {
+    /// <summary>The agent observation/action commands enabled in a provisioned session's co-located command table.</summary>
+    public static readonly string[] DefaultCommands =
+        ["capture", "query", "displays", "find", "wait-for", "invoke", "drag", "click", "record"];
+
+    private static string? _sessionsRoot;
+
+    /// <summary>
+    /// Root under which each session gets its own directory. Defaults to
+    /// <c>%LOCALAPPDATA%\MCEC\sessions</c> (temp fallback if that can't be resolved). Settable by tests.
+    /// </summary>
+    public static string SessionsRoot {
+        get => _sessionsRoot ??= DefaultSessionsRoot();
+        set => _sessionsRoot = value;
+    }
+
+    /// <summary>The directory the running mcec.exe (and its dependencies) live in — the copy source.</summary>
+    public static string BinariesDir { get; set; } = AppContext.BaseDirectory;
+
+    private static string DefaultSessionsRoot() {
+        try {
+            string local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!string.IsNullOrEmpty(local)) {
+                return Path.Combine(local, "MCEC", "sessions");
+            }
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Warn($"SessionProvisioner: falling back to temp sessions root: {e.Message}");
+        }
+        return Path.Combine(Path.GetTempPath(), "MCEC", "sessions");
+    }
+
+    /// <summary>
+    /// Creates a fresh session directory, copies the binaries in, writes an agent-ready co-located config,
+    /// and returns the handoff. Throws on failure after removing any partial directory.
+    /// </summary>
+    /// <param name="mcpServerEnabled">Enable the session's MCP/HTTP transport (bound to localhost).</param>
+    /// <param name="commands">Command names to enable in the session (defaults to <see cref="DefaultCommands"/>).</param>
+    public static ProvisionedSession Provision(bool mcpServerEnabled = true, IEnumerable<string>? commands = null) {
+        string sessionId = Guid.NewGuid().ToString("N")[..12];
+        string dir = Path.Combine(SessionsRoot, sessionId);
+        string version = System.Windows.Forms.Application.ProductVersion;
+        int port = mcpServerEnabled ? FindFreeLoopbackPort() : 0;
+        string[] enable = [.. (commands ?? DefaultCommands)
+            .Select(c => c.Trim())
+            .Where(c => !string.IsNullOrEmpty(c))
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+
+        try {
+            Directory.CreateDirectory(dir);
+            CopyBinaries(BinariesDir, dir);
+            WriteSessionSettings(dir, mcpServerEnabled, port);
+            WriteSessionCommands(dir, enable, version);
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Error($"SessionProvisioner: provisioning failed, cleaning up '{dir}': {e.Message}");
+            TryDeleteDirectory(dir);
+            throw new InvalidOperationException($"Failed to provision session '{sessionId}': {e.Message}", e);
+        }
+
+        string exePath = Path.Combine(dir, "mcec.exe");
+        AgentRuntime.Audit("provision-session",
+            $"provisioned {sessionId} at {dir} (mcp={mcpServerEnabled}{(mcpServerEnabled ? $" port={port}" : "")}, commands=[{string.Join(",", enable)}])");
+
+        return new ProvisionedSession {
+            SessionId = sessionId,
+            Directory = dir,
+            ExePath = exePath,
+            McpServerEnabled = mcpServerEnabled,
+            BindAddress = "127.0.0.1",
+            Port = port,
+            Token = Guid.NewGuid().ToString("N"),
+        };
+    }
+
+    /// <summary>
+    /// Tears down a provisioned session by deleting its directory. Returns true when the directory was
+    /// removed (or was already gone). A directory whose files are still locked (the session is running)
+    /// returns false — stop the session first.
+    /// </summary>
+    public static bool Teardown(string sessionId) {
+        if (string.IsNullOrWhiteSpace(sessionId)) {
+            return false;
+        }
+        // Guard against path traversal: a session id is a bare token, never a path.
+        string safeId = Path.GetFileName(sessionId.Trim());
+        string dir = Path.Combine(SessionsRoot, safeId);
+        if (!Directory.Exists(dir)) {
+            AgentRuntime.Audit("end-session", $"{safeId} — directory already gone");
+            return true;
+        }
+        bool ok = TryDeleteDirectory(dir);
+        AgentRuntime.Audit("end-session", ok ? $"{safeId} — torn down ({dir})" : $"{safeId} — could not delete (in use?) {dir}");
+        return ok;
+    }
+
+    /// <summary>
+    /// Belt-and-suspenders cleanup: deletes session directories older than <paramref name="maxAge"/> so a
+    /// leaked/abandoned session never lingers. A running session's files are locked and are skipped (they'll
+    /// be reaped on a later launch once the process exits). Best-effort — never throws. Returns the count
+    /// reaped.
+    /// </summary>
+    public static int ReapOrphans(TimeSpan maxAge) {
+        int reaped = 0;
+        try {
+            if (!Directory.Exists(SessionsRoot)) {
+                return 0;
+            }
+            DateTime cutoff = DateTime.UtcNow - maxAge;
+            foreach (string dir in Directory.GetDirectories(SessionsRoot)) {
+                DateTime created;
+                try {
+                    created = Directory.GetCreationTimeUtc(dir);
+                }
+                catch (Exception e) {
+                    Logger.Instance.Log4.Warn($"SessionProvisioner: could not stat '{dir}': {e.Message}");
+                    continue;
+                }
+                if (created > cutoff) {
+                    continue; // too new — could be an active or just-provisioned session
+                }
+                if (TryDeleteDirectory(dir)) {
+                    reaped++;
+                    Logger.Instance.Log4.Info($"SessionProvisioner: reaped stale session dir {dir}");
+                }
+            }
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Warn($"SessionProvisioner: reaping failed: {e.Message}");
+        }
+        if (reaped > 0) {
+            AgentRuntime.Audit("provision-session", $"reaped {reaped} stale session dir(s) under {SessionsRoot}");
+        }
+        return reaped;
+    }
+
+    /// <summary>Recursively copies the binaries, skipping any mutable config/log the installed instance left behind.</summary>
+    private static void CopyBinaries(string source, string dest) {
+        // Never carry the installed instance's mutable state into the copy — the session gets a fresh,
+        // agent-ready config written separately. Also never recurse into the sessions root if it happens
+        // to live under the binaries dir.
+        Directory.CreateDirectory(dest);
+        foreach (string file in Directory.GetFiles(source)) {
+            string name = Path.GetFileName(file);
+            if (IsExcludedFile(name)) {
+                continue;
+            }
+            File.Copy(file, Path.Combine(dest, name), overwrite: true);
+        }
+        foreach (string subDir in Directory.GetDirectories(source)) {
+            if (string.Equals(Path.GetFullPath(subDir).TrimEnd(Path.DirectorySeparatorChar),
+                              Path.GetFullPath(SessionsRoot).TrimEnd(Path.DirectorySeparatorChar),
+                              StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+            CopyBinaries(subDir, Path.Combine(dest, Path.GetFileName(subDir)));
+        }
+    }
+
+    private static bool IsExcludedFile(string name) =>
+        name.Equals(AppSettings.SettingsFileName, StringComparison.OrdinalIgnoreCase)
+        || name.Equals("mcec.commands", StringComparison.OrdinalIgnoreCase)
+        || name.EndsWith(".log", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Writes the co-located, agent-ready <c>mcec.settings</c> for the session.</summary>
+    private static void WriteSessionSettings(string dir, bool mcpServerEnabled, int port) {
+        AppSettings settings = new() {
+            AgentCommandsEnabled = true,          // this copy is FOR the agent; enabled only here
+            McpServerEnabled = mcpServerEnabled,
+            McpBindAddress = "127.0.0.1",         // localhost only
+            McpHttpPort = port,
+            ActAsServer = false,                  // no TCP server → no Windows Firewall prompt (isolation practice)
+            ActAsSerialServer = false,
+            ActAsClient = false,
+            ActivityMonitorEnabled = false,
+            CommandOverlayEnabled = true,         // keep the "MCEC is driving" overlay for auditability
+            EmergencyStopEnabled = true,          // the operator panic hotkey still applies to the session
+            AllowSessionProvisioning = false,     // a provisioned session must not re-provision
+            HideOnStartup = false,
+        };
+        settings.Serialize(Path.Combine(dir, AppSettings.SettingsFileName));
+    }
+
+    /// <summary>Writes the co-located <c>mcec.commands</c> enabling the requested agent commands.</summary>
+    private static void WriteSessionCommands(string dir, IReadOnlyList<string> commands, string version) {
+        List<Command> list = [];
+        foreach (string name in commands) {
+            Command? cmd = CreateEnabledCommand(name);
+            if (cmd is null) {
+                Logger.Instance.Log4.Warn($"SessionProvisioner: unknown command '{name}' requested; skipping.");
+                continue;
+            }
+            list.Add(cmd);
+        }
+        SerializedCommands sc = new() { commandArray = [.. list] };
+        SerializedCommands.SaveCommands(Path.Combine(dir, "mcec.commands"), sc, version);
+    }
+
+    /// <summary>
+    /// Builds the correctly-typed <see cref="Command"/> for a name, enabled, so it serializes under the
+    /// right element (query/capture/invoke/…) and loads back as the right derived type. Returns null for an
+    /// unknown name.
+    /// </summary>
+    private static Command? CreateEnabledCommand(string name) => name.ToLowerInvariant() switch {
+        "capture" => new CaptureCommand { Cmd = "capture", Enabled = true },
+        "query" => new QueryCommand { Cmd = "query", Enabled = true },
+        "displays" => new DisplaysCommand { Cmd = "displays", Enabled = true },
+        "find" => new FindCommand { Cmd = "find", Enabled = true },
+        "wait-for" => new FindCommand { Cmd = "wait-for", Enabled = true },
+        "invoke" => new InvokeCommand { Cmd = "invoke", Enabled = true },
+        "drag" => new DragCommand { Cmd = "drag", Enabled = true },
+        "click" => new ClickCommand { Cmd = "click", Enabled = true },
+        "record" => new RecordCommand { Cmd = "record", Enabled = true },
+        _ => null,
+    };
+
+    /// <summary>Asks the OS for a free loopback TCP port by binding to port 0 and reading the assignment.</summary>
+    private static int FindFreeLoopbackPort() {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        try {
+            listener.Start();
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally {
+            listener.Stop();
+        }
+    }
+
+    private static bool TryDeleteDirectory(string dir) {
+        try {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, recursive: true);
+            }
+            return true;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException) {
+            // Files are locked (session still running) — leave it for a later reap.
+            Logger.Instance.Log4.Warn($"SessionProvisioner: could not delete '{dir}': {e.Message}");
+            return false;
+        }
+    }
+}

--- a/src/Commands/CommandInvoker.cs
+++ b/src/Commands/CommandInvoker.cs
@@ -215,6 +215,19 @@ public class CommandInvoker : Hashtable {
         // TODO: This is simple and just dequeues and executes anything on the queue
         // needs to be smarter? Will this block incoming?
         while (executeQueue.TryDequeue(out ICommand? icmd)) {
+            // Emergency stop (#135): if the operator engaged the panic hotkey, drop the rest of the queue
+            // instead of actuating it. A paced/embedded command sequence (a macro, or commands after a
+            // `pause`) must not keep firing after the stop — checking the latch BETWEEN commands is what
+            // makes "the queue is dropped" true rather than only latching future tool calls.
+            if (AgentRuntime.EmergencyStopped) {
+                int dropped = 1; // the command we just dequeued and are NOT running
+                while (executeQueue.TryDequeue(out _)) {
+                    dropped++;
+                }
+                Logger.Instance.Log4.Warn($"{GetType().Name}: emergency stop engaged — dropped {dropped} queued command(s) without executing.");
+                break;
+            }
+
             ((Command)icmd).Execute();
             // Read pacing via the UI-agnostic AgentRuntime seam so the engine works headless
             // (--mcp) where there is no MainWindow. In GUI mode this is the same settings object.

--- a/src/Commands/MouseCommand.cs
+++ b/src/Commands/MouseCommand.cs
@@ -344,6 +344,12 @@ public class MouseCommand : Command {
         sim.Mouse.LeftButtonDown();
         Thread.Sleep(DragPressDwellMs);
         for (int i = 1; i < path.Count; i++) {
+            // Emergency stop (#135): if the operator engaged the panic hotkey mid-drag, stop advancing and
+            // fall through to release the button now, so the gesture can't drag on with the button held.
+            if (AgentRuntime.EmergencyStopped) {
+                Logger.Instance.Log4.Warn($"{nameof(MouseCommand)}: drag aborted by emergency stop at point {i}/{path.Count}.");
+                break;
+            }
             MoveToPixel(sim, path[i], vs);
             Thread.Sleep(DragMoveDwellMs);
         }

--- a/src/Gma.UserActivityMonitor/GlobalKeyEventArgs.cs
+++ b/src/Gma.UserActivityMonitor/GlobalKeyEventArgs.cs
@@ -1,0 +1,34 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Windows.Forms;
+
+namespace Gma.UserActivityMonitor;
+
+/// <summary>
+/// Extended global key event surfaced by <see cref="HookManager"/>'s low-level keyboard hook. Unlike the
+/// plain <see cref="KeyEventArgs"/> events, this one carries whether the key was <see cref="Injected"/>
+/// (synthesized by software via <c>SendInput</c>, flagged <c>LLKHF_INJECTED</c> by Windows) rather than
+/// pressed on real hardware.
+///
+/// <para>The emergency-stop (#135) needs this distinction: MCEC's own agent actuation injects keystrokes,
+/// so an e-stop that reacted to injected keys could be tripped — or defeated — by the very agent it is
+/// meant to override. Reacting to <see cref="Injected"/> == <c>false</c> only makes the hotkey a true
+/// human override.</para>
+/// </summary>
+public sealed class GlobalKeyEventArgs : EventArgs {
+    public GlobalKeyEventArgs(Keys keyCode, bool injected) {
+        KeyCode = keyCode;
+        Injected = injected;
+    }
+
+    /// <summary>The virtual key code of the event (as a WinForms <see cref="Keys"/> value).</summary>
+    public Keys KeyCode { get; }
+
+    /// <summary>True when the event was software-injected (<c>LLKHF_INJECTED</c>), false for real hardware input.</summary>
+    public bool Injected { get; }
+
+    /// <summary>Set to true to suppress the key from further processing by other applications.</summary>
+    public bool Handled { get; set; }
+}

--- a/src/Gma.UserActivityMonitor/HookManager.Callbacks.cs
+++ b/src/Gma.UserActivityMonitor/HookManager.Callbacks.cs
@@ -308,12 +308,34 @@ public static partial class HookManager {
         if (nCode >= 0) {
             //read structure KeyboardHookStruct at lParam
             KeyboardHookStruct MyKeyboardHookStruct = (KeyboardHookStruct)Marshal.PtrToStructure(lParam, typeof(KeyboardHookStruct))!;
+
+            // LLKHF_INJECTED (0x10): the event was synthesized by SendInput rather than pressed on real
+            // hardware. Surfaced on the *Ext events so the emergency-stop (#135) can react to physical
+            // input only — MCEC's own agent actuation injects keys, and the panic hotkey must be immune to
+            // both accidental self-trip and deliberate self-defeat.
+            const int LLKHF_INJECTED = 0x10;
+            bool injected = (MyKeyboardHookStruct.Flags & LLKHF_INJECTED) != 0;
+
             //raise KeyDown
             if (s_KeyDown != null && (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN)) {
                 Keys keyData = (Keys)MyKeyboardHookStruct.VirtualKeyCode;
                 KeyEventArgs e = new KeyEventArgs(keyData);
                 s_KeyDown.Invoke(null, e);
                 handled = e.Handled;
+            }
+
+            //raise KeyDownExt (with injected flag)
+            if (s_KeyDownExt != null && (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN)) {
+                GlobalKeyEventArgs ge = new((Keys)MyKeyboardHookStruct.VirtualKeyCode, injected);
+                s_KeyDownExt.Invoke(null, ge);
+                handled = handled || ge.Handled;
+            }
+
+            //raise KeyUpExt (with injected flag)
+            if (s_KeyUpExt != null && (wParam == WM_KEYUP || wParam == WM_SYSKEYUP)) {
+                GlobalKeyEventArgs ge = new((Keys)MyKeyboardHookStruct.VirtualKeyCode, injected);
+                s_KeyUpExt.Invoke(null, ge);
+                handled = handled || ge.Handled;
             }
 
             // raise KeyPress
@@ -392,7 +414,9 @@ public static partial class HookManager {
         //if no subsribers are registered unsubsribe from hook
         if (s_KeyDown == null &&
             s_KeyUp == null &&
-            s_KeyPress == null) {
+            s_KeyPress == null &&
+            s_KeyDownExt == null &&
+            s_KeyUpExt == null) {
             ForceUnsunscribeFromGlobalKeyboardEvents();
         }
     }

--- a/src/Gma.UserActivityMonitor/HookManager.cs
+++ b/src/Gma.UserActivityMonitor/HookManager.cs
@@ -270,7 +270,7 @@ public static partial class HookManager {
     private static event KeyEventHandler s_KeyDown = null!;
 
     /// <summary>
-    /// Occurs when a key is preseed. 
+    /// Occurs when a key is preseed.
     /// </summary>
     public static event KeyEventHandler KeyDown {
         add {
@@ -279,6 +279,41 @@ public static partial class HookManager {
         }
         remove {
             s_KeyDown -= value;
+            TryUnsubscribeFromGlobalKeyboardEvents();
+        }
+    }
+
+    internal static event EventHandler<GlobalKeyEventArgs>? s_KeyDownExt;
+
+    /// <summary>
+    /// Occurs when a key is pressed, with the software-injected flag exposed (see
+    /// <see cref="GlobalKeyEventArgs.Injected"/>). Used by the emergency-stop (#135) so the panic hotkey
+    /// reacts to real hardware input only and can never be tripped or defeated by injected keystrokes.
+    /// </summary>
+    public static event EventHandler<GlobalKeyEventArgs> KeyDownExt {
+        add {
+            EnsureSubscribedToGlobalKeyboardEvents();
+            s_KeyDownExt += value;
+        }
+        remove {
+            s_KeyDownExt -= value;
+            TryUnsubscribeFromGlobalKeyboardEvents();
+        }
+    }
+
+    internal static event EventHandler<GlobalKeyEventArgs>? s_KeyUpExt;
+
+    /// <summary>
+    /// Occurs when a key is released, with the software-injected flag exposed. The emergency-stop tracks
+    /// physically-held modifiers via this so a released modifier never leaves the chord half-armed.
+    /// </summary>
+    public static event EventHandler<GlobalKeyEventArgs> KeyUpExt {
+        add {
+            EnsureSubscribedToGlobalKeyboardEvents();
+            s_KeyUpExt += value;
+        }
+        remove {
+            s_KeyUpExt -= value;
             TryUnsubscribeFromGlobalKeyboardEvents();
         }
     }

--- a/src/InternalsVisibleTo.cs
+++ b/src/InternalsVisibleTo.cs
@@ -1,0 +1,8 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Runtime.CompilerServices;
+
+// Expose internal members (e.g. AgentRuntime.SetEmergencyStopped) to the unit-test assembly so tests can
+// drive process-global safety state directly without going through the input-injecting orchestration.
+[assembly: InternalsVisibleTo("MCEControl.xUnit")]

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -36,6 +36,10 @@ public partial class MainWindow : Form {
     // The on-screen command overlay (#119), when enabled. Null in headless mode or when disabled.
     private CommandOverlayWindow? commandOverlay;
 
+    // Emergency stop (#135): the "Re-arm" affordance, shown on the menu only while a stop is engaged.
+    private ToolStripMenuItem? rearmMenuItem;
+    private bool emergencyStopArmed;
+
     // Indicates whether user hit the close box (minimize)
     // or the app is exiting
     private bool shuttingDown;
@@ -91,6 +95,12 @@ public partial class MainWindow : Form {
             }
 
             UpdateService.Instance.GotLatestVersion -= UpdateService_GotLatestVersion;
+
+            EmergencyStop.StateChanged -= OnEmergencyStopStateChanged;
+            if (emergencyStopArmed) {
+                EmergencyStop.Stop();
+                emergencyStopArmed = false;
+            }
         }
         base.Dispose(disposing);
     }
@@ -171,7 +181,40 @@ public partial class MainWindow : Form {
 
         UpdateService.Instance.GotLatestVersion += UpdateService_GotLatestVersion;
 
+        SetUpEmergencyStopUi();
+
         Start();
+    }
+
+    /// <summary>
+    /// Adds the emergency-stop (#135) "Re-arm" menu item and wires it to <see cref="EmergencyStop"/>. The
+    /// item is a clear operator affordance that appears only while a stop is engaged; the latch is never
+    /// cleared automatically. Built in code (not the designer) so the safety UI travels with the feature.
+    /// </summary>
+    private void SetUpEmergencyStopUi() {
+        rearmMenuItem = new ToolStripMenuItem("⛔ &Re-arm (Emergency Stop)") {
+            Visible = false,
+            ForeColor = System.Drawing.Color.Firebrick,
+        };
+        rearmMenuItem.Click += (_, _) => EmergencyStop.Rearm();
+        menuStrip.Items.Add(rearmMenuItem);
+
+        EmergencyStop.StateChanged += OnEmergencyStopStateChanged;
+    }
+
+    private void OnEmergencyStopStateChanged(bool stopped) {
+        // StateChanged fires on the global-hook thread; marshal to the UI thread to touch the menu.
+        if (rearmMenuItem is null) {
+            return;
+        }
+        if (menuStrip.InvokeRequired) {
+            menuStrip.BeginInvoke((Action)(() => OnEmergencyStopStateChanged(stopped)));
+            return;
+        }
+        rearmMenuItem.Visible = stopped;
+        SetStatus(stopped
+            ? $"⛔ STOPPED by operator — Re-arm to resume ({EmergencyStop.StoppedReason})"
+            : $"Version: {Application.ProductVersion}");
     }
 
     private void UpdateService_GotLatestVersion(object? sender, Version version) {
@@ -273,6 +316,20 @@ public partial class MainWindow : Form {
             AgentServer.StartHttp();
         }
 
+        // MCEC 3.0: emergency stop (#135) — a global panic hotkey that halts an agent session from ANY
+        // focused window. Arm it here in the GUI host (the low-level keyboard hook needs this thread's
+        // message loop) whenever the agent front door could be driving. It reacts to physical input only,
+        // so the agent can never trip or defeat it.
+        if (!AgentRuntime.Headless && Settings.EmergencyStopEnabled && (Settings.McpServerEnabled || Settings.AgentCommandsEnabled)) {
+            EmergencyStopHotkey? parsed = EmergencyStopHotkey.Parse(Settings.EmergencyStopHotkey);
+            if (parsed is null) {
+                Logger.Instance.Log4.Warn($"EmergencyStop: could not parse hotkey '{Settings.EmergencyStopHotkey}'; using default {EmergencyStopHotkey.DefaultSpec}.");
+                parsed = EmergencyStopHotkey.Default;
+            }
+            EmergencyStop.Start(parsed);
+            emergencyStopArmed = true;
+        }
+
         // MCEC 3.0: on-screen command overlay (#119) — narrates each command as it executes so anyone
         // watching sees that MCEC is driving. On by default; never shown headless. Independent (not
         // owned) so it keeps narrating even when the MCEC window is minimized to the tray.
@@ -299,6 +356,10 @@ public partial class MainWindow : Form {
         else {
             UserActivityMonitorService.Instance.Stop();
             AgentServer.StopHttp();
+            if (emergencyStopArmed) {
+                EmergencyStop.Stop();
+                emergencyStopArmed = false;
+            }
             commandOverlay?.Dispose();
             commandOverlay = null;
             StopClient();

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -76,6 +76,10 @@ internal static class Program {
         // v3.0: carry an existing user's MCEControl.settings/.commands forward to the new mcec.* names.
         ConfigMigration.Run(ConfigPath);
 
+        // #138: belt-and-suspenders — reap any stale/abandoned provisioned session directories so a leaked
+        // session (crashed/killed before teardown) never lingers. Running sessions' files are locked and skipped.
+        SessionProvisioner.ReapOrphans(TimeSpan.FromHours(AgentServer.SessionReapAgeHours));
+
         AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
         TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -241,6 +241,25 @@ public static class AgentServer {
             new JsonObject { ["command"] = PropSchema("string", "The MCEC command string to enqueue") },
             ["command"]));
 
+        // Isolated session provisioning (#138). Requires the operator to have opted in
+        // (AllowSessionProvisioning); it never mutates the installed config.
+        JsonObject provisionProps = new() {
+            ["mcpServer"] = PropSchema("boolean", "Enable the provisioned instance's localhost MCP/HTTP server (default true)"),
+            ["commands"] = new JsonObject {
+                ["type"] = "array",
+                ["description"] = "Command names to enable in the session (default: the agent observation/action set)",
+                ["items"] = new JsonObject { ["type"] = "string" },
+            },
+        };
+        tools.Add(Tool("provision-session",
+            "Get a fresh, disposable, isolated MCEC instance to run from instead of enabling the installed one. Returns a directory containing mcec.exe + an agent-ready co-located config (agent commands enabled ONLY inside the copy), plus how to launch/connect and the sessionId to tear it down. Requires the operator to have enabled AllowSessionProvisioning; the installed config is never touched. Call end-session (or delete the directory) when finished.",
+            provisionProps, []));
+
+        tools.Add(Tool("end-session",
+            "Tear down a provisioned session (from provision-session) by deleting its directory. Stop the session's mcec.exe first, or its files stay locked. MCEC also reaps stale session dirs on launch.",
+            new JsonObject { ["sessionId"] = PropSchema("string", "The sessionId returned by provision-session") },
+            ["sessionId"]));
+
         return tools;
     }
 
@@ -262,8 +281,27 @@ public static class AgentServer {
         string name = AsString(prms?["name"]);
         JsonObject args = prms?["arguments"] as JsonObject ?? [];
 
+        // Emergency stop (#135): once the operator engages the panic hotkey, EVERY tool call is refused
+        // (actuation, observation, and raw send_command alike) until they explicitly re-arm — the human
+        // override latches and is checked before anything else. A distinct error code tells the agent to
+        // stop and surface it, not retry.
+        if (AgentRuntime.EmergencyStopped) {
+            AgentRuntime.Audit(name, "BLOCKED — emergency stop engaged; operator must re-arm");
+            return ToolError(
+                "Emergency stop is engaged — the operator halted this session. All tool calls are refused until they re-arm. Stop and tell the user; do not retry.",
+                "emergency-stopped");
+        }
+
         if (name == "send_command") {
             return RunSendCommand(args);
+        }
+
+        if (name == "provision-session") {
+            return RunProvisionSession(args);
+        }
+
+        if (name == "end-session") {
+            return RunEndSession(args);
         }
 
         if (name is "capture" or "query" or "displays" or "find" or "wait-for" or "invoke" or "record" or "drag" or "click") {
@@ -476,6 +514,67 @@ public static class AgentServer {
         JsonObject result = new() { ["output"] = string.IsNullOrEmpty(captured) ? "ok" : captured };
         CommandEventHub.Publish(new CommandEvent("send_command", CommandTersifier.ForRawCommand(command), CommandOutcome.Ok, session.SessionId));
         return McpResult(AgentToolResult.Success(result, session.SessionId));
+    }
+
+    /// <summary>
+    /// Provisions a fresh, disposable, isolated MCEC instance (#138) and returns the handoff. Gated behind
+    /// the operator's <see cref="AppSettings.AllowSessionProvisioning"/> opt-in — the one thing that cannot
+    /// be self-served — and never touches the installed config. Also reaps stale session dirs opportunistically.
+    /// </summary>
+    private static JsonObject RunProvisionSession(JsonObject args) {
+        if (AgentRuntime.Settings?.AllowSessionProvisioning != true) {
+            AgentRuntime.Audit("provision-session", "BLOCKED — session provisioning is not authorized");
+            return ToolError(
+                "Session provisioning is not authorized. The operator must enable AllowSessionProvisioning to opt in; it cannot be self-served.",
+                "provisioning-not-authorized");
+        }
+
+        bool mcpServer = args["mcpServer"] is not JsonValue mv || !mv.TryGetValue(out bool m) || m; // default true
+        List<string>? commands = StrArray(args["commands"] as JsonArray);
+
+        try {
+            SessionProvisioner.ReapOrphans(TimeSpan.FromHours(SessionReapAgeHours));
+            ProvisionedSession session = SessionProvisioner.Provision(mcpServer, commands);
+            return McpResult(AgentToolResult.Success(session.ToJsonObject(), AgentRuntime.Session.SessionId));
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Error($"AgentServer: provision-session failed: {e.Message}");
+            return ToolError($"Failed to provision a session: {e.Message}", "provisioning-failed");
+        }
+    }
+
+    /// <summary>Tears down a provisioned session directory by id (#138).</summary>
+    private static JsonObject RunEndSession(JsonObject args) {
+        string? sessionId = Str(args, "sessionId");
+        if (string.IsNullOrWhiteSpace(sessionId)) {
+            return ToolError("end-session requires a non-empty 'sessionId' argument.", "bad-arguments");
+        }
+        bool removed = SessionProvisioner.Teardown(sessionId);
+        JsonObject result = new() {
+            ["sessionId"] = sessionId,
+            ["removed"] = removed,
+        };
+        if (!removed) {
+            result["note"] = "The session directory could not be deleted — its mcec.exe may still be running. Stop it and retry, or MCEC will reap it on a later launch.";
+        }
+        return McpResult(AgentToolResult.Success(result, AgentRuntime.Session.SessionId));
+    }
+
+    /// <summary>Age after which an orphaned/abandoned provisioned session directory is reaped on launch/provision.</summary>
+    public const int SessionReapAgeHours = 12;
+
+    /// <summary>Reads a JSON array of strings into a list, or null when the node is absent/empty.</summary>
+    private static List<string>? StrArray(JsonArray? array) {
+        if (array is null || array.Count == 0) {
+            return null;
+        }
+        List<string> items = [];
+        foreach (JsonNode? node in array) {
+            if (node is JsonValue v && v.TryGetValue(out string? s) && !string.IsNullOrWhiteSpace(s)) {
+                items.Add(s);
+            }
+        }
+        return items.Count > 0 ? items : null;
     }
 
     /// <summary>Builds and populates an agent command instance from MCP tool arguments.</summary>

--- a/src/Services/AppSettings.cs
+++ b/src/Services/AppSettings.cs
@@ -127,6 +127,24 @@ public class AppSettings : ICloneable {
     [SafeForTelemetryAttribute]
     public bool McpServerEnabled { get; set; } = false;
 
+    // --- Emergency stop (issue #135) ---
+    // SAFETY: a global "dead man's switch" hotkey the operator can hit from ANY window to instantly halt
+    // an agent session. On by default whenever the agent front door is used; reacts to physical input only
+    // (the agent can never trip or defeat it). The default chord is one no app uses and the agent never
+    // synthesizes. See EmergencyStopHotkey for the accepted spec format.
+    [SafeForTelemetryAttribute]
+    public bool EmergencyStopEnabled { get; set; } = true;
+
+    // TELEMETRY: a rebound hotkey is a benign UI preference, but keep it out of telemetry for simplicity.
+    public string EmergencyStopHotkey { get; set; } = MCEControl.EmergencyStopHotkey.DefaultSpec;
+
+    // --- Isolated session provisioning (issue #138) ---
+    // SECURITY: an agent asks MCEC to hand it a fresh, disposable instance dir (agent commands enabled only
+    // inside the copy) instead of mutating the installed config. Provisioning is the ONE thing that cannot
+    // be self-served — it must be an explicit operator opt-in or the isolation is theater. Off by default.
+    [SafeForTelemetryAttribute]
+    public bool AllowSessionProvisioning { get; set; } = false;
+
     // TELEMETRY: A bind address is PII-adjacent, so it is not collected.
     public string McpBindAddress { get; set; } = "127.0.0.1";
     [SafeForTelemetryAttribute]

--- a/tests/MCEControl.xUnit/Agent/EmergencyStopDetectorTests.cs
+++ b/tests/MCEControl.xUnit/Agent/EmergencyStopDetectorTests.cs
@@ -1,0 +1,100 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Windows.Forms;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Unit tests for the emergency-stop (#135) chord detector — most importantly that it fires only on the
+/// full chord and NEVER on injected (agent-synthesized) input.
+/// </summary>
+public class EmergencyStopDetectorTests {
+    private static EmergencyStopDetector Default() => new(EmergencyStopHotkey.Default);
+
+    private static void HoldChordModifiers(EmergencyStopDetector d, bool injected = false) {
+        d.OnKeyDown(Keys.LControlKey, injected);
+        d.OnKeyDown(Keys.LMenu, injected);   // alt
+        d.OnKeyDown(Keys.LShiftKey, injected);
+    }
+
+    [Fact]
+    public void PhysicalChord_Fires() {
+        EmergencyStopDetector d = Default();
+        HoldChordModifiers(d);
+
+        Assert.True(d.OnKeyDown(Keys.S, injected: false));
+    }
+
+    [Fact]
+    public void InjectedTriggerKey_NeverFires_EvenWithPhysicalModifiers() {
+        EmergencyStopDetector d = Default();
+        HoldChordModifiers(d, injected: false);
+
+        // The agent injecting the S keypress must not trip the stop.
+        Assert.False(d.OnKeyDown(Keys.S, injected: true));
+    }
+
+    [Fact]
+    public void InjectedModifiers_DoNotArmChord() {
+        EmergencyStopDetector d = Default();
+        // All modifiers arrive injected (agent holding them); a physical S alone must NOT complete the chord.
+        HoldChordModifiers(d, injected: true);
+
+        Assert.False(d.OnKeyDown(Keys.S, injected: false));
+    }
+
+    [Fact]
+    public void MissingModifier_DoesNotFire() {
+        EmergencyStopDetector d = Default();
+        d.OnKeyDown(Keys.LControlKey, false);
+        d.OnKeyDown(Keys.LShiftKey, false);
+        // No Alt held.
+        Assert.False(d.OnKeyDown(Keys.S, injected: false));
+    }
+
+    [Fact]
+    public void ReleasedModifier_DisarmsChord() {
+        EmergencyStopDetector d = Default();
+        HoldChordModifiers(d);
+        d.OnKeyUp(Keys.LMenu, injected: false); // release Alt physically
+
+        Assert.False(d.OnKeyDown(Keys.S, injected: false));
+    }
+
+    [Fact]
+    public void InjectedModifierRelease_IsIgnored_ChordStillArmed() {
+        EmergencyStopDetector d = Default();
+        HoldChordModifiers(d);
+        // An injected Alt-up (agent releasing) must not disarm a physically-held chord.
+        d.OnKeyUp(Keys.LMenu, injected: true);
+
+        Assert.True(d.OnKeyDown(Keys.S, injected: false));
+    }
+
+    [Fact]
+    public void WrongMainKey_DoesNotFire() {
+        EmergencyStopDetector d = Default();
+        HoldChordModifiers(d);
+        Assert.False(d.OnKeyDown(Keys.Q, injected: false));
+    }
+
+    [Fact]
+    public void Reset_ClearsHeldModifiers() {
+        EmergencyStopDetector d = Default();
+        HoldChordModifiers(d);
+        d.Reset();
+        Assert.False(d.OnKeyDown(Keys.S, injected: false));
+    }
+
+    [Fact]
+    public void ExtraModifierHeld_StillFires() {
+        // Win also held alongside the required Ctrl+Alt+Shift — the required subset is present, so it fires.
+        EmergencyStopDetector d = Default();
+        HoldChordModifiers(d);
+        d.OnKeyDown(Keys.LWin, injected: false);
+        Assert.True(d.OnKeyDown(Keys.S, injected: false));
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/EmergencyStopHotkeyTests.cs
+++ b/tests/MCEControl.xUnit/Agent/EmergencyStopHotkeyTests.cs
@@ -1,0 +1,68 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Windows.Forms;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>Unit tests for parsing the emergency-stop (#135) hotkey spec.</summary>
+public class EmergencyStopHotkeyTests {
+    [Fact]
+    public void Default_IsCtrlAltShiftS() {
+        EmergencyStopHotkey hk = EmergencyStopHotkey.Default;
+
+        Assert.Equal(Keys.S, hk.Key);
+        Assert.Equal(3, hk.Modifiers.Count);
+        Assert.Contains("ctrl", hk.Modifiers);
+        Assert.Contains("alt", hk.Modifiers);
+        Assert.Contains("shift", hk.Modifiers);
+        Assert.Equal("Ctrl+Alt+Shift+S", hk.Display);
+    }
+
+    [Theory]
+    [InlineData("ctrl+alt+shift+s")]
+    [InlineData("Shift+Ctrl+Alt+S")]   // order-independent
+    [InlineData("  Ctrl + Alt + Shift + S ")] // whitespace tolerant
+    public void Parse_NormalizesToCanonicalDisplay(string spec) {
+        EmergencyStopHotkey hk = EmergencyStopHotkey.Parse(spec)!;
+        Assert.Equal("Ctrl+Alt+Shift+S", hk.Display);
+    }
+
+    [Fact]
+    public void Parse_SingleDedicatedKey_NoModifiers() {
+        EmergencyStopHotkey hk = EmergencyStopHotkey.Parse("Pause")!;
+        Assert.Equal(Keys.Pause, hk.Key);
+        Assert.Empty(hk.Modifiers);
+    }
+
+    [Fact]
+    public void Parse_Digit_MapsToDKey() {
+        EmergencyStopHotkey hk = EmergencyStopHotkey.Parse("Ctrl+1")!;
+        Assert.Equal(Keys.D1, hk.Key);
+        Assert.Single(hk.Modifiers);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Ctrl+Alt+Shift")]     // modifier-only, no main key
+    [InlineData("Ctrl+A+B")]           // two non-modifier keys
+    [InlineData("Ctrl+NotAKey")]       // unknown key name
+    [InlineData(null)]
+    public void Parse_Invalid_ReturnsNull(string? spec) {
+        Assert.Null(EmergencyStopHotkey.Parse(spec));
+    }
+
+    [Theory]
+    [InlineData(Keys.LControlKey, "ctrl")]
+    [InlineData(Keys.RControlKey, "ctrl")]
+    [InlineData(Keys.LShiftKey, "shift")]
+    [InlineData(Keys.RMenu, "alt")]
+    [InlineData(Keys.LWin, "win")]
+    [InlineData(Keys.S, null)]
+    public void ModifierName_CollapsesLeftRightVariants(Keys key, string? expected) {
+        Assert.Equal(expected, EmergencyStopHotkey.ModifierName(key));
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/SessionProvisionerTests.cs
+++ b/tests/MCEControl.xUnit/Agent/SessionProvisionerTests.cs
@@ -1,0 +1,146 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.IO;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Unit tests for isolated session provisioning (#138): the provisioned copy is isolated from the
+/// installed instance, agent commands are enabled only inside it, and teardown/reaping clean up.
+/// Mutates the process-global <see cref="SessionProvisioner.SessionsRoot"/>/<c>BinariesDir</c>, so it
+/// joins the serial agent collection; each test also uses a unique temp root.
+/// </summary>
+[Collection("AgentSerial")]
+public class SessionProvisionerTests : IDisposable {
+    private readonly string _root;
+    private readonly string _fakeBinaries;
+    private readonly string _origRoot;
+    private readonly string _origBinaries;
+
+    public SessionProvisionerTests() {
+        _origRoot = SessionProvisioner.SessionsRoot;
+        _origBinaries = SessionProvisioner.BinariesDir;
+
+        string baseTemp = Path.Combine(Path.GetTempPath(), "mcec-provision-test", Path.GetRandomFileName());
+        _root = Path.Combine(baseTemp, "sessions");
+        _fakeBinaries = Path.Combine(baseTemp, "install");
+        Directory.CreateDirectory(_fakeBinaries);
+
+        // A minimal fake "installed" layout: an exe + a dll (copied), and the installed instance's mutable
+        // config + a log (must NOT be copied — the session gets its own fresh config).
+        File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.exe"), "stub");
+        File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.dll"), "stub");
+        File.WriteAllText(Path.Combine(_fakeBinaries, AppSettings.SettingsFileName), "<AppSettings><AgentCommandsEnabled>false</AgentCommandsEnabled></AppSettings>");
+        File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.commands"), "<installed/>");
+        File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.log"), "old log");
+        Directory.CreateDirectory(Path.Combine(_fakeBinaries, "runtimes"));
+        File.WriteAllText(Path.Combine(_fakeBinaries, "runtimes", "native.dll"), "stub");
+
+        SessionProvisioner.SessionsRoot = _root;
+        SessionProvisioner.BinariesDir = _fakeBinaries;
+    }
+
+    public void Dispose() {
+        SessionProvisioner.SessionsRoot = _origRoot;
+        SessionProvisioner.BinariesDir = _origBinaries;
+        try {
+            string baseTemp = Directory.GetParent(_root)!.FullName;
+            if (Directory.Exists(baseTemp)) {
+                Directory.Delete(baseTemp, recursive: true);
+            }
+        }
+        catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void Provision_CopiesBinaries_ButNotInstalledConfigOrLogs() {
+        ProvisionedSession session = SessionProvisioner.Provision(mcpServerEnabled: true);
+
+        Assert.True(Directory.Exists(session.Directory));
+        Assert.True(File.Exists(Path.Combine(session.Directory, "mcec.exe")));
+        Assert.True(File.Exists(Path.Combine(session.Directory, "mcec.dll")));
+        Assert.True(File.Exists(Path.Combine(session.Directory, "runtimes", "native.dll")));
+
+        // The installed instance's log is never carried into the copy.
+        Assert.False(File.Exists(Path.Combine(session.Directory, "mcec.log")));
+
+        // The session's mcec.commands is the FRESH one (not the installed "<installed/>" stub).
+        string commands = File.ReadAllText(Path.Combine(session.Directory, "mcec.commands"));
+        Assert.DoesNotContain("<installed/>", commands);
+    }
+
+    [Fact]
+    public void Provision_WritesAgentReadyConfig_EnabledOnlyInTheCopy() {
+        ProvisionedSession session = SessionProvisioner.Provision(mcpServerEnabled: true);
+
+        string settings = File.ReadAllText(Path.Combine(session.Directory, AppSettings.SettingsFileName));
+        Assert.Contains("<AgentCommandsEnabled>true</AgentCommandsEnabled>", settings);
+        Assert.Contains("<McpServerEnabled>true</McpServerEnabled>", settings);
+        // Isolation practice: no TCP server (avoids the firewall prompt) and it can't re-provision.
+        Assert.Contains("<ActAsServer>false</ActAsServer>", settings);
+        Assert.Contains("<AllowSessionProvisioning>false</AllowSessionProvisioning>", settings);
+
+        string commands = File.ReadAllText(Path.Combine(session.Directory, "mcec.commands"));
+        Assert.Contains("invoke", commands);
+        Assert.Contains("enabled=\"true\"", commands);
+    }
+
+    [Fact]
+    public void Provision_LeavesInstalledConfigUntouched() {
+        string before = File.ReadAllText(Path.Combine(_fakeBinaries, AppSettings.SettingsFileName));
+
+        SessionProvisioner.Provision(mcpServerEnabled: false);
+
+        string after = File.ReadAllText(Path.Combine(_fakeBinaries, AppSettings.SettingsFileName));
+        Assert.Equal(before, after); // the real install's settings are never written
+    }
+
+    [Fact]
+    public void Provision_ReturnsConnectionInfo_WhenMcpEnabled() {
+        ProvisionedSession session = SessionProvisioner.Provision(mcpServerEnabled: true);
+
+        Assert.True(session.McpServerEnabled);
+        Assert.True(session.Port > 0);
+        Assert.Equal("127.0.0.1", session.BindAddress);
+        Assert.EndsWith("mcec.exe", session.ExePath);
+        Assert.Matches("^[0-9a-f]{12}$", session.SessionId);
+
+        System.Text.Json.Nodes.JsonObject json = session.ToJsonObject();
+        Assert.Equal($"http://127.0.0.1:{session.Port}/mcp", json["mcpEndpoint"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Teardown_DeletesTheSessionDirectory() {
+        ProvisionedSession session = SessionProvisioner.Provision(mcpServerEnabled: false);
+        Assert.True(Directory.Exists(session.Directory));
+
+        bool removed = SessionProvisioner.Teardown(session.SessionId);
+
+        Assert.True(removed);
+        Assert.False(Directory.Exists(session.Directory));
+    }
+
+    [Fact]
+    public void Teardown_UnknownSession_ReturnsTrue() {
+        Assert.True(SessionProvisioner.Teardown("does-not-exist"));
+    }
+
+    [Fact]
+    public void ReapOrphans_RemovesOldDirs_KeepsFreshOnes() {
+        ProvisionedSession stale = SessionProvisioner.Provision(mcpServerEnabled: false);
+        ProvisionedSession fresh = SessionProvisioner.Provision(mcpServerEnabled: false);
+
+        // Backdate the "stale" session's directory well past the reap window.
+        Directory.SetCreationTimeUtc(stale.Directory, DateTime.UtcNow - TimeSpan.FromHours(48));
+
+        int reaped = SessionProvisioner.ReapOrphans(TimeSpan.FromHours(12));
+
+        Assert.True(reaped >= 1);
+        Assert.False(Directory.Exists(stale.Directory));
+        Assert.True(Directory.Exists(fresh.Directory));
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/SessionProvisionerTests.cs
+++ b/tests/MCEControl.xUnit/Agent/SessionProvisionerTests.cs
@@ -125,8 +125,27 @@ public class SessionProvisionerTests : IDisposable {
     }
 
     [Fact]
-    public void Teardown_UnknownSession_ReturnsTrue() {
-        Assert.True(SessionProvisioner.Teardown("does-not-exist"));
+    public void Teardown_UnknownButValidId_ReturnsTrue() {
+        // A well-formed but non-existent session id is idempotent success (nothing to remove).
+        Assert.True(SessionProvisioner.Teardown("abc123def456"));
+    }
+
+    [Theory]
+    [InlineData("..")]
+    [InlineData("../..")]
+    [InlineData("a/b")]
+    [InlineData("does-not-exist")]       // wrong shape
+    [InlineData("ABC123DEF456")]         // upper-case hex is not the id shape
+    public void Teardown_RejectsTraversalAndMalformedIds_WithoutDeletingOutsideRoot(string id) {
+        // A sentinel next to the sessions root must survive a traversal-style teardown attempt.
+        string parent = Directory.GetParent(_root)!.FullName;
+        string sentinel = Path.Combine(parent, "install"); // created in the fixture
+        Assert.True(Directory.Exists(sentinel));
+
+        bool removed = SessionProvisioner.Teardown(id);
+
+        Assert.False(removed);
+        Assert.True(Directory.Exists(sentinel), "teardown must not delete anything outside the sessions root");
     }
 
     [Fact]

--- a/tests/MCEControl.xUnit/Commands/CommandInvokerEmergencyStopTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CommandInvokerEmergencyStopTests.cs
@@ -1,0 +1,48 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Verifies the emergency stop (#135) drops the command queue: when the latch is engaged,
+/// <see cref="CommandInvoker.ExecuteNext"/> must stop dequeuing/executing so a paced or embedded
+/// sequence can't keep actuating after the operator halted. Uses the serial collection because it
+/// toggles the process-global latch.
+/// </summary>
+[Collection("AgentSerial")]
+public class CommandInvokerEmergencyStopTests {
+    [Fact]
+    public void ExecuteNext_DropsQueuedCommands_WhenEmergencyStopped() {
+        CommandInvoker invoker = [];
+        TestCommand first = new() { Cmd = "a" };
+        TestCommand second = new() { Cmd = "b" };
+        invoker.EnqueueCommand(first);
+        invoker.EnqueueCommand(second);
+
+        AgentRuntime.SetEmergencyStopped(true);
+        try {
+            invoker.ExecuteNext();
+
+            Assert.False(first.ExecuteCalled, "no command should run once the stop is latched");
+            Assert.False(second.ExecuteCalled);
+        }
+        finally {
+            AgentRuntime.SetEmergencyStopped(false);
+        }
+    }
+
+    [Fact]
+    public void ExecuteNext_RunsQueuedCommands_WhenNotStopped() {
+        CommandInvoker invoker = [];
+        TestCommand cmd = new() { Cmd = "a" };
+        invoker.EnqueueCommand(cmd);
+
+        AgentRuntime.SetEmergencyStopped(false);
+        invoker.ExecuteNext();
+
+        Assert.True(cmd.ExecuteCalled);
+    }
+}

--- a/tests/MCEControl.xUnit/Services/AgentServerSafetyTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerSafetyTests.cs
@@ -1,0 +1,132 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.IO;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Tests the two agent safety features at the MCP dispatch boundary: the emergency-stop (#135) latch
+/// refuses every tool call, and isolated session provisioning (#138) is gated on the operator opt-in.
+/// </summary>
+[Collection("AgentSerial")]
+public class AgentServerSafetyTests {
+    private static JsonObject Request(int id, string method, JsonObject? prms = null) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"] = id,
+        ["method"] = method,
+        ["params"] = prms ?? [],
+    };
+
+    private static JsonObject Call(int id, string tool, JsonObject args) =>
+        AgentServer.Dispatch(Request(id, "tools/call", new JsonObject { ["name"] = tool, ["arguments"] = args }))!;
+
+    private static JsonObject Envelope(JsonObject resp) =>
+        JsonNode.Parse(FirstTextBlock(resp["result"]!.AsObject()))!.AsObject();
+
+    private static string FirstTextBlock(JsonObject toolResult) {
+        foreach (JsonNode? block in toolResult["content"]!.AsArray()) {
+            if (block?["type"]?.GetValue<string>() == "text") {
+                return block["text"]!.GetValue<string>();
+            }
+        }
+        Assert.Fail("no text content block in tool result");
+        return "";
+    }
+
+    [Fact]
+    public void EmergencyStopped_RefusesEveryToolCall() {
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.SetEmergencyStopped(true);
+        try {
+            JsonObject resp = Call(1, "capture", new JsonObject { ["foreground"] = true });
+            JsonObject env = Envelope(resp);
+
+            Assert.False(env["ok"]!.GetValue<bool>());
+            Assert.Equal("emergency-stopped", env["error"]!.AsObject()["code"]!.GetValue<string>());
+            Assert.True(resp["result"]!.AsObject()["isError"]!.GetValue<bool>());
+        }
+        finally {
+            AgentRuntime.SetEmergencyStopped(false);
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void EmergencyStopped_RefusesSendCommandToo() {
+        AgentRuntime.SetEmergencyStopped(true);
+        try {
+            JsonObject env = Envelope(Call(2, "send_command", new JsonObject { ["command"] = "winr" }));
+            Assert.Equal("emergency-stopped", env["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.SetEmergencyStopped(false);
+        }
+    }
+
+    [Fact]
+    public void ToolsList_IncludesProvisioningTools() {
+        JsonArray tools = AgentServer.Dispatch(Request(3, "tools/list"))!["result"]!.AsObject()["tools"]!.AsArray();
+        bool hasProvision = false, hasEnd = false;
+        foreach (JsonNode? tool in tools) {
+            string? name = tool?["name"]?.GetValue<string>();
+            hasProvision |= name == "provision-session";
+            hasEnd |= name == "end-session";
+        }
+        Assert.True(hasProvision, "provision-session tool missing");
+        Assert.True(hasEnd, "end-session tool missing");
+    }
+
+    [Fact]
+    public void ProvisionSession_NotAuthorized_IsRefused() {
+        AgentRuntime.Settings = new AppSettings { AllowSessionProvisioning = false };
+        try {
+            JsonObject env = Envelope(Call(4, "provision-session", []));
+            Assert.False(env["ok"]!.GetValue<bool>());
+            Assert.Equal("provisioning-not-authorized", env["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void ProvisionSession_Authorized_ReturnsIsolatedDirectory_AndEndSessionTearsItDown() {
+        string origRoot = SessionProvisioner.SessionsRoot;
+        string origBin = SessionProvisioner.BinariesDir;
+        string baseTemp = Path.Combine(Path.GetTempPath(), "mcec-provision-gate-test", Path.GetRandomFileName());
+        string fakeBin = Path.Combine(baseTemp, "install");
+        Directory.CreateDirectory(fakeBin);
+        File.WriteAllText(Path.Combine(fakeBin, "mcec.exe"), "stub");
+
+        AgentRuntime.Settings = new AppSettings { AllowSessionProvisioning = true };
+        SessionProvisioner.SessionsRoot = Path.Combine(baseTemp, "sessions");
+        SessionProvisioner.BinariesDir = fakeBin;
+        try {
+            JsonObject env = Envelope(Call(5, "provision-session", new JsonObject { ["mcpServer"] = false }));
+            Assert.True(env["ok"]!.GetValue<bool>());
+
+            JsonObject result = env["result"]!.AsObject();
+            string dir = result["directory"]!.GetValue<string>();
+            string sessionId = result["sessionId"]!.GetValue<string>();
+            Assert.True(Directory.Exists(dir));
+            Assert.True(File.Exists(Path.Combine(dir, "mcec.exe")));
+
+            // end-session removes it.
+            JsonObject endEnv = Envelope(Call(6, "end-session", new JsonObject { ["sessionId"] = sessionId }));
+            Assert.True(endEnv["ok"]!.GetValue<bool>());
+            Assert.True(endEnv["result"]!.AsObject()["removed"]!.GetValue<bool>());
+            Assert.False(Directory.Exists(dir));
+        }
+        finally {
+            SessionProvisioner.SessionsRoot = origRoot;
+            SessionProvisioner.BinariesDir = origBin;
+            AgentRuntime.Settings = null;
+            try { if (Directory.Exists(baseTemp)) { Directory.Delete(baseTemp, recursive: true); } } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Two operator-safety features for Agent Mode, shipped in one PR because both are about the operator staying in control while MCEC drives the desktop. Closes #135 and #138.

Design doc (the plan): [`docs/safety-emergency-stop-and-provisioning.md`](../blob/claude/issue-135-138-safety/docs/safety-emergency-stop-and-provisioning.md).

## #135 — Emergency Stop (global dead-man's-switch)

A single keystroke, hittable from **any** focused window, that instantly halts the active agent session. The agent can neither trip it accidentally nor defeat it deliberately.

- **Hotkey:** default `Ctrl+Alt+Shift+S` (a chord no app uses and the agent never synthesizes); configurable via `EmergencyStopHotkey`.
- **Physical-input only:** surfaces the `LLKHF_INJECTED` flag on new `KeyDownExt`/`KeyUpExt` events from the existing `WH_KEYBOARD_LL` hook. MCEC's own injected keystrokes are ignored, so the agent can't press or hold the combo to trip/defeat it — a true human override.
- **Latches the actuation gate:** `AgentRuntime.EmergencyStopped` is checked in `AgentServer.CallTool`; **every** tool call (actuation, observation, `send_command`) is refused with a distinct `emergency-stopped` error until the operator re-arms.
- **Aborts in-flight actuation:** stops any recording; an in-flight `drag` observes the latch between waypoints and releases the button; the invoke worker's leftovers are neutralized by the input release.
- **Releases held input:** all mouse buttons up + shift/ctrl/alt/win reset.
- **Loud feedback:** persistent red overlay banner, `AGENT-AUDIT:` log, status bar, session record, and a **Re-arm** menu affordance (latch never clears automatically).

## #138 — Isolated session provisioning

Stops agents from mutating the operator's **installed** config (enable-then-disable leaks enabled security gates on any crash).

- `provision-session` hands an authorized agent a fresh, disposable directory with `mcec.exe` + deps and an agent-ready **co-located** config (agent commands enabled **only** inside the copy). Chosen approach: **copy binaries** — run from a non-`Program Files` dir so `ConfigPath` resolves to the session dir itself.
- The installed `mcec.settings`/`mcec.commands` are never read or written.
- **Gated** behind an explicit operator opt-in (`AllowSessionProvisioning`) — the one thing that can't be self-served.
- `end-session` tears the dir down; abandoned/leaked sessions are **reaped on launch** (running sessions' files are locked and skipped).
- Agent guidance (`AgentInstructions.md` single source of truth + `AGENTS.md`) updated to tell agents to provision + tear down, and to stop on `emergency-stopped`.

## Acceptance criteria

Both issues' checklists are mapped and covered in the design doc's "Acceptance criteria coverage" section.

## Tests

New unit tests: hotkey parsing, physical-vs-injected chord detection (the key security property), latch refusal at the MCP boundary, provisioning isolation/teardown/reaping, and provisioning authorization gating. Full suite green (310 passed, 22 input-tests skipped as designed); `dotnet build` warning-clean (strict mode).

## Notes / follow-ups (in the design doc)

- E-stop is armed in the **GUI host** (the LL hook needs the message loop); headless `--mcp` halts via its parent — a headless e-stop channel is a follow-up.
- UIPI: a non-elevated MCEC's hook won't see keys over an elevated foreground window / secure desktop — documented.
- Richer per-session authorization/token scoping ties into epics #92 / #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)