### PR TITLE
fix(security): unauthenticated remote crash — OOB read in telnet negotiation (#144)

### DIFF
--- a/src/Services/SocketServer.cs
+++ b/src/Services/SocketServer.cs
@@ -197,64 +197,22 @@ sealed public class SocketServer : ServiceBase, IDisposable {
                 return;
             }
 
-            // _currentCommand contains the current command we are parsing out and 
-            // _currentIndex is the index into it
-            //int n = 0;
-            for (int i = 0; i < iRx; i++) {
-                byte b = clientContext.DataBuffer[i];
-                switch (b) {
-                    case (byte)TelnetVerbs.IAC:
-                        // interpret as a command
-                        i++;
-                        if (i < iRx) {
-                            byte verb = clientContext.DataBuffer[i];
-                            switch (verb) {
-                                case (int)TelnetVerbs.IAC:
-                                    //literal IAC = 255 escaped, so append char 255 to string
-                                    clientContext.CmdBuilder.Append(verb);
-                                    break;
-                                case (int)TelnetVerbs.DO:
-                                case (int)TelnetVerbs.DONT:
-                                case (int)TelnetVerbs.WILL:
-                                case (int)TelnetVerbs.WONT:
-                                    // reply to all commands with "WONT", unless it is SGA (suppres go ahead)
-                                    i++;
-                                    byte inputoption = clientContext.DataBuffer[i];
-                                    if (i < iRx) {
-                                        clientContext.Socket.Send([(byte)TelnetVerbs.IAC]);
-                                        if (inputoption == (int)TelnetOptions.SGA) {
-                                            clientContext.Socket.Send([verb == (int) TelnetVerbs.DO
-                                                                    ? (byte) TelnetVerbs.WILL
-                                                                    : (byte) TelnetVerbs.DO]);
-                                        }
-                                        else {
-                                            clientContext.Socket.Send([verb == (int) TelnetVerbs.DO
-                                                                    ? (byte) TelnetVerbs.WONT
-                                                                    : (byte) TelnetVerbs.DONT]);
-                                        }
-
-                                        clientContext.Socket.Send([inputoption]);
-                                    }
-                                    break;
-                            }
-                        }
-                        break;
-
-                    case (byte)'\r':
-                    case (byte)'\n':
-                    case (byte)'\0':
-                        // Skip any delimiter chars that might have been left from earlier input
-                        if (clientContext.CmdBuilder.Length > 0) {
-                            SendNotification(ServiceNotification.ReceivedData, CurrentStatus, clientContext, clientContext.CmdBuilder.ToString());
-                            // Reset n to start new command
-                            clientContext.CmdBuilder.Clear();
-                        }
-                        break;
-
-                    default:
-                        clientContext.CmdBuilder.Append((char)b);
-                        break;
-                }
+            // Parse the received chunk. Guard the parse loop so a malformed/crafted packet can
+            // never escape as an unhandled exception on this ThreadPool callback and terminate
+            // the process (issue #144 — unauthenticated remote crash). Any parse failure closes
+            // the offending client instead.
+            try {
+                ParseReceivedData(
+                    clientContext.DataBuffer,
+                    iRx,
+                    clientContext.CmdBuilder,
+                    reply => clientContext.Socket.Send(reply),
+                    command => SendNotification(ServiceNotification.ReceivedData, CurrentStatus, clientContext, command));
+            }
+            catch (Exception ex) {
+                SendNotification(ServiceNotification.Error, CurrentStatus, clientContext, $"OnDataReceived: parse error: {ex.Message}");
+                CloseSocket(clientContext);
+                return;
             }
 
             // Continue the waiting for data on the Socket
@@ -268,6 +226,83 @@ sealed public class SocketServer : ServiceBase, IDisposable {
             }
             else {
                 SendNotification(ServiceNotification.Error, CurrentStatus, clientContext, $"OnDataReceived: {se.Message}, {se.HResult:X} ({se.SocketErrorCode})");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses a received chunk of bytes: strips inline telnet negotiation (IAC …) and emits a
+    /// command via <paramref name="onCommand"/> on each CR/LF/NUL delimiter. Extracted from
+    /// <see cref="OnDataReceived"/> so it can be unit tested and hardened against malformed input.
+    /// </summary>
+    /// <remarks>
+    /// Issue #144: the telnet option byte was read <b>before</b> its bounds check, so a crafted
+    /// packet whose last two bytes are IAC DO (option byte at <c>count</c>) caused an
+    /// out-of-bounds read → unhandled exception → process crash. Every buffer access here is now
+    /// bounds-checked first: a truncated IAC/verb/option sequence is silently ignored.
+    /// </remarks>
+    internal static void ParseReceivedData(
+            byte[] buffer,
+            int count,
+            StringBuilder cmdBuilder,
+            Action<byte[]> sendReply,
+            Action<string> onCommand) {
+        for (int i = 0; i < count; i++) {
+            byte b = buffer[i];
+            switch (b) {
+                case (byte)TelnetVerbs.IAC:
+                    // interpret as a telnet command; need at least a verb byte
+                    i++;
+                    if (i >= count) {
+                        break; // truncated IAC — nothing to interpret
+                    }
+                    byte verb = buffer[i];
+                    switch (verb) {
+                        case (int)TelnetVerbs.IAC:
+                            //literal IAC = 255 escaped, so append char 255 to string
+                            cmdBuilder.Append(verb);
+                            break;
+                        case (int)TelnetVerbs.DO:
+                        case (int)TelnetVerbs.DONT:
+                        case (int)TelnetVerbs.WILL:
+                        case (int)TelnetVerbs.WONT:
+                            // need an option byte; read it ONLY after the bounds check (#144)
+                            i++;
+                            if (i >= count) {
+                                break; // truncated option — ignore, do not read past the buffer
+                            }
+                            byte inputoption = buffer[i];
+                            // reply to all commands with "WONT", unless it is SGA (suppress go ahead)
+                            sendReply([(byte)TelnetVerbs.IAC]);
+                            if (inputoption == (int)TelnetOptions.SGA) {
+                                sendReply([verb == (int)TelnetVerbs.DO
+                                            ? (byte)TelnetVerbs.WILL
+                                            : (byte)TelnetVerbs.DO]);
+                            }
+                            else {
+                                sendReply([verb == (int)TelnetVerbs.DO
+                                            ? (byte)TelnetVerbs.WONT
+                                            : (byte)TelnetVerbs.DONT]);
+                            }
+
+                            sendReply([inputoption]);
+                            break;
+                    }
+                    break;
+
+                case (byte)'\r':
+                case (byte)'\n':
+                case (byte)'\0':
+                    // Skip any delimiter chars that might have been left from earlier input
+                    if (cmdBuilder.Length > 0) {
+                        onCommand(cmdBuilder.ToString());
+                        cmdBuilder.Clear();
+                    }
+                    break;
+
+                default:
+                    cmdBuilder.Append((char)b);
+                    break;
             }
         }
     }

--- a/tests/MCEControl.xUnit/Services/SocketServerTelnetParseTests.cs
+++ b/tests/MCEControl.xUnit/Services/SocketServerTelnetParseTests.cs
@@ -1,0 +1,116 @@
+//-------------------------------------------------------------------
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+//-------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Regression tests for the telnet negotiation parser (issue #144): a crafted TCP packet
+/// must never cause an out-of-bounds read / unhandled exception that crashes the process.
+/// </summary>
+public class SocketServerTelnetParseTests {
+    private const byte IAC = 255;
+    private const byte WILL = 251;
+    private const byte WONT = 252;
+    private const byte DO = 253;
+    private const byte DONT = 254;
+    private const byte SGA = 3; // TelnetOptions.SGA
+
+    private static List<byte[]> Parse(byte[] buffer, int count, out List<string> commands) {
+        var replies = new List<byte[]>();
+        var cmds = new List<string>();
+        SocketServer.ParseReceivedData(
+            buffer,
+            count,
+            new StringBuilder(),
+            reply => replies.Add(reply),
+            cmd => cmds.Add(cmd));
+        commands = cmds;
+        return replies;
+    }
+
+    [Fact]
+    public void FullBuffer_EndingInIacDo_DoesNotThrow() {
+        // The #144 exploit: a full 1024-byte buffer whose last two bytes are IAC DO.
+        // The option byte would be read at index 1024 -> IndexOutOfRangeException.
+        var buffer = new byte[1024];
+        buffer[1022] = IAC;
+        buffer[1023] = DO;
+
+        var ex = Record.Exception(() => Parse(buffer, 1024, out _));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void TruncatedIacVerbOption_ProducesNoReply_AndDoesNotThrow() {
+        // IAC DO with no option byte present (verb ends the chunk): must be ignored, no reply,
+        // and must not read past the received count.
+        var buffer = new byte[8];
+        buffer[0] = IAC;
+        buffer[1] = DO; // no option byte follows within count
+
+        var replies = Parse(buffer, 2, out _);
+
+        Assert.Empty(replies);
+    }
+
+    [Fact]
+    public void CompleteDoSga_RepliesWill() {
+        // IAC DO SGA -> server replies IAC WILL SGA.
+        var buffer = new byte[] { IAC, DO, SGA };
+
+        var replies = Parse(buffer, 3, out _);
+
+        Assert.Equal(3, replies.Count);
+        Assert.Equal(IAC, replies[0][0]);
+        Assert.Equal(WILL, replies[1][0]);
+        Assert.Equal(SGA, replies[2][0]);
+    }
+
+    [Fact]
+    public void CompleteDoNonSga_RepliesWont() {
+        // IAC DO <non-SGA option> -> server replies IAC WONT option.
+        const byte someOption = 24; // TERMINAL-TYPE
+        var buffer = new byte[] { IAC, DO, someOption };
+
+        var replies = Parse(buffer, 3, out _);
+
+        Assert.Equal(3, replies.Count);
+        Assert.Equal(IAC, replies[0][0]);
+        Assert.Equal(WONT, replies[1][0]);
+        Assert.Equal(someOption, replies[2][0]);
+    }
+
+    [Fact]
+    public void PlainText_TerminatedByNewline_YieldsOneCommand() {
+        var buffer = Encoding.ASCII.GetBytes("hello\r");
+
+        Parse(buffer, buffer.Length, out var commands);
+
+        Assert.Single(commands);
+        Assert.Equal("hello", commands[0]);
+    }
+
+    [Fact]
+    public void DontAndWont_AreHandledSymmetrically() {
+        // IAC DONT SGA -> reply IAC DO SGA ; IAC WONT <opt> -> reply IAC DONT <opt>
+        var buffer = new byte[] { IAC, DONT, SGA, IAC, WONT, 24 };
+
+        var replies = Parse(buffer, buffer.Length, out _);
+
+        Assert.Equal(6, replies.Count);
+        Assert.Equal(IAC, replies[0][0]);
+        Assert.Equal(DO, replies[1][0]);
+        Assert.Equal(SGA, replies[2][0]);
+        Assert.Equal(IAC, replies[3][0]);
+        Assert.Equal(DONT, replies[4][0]);
+        Assert.Equal((byte)24, replies[5][0]);
+    }
+}

--- a/tests/MCEControl.xUnit/Services/SocketServerTelnetParseTests.cs
+++ b/tests/MCEControl.xUnit/Services/SocketServerTelnetParseTests.cs
@@ -62,6 +62,27 @@ public class SocketServerTelnetParseTests {
     }
 
     [Fact]
+    public void TrailingLoneIac_DoesNotThrow_AndProducesNoReply() {
+        // A chunk ending in a bare IAC (no verb byte follows): must be ignored, no reply, no throw.
+        var buffer = new byte[] { (byte)'x', IAC };
+
+        var replies = Parse(buffer, buffer.Length, out _);
+
+        Assert.Empty(replies);
+    }
+
+    [Fact]
+    public void LiteralIacEscape_DoesNotThrow_AndProducesNoReply() {
+        // IAC IAC is the escape for a literal 0xFF; it is appended to the command buffer, not
+        // treated as negotiation, so it must emit no telnet reply and must not throw.
+        var buffer = new byte[] { IAC, IAC };
+
+        var replies = Parse(buffer, buffer.Length, out _);
+
+        Assert.Empty(replies);
+    }
+
+    [Fact]
     public void CompleteDoSga_RepliesWill() {
         // IAC DO SGA -> server replies IAC WILL SGA.
         var buffer = new byte[] { IAC, DO, SGA };


### PR DESCRIPTION
Closes #144

## Problem (P1 — unauthenticated remote DoS)

`SocketServer.OnDataReceived` read the telnet **option byte before** its bounds check:

```csharp
i++;
byte inputoption = clientContext.DataBuffer[i];   // read BEFORE the check
if (i < iRx) { ... }
```

`DataBuffer` is a fixed 1024-byte array and `EndReceive` can return `iRx == 1024`. A client that sends a 1024-byte chunk whose last two bytes are `0xFF 0xFD` (IAC DO) drives `i` to `1024`, so `DataBuffer[1024]` throws `IndexOutOfRangeException`. `OnDataReceived` only caught `SocketException`, so the exception escaped the async socket callback on a ThreadPool thread → **unhandled exception → process termination**. The socket server binds `IPAddress.Any` with no auth, so any host reaching the command port (default 5150) can crash MCEC with one packet.

## Fix

- **Bounds-check first.** Extracted the parse loop into `SocketServer.ParseReceivedData(...)` and moved every buffer read (verb byte, option byte) to *after* an `i < count` check. Truncated `IAC` / verb / option sequences are now ignored instead of reading past the received data.
- **Defense in depth.** The `ParseReceivedData` call in `OnDataReceived` is wrapped in `catch (Exception)` that closes the offending client, so no future parsing bug can crash the process from remote input.
- **Testability.** The parser is decoupled from the live `Socket` (reply bytes and parsed commands are delivered via callbacks), so it can be unit tested directly.

Behavior for well-formed telnet negotiation is unchanged (verified by tests below).

## Tests (written first, red → green)

`tests/MCEControl.xUnit/Services/SocketServerTelnetParseTests.cs`:

| Test | Guards |
|------|--------|
| `FullBuffer_EndingInIacDo_DoesNotThrow` | the exact #144 exploit — full 1024-byte buffer ending in IAC DO |
| `TruncatedIacVerbOption_ProducesNoReply_AndDoesNotThrow` | verb present, option byte missing at end of chunk |
| `CompleteDoSga_RepliesWill` / `CompleteDoNonSga_RepliesWont` / `DontAndWont_AreHandledSymmetrically` | negotiation replies unchanged |
| `PlainText_TerminatedByNewline_YieldsOneCommand` | normal command extraction unaffected |

Full suite: **341 passed, 22 skipped (desktop/real-input), 0 failed** locally.

## Notes / scope

Focused on the P1 OOB crash. The other SocketServer P2 findings (#147, #148, #149, #150) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)