### PR TITLE
ci(security): pin third-party actions to full commit SHAs (#162)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           --results-directory ./TestResults
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        uses: EnricoMi/publish-unit-test-result-action/windows@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           files: TestResults/**/*.trx

--- a/.github/workflows/real-windows.yml
+++ b/.github/workflows/real-windows.yml
@@ -69,7 +69,7 @@ jobs:
           --results-directory ./TestResults
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        uses: EnricoMi/publish-unit-test-result-action/windows@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           files: TestResults/**/*.trx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Submit to winget-pkgs
         if: ${{ env.HAS_WINGET == 'true' }}
-        uses: vedantmgoyal9/winget-releaser@v2
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: Kindel.mcec
           version: ${{ steps.ver.outputs.version }}


### PR DESCRIPTION
## Why

Third-party actions were referenced by mutable major-version tags (`@v2`). A moved tag or a compromised action repo runs attacker-controlled code inside our pipeline with the workflow token — and in `release.yml` the winget-releaser step is handed `WINGET_TOKEN`, so a tag hijack there would leak that PAT. Pinning to a full-length commit SHA makes the referenced code immutable.

## What changed

| Action | File(s) | Old ref | New pin | Resolved version |
|---|---|---|---|---|
| `EnricoMi/publish-unit-test-result-action/windows` | `.github/workflows/ci.yml:62`, `.github/workflows/real-windows.yml:72` | `@v2` | `@d0a4676d0e0b938bc201470d88276b7c74c712b3` | `v2.24.0` |
| `vedantmgoyal9/winget-releaser` | `.github/workflows/release.yml:131` | `@v2` | `@4ffc7888bffd451b357355dc214d43bb9f23917e` | `v2` (repo publishes only a `v2` tag; commit dated 2024-11-27) |

Scope is intentionally limited to third-party (non-GitHub, non-Azure) actions per the issue; `actions/*` and `azure/*` refs are unchanged.

## Verification

- Resolved each tag via `gh api repos/<owner>/<repo>/git/ref/tags/v2`; EnricoMi's `v2` is an annotated tag, so it was dereferenced via `git/tags/<sha>` to the underlying commit `d0a4676…`, which matches tag `v2.24.0`. winget-releaser's `v2` is a lightweight tag pointing directly at commit `4ffc788…`.
- Confirmed both commits exist: `gh api repos/<owner>/<repo>/commits/<sha> --jq .sha`.
- Re-parsed all three edited workflows with `yaml.safe_load` — all valid. (`actionlint` not available on this machine.)
- `.github/dependabot.yml` already includes the `github-actions` ecosystem (weekly), so these SHA pins will be kept up to date automatically.

## Recommended follow-up (repo admin, out of scope here)

- Enable repo/org SHA-pinning enforcement (`sha_pinning_required`).
- Restrict `allowed_actions` from `all` to verified creators + an explicit allowlist.
- Optionally SHA-pin `actions/*` and `azure/*` as best practice.

Fixes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU