### PR TITLE
ci: fail the build on leftover merge conflict markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,22 @@ env:
   CONFIGURATION: 'Release'
 
 jobs:
+  conflict-markers:
+    name: No conflict markers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Scan tracked files for leftover merge conflict markers
+        run: |
+          # The {7} quantifiers are deliberate: they mean "seven of this char" without the
+          # literal 7-char marker ever appearing in this file, so the scan never flags itself.
+          if git grep -nE '^(<{7} |={7}$|>{7} |\|{7} )' -- .; then
+            echo "::error::Leftover merge conflict markers found (see matches above). Resolve the merge before pushing."
+            exit 1
+          fi
+          echo "No conflict markers found."
+
   build-and-test:
     name: Build and Test
     runs-on: windows-latest


### PR DESCRIPTION
## Why
A stray `<<<<<<< HEAD` marker was committed to `AGENTS.md` on develop and went unnoticed until it surfaced during the #133 merge (fixed there). Nothing in CI catches this class of mistake.

## What
Adds a fast `No conflict markers` job (ubuntu, no build) to `ci.yml` that `git grep`s all tracked files for the four conflict-marker forms and fails with a clear `::error::` if any are found:
- `<<<<<<< ` (ours)
- `=======` (separator, exactly 7)
- `>>>>>>> ` (theirs)
- `||||||| ` (diff3 base)

## Notes
- The scan pattern uses `{7}` quantifiers, so the literal 7-char markers never appear in the workflow file — **it won't flag itself**.
- Verified locally: catches all four forms, ignores inline `=` runs and 8+-equals markdown setext underlines, and reports clean on current develop.
- Runs in parallel with Build and Test; adds a few seconds.

Closes the gap that let the AGENTS.md marker slip through.