### PR TITLE
fix(security): use monotonic client id as SocketServer client-list key (#147)

### DIFF
--- a/src/Services/SocketServer.cs
+++ b/src/Services/SocketServer.cs
@@ -24,10 +24,9 @@ sealed public class SocketServer : ServiceBase, IDisposable {
     // to communicate with each connected client. For thread safety.
     private readonly ConcurrentDictionary<int, Socket> _clientList = new();
 
-    // The following variable will keep track of the cumulative
-    // total number of clients connected at any time. Since multiple threads
-    // can access this variable, modifying this variable should be done
-    // in a thread safe manner
+    // Number of currently connected clients (incremented on connect,
+    // decremented on disconnect). Since multiple threads can access this
+    // variable, modifying it should be done in a thread safe manner.
     private int _clientCount;
 
     // Monotonically increasing id used as the _clientList key and ClientNumber.
@@ -59,6 +58,9 @@ sealed public class SocketServer : ServiceBase, IDisposable {
             _clientList.TryRemove(i, out Socket? socket);
             if (socket != null) {
                 Log4.Debug("Closing Socket #" + i);
+                // Keep the connected tally in sync with the force-closed sockets
+                // so a later Start does not report a stale count.
+                Interlocked.Decrement(ref _clientCount);
                 socket.Close();
             }
         }
@@ -161,8 +163,14 @@ sealed public class SocketServer : ServiceBase, IDisposable {
         // socket and later closing the wrong client (#147).
         int clientId = Interlocked.Increment(ref _nextClientId);
 
-        // Add the workerSocket reference to the list
-        _clientList.GetOrAdd(clientId, workerSocket);
+        // Add the workerSocket reference to the list. Ids are never reused, so
+        // TryAdd must always succeed; fail loudly if that invariant regresses
+        // (a silent GetOrAdd is exactly how #147 hid).
+        bool added = _clientList.TryAdd(clientId, workerSocket);
+        System.Diagnostics.Debug.Assert(added, $"SocketServer client id {clientId} was already in use");
+        if (!added) {
+            Log4.Error($"SocketServer RegisterClient: duplicate client id {clientId}; socket will not be tracked");
+        }
 
         return new ServerReplyContext(this, workerSocket, clientId);
     }

--- a/src/Services/SocketServer.cs
+++ b/src/Services/SocketServer.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -23,11 +24,20 @@ sealed public class SocketServer : ServiceBase, IDisposable {
     // to communicate with each connected client. For thread safety.
     private readonly ConcurrentDictionary<int, Socket> _clientList = new();
 
-    // The following variable will keep track of the cumulative 
+    // The following variable will keep track of the cumulative
     // total number of clients connected at any time. Since multiple threads
     // can access this variable, modifying this variable should be done
     // in a thread safe manner
     private int _clientCount;
+
+    // Monotonically increasing id used as the _clientList key and ClientNumber.
+    // Never decremented — unlike _clientCount, which drops on disconnect — so
+    // keys stay unique for the lifetime of the server (#147).
+    private int _nextClientId;
+
+    // Test seams (InternalsVisibleTo MCEControl.xUnit)
+    internal int ConnectedClientCount => _clientCount;
+    internal IReadOnlyDictionary<int, Socket> TrackedClients => _clientList;
 
     #region IDisposable Members
     public void Dispose() {
@@ -104,16 +114,9 @@ sealed public class SocketServer : ServiceBase, IDisposable {
             // a new Socket object
             Socket workerSocket = _mainSocket.EndAccept(async);
 
-            // Now increment the client count for this client 
-            // in a thread safe manner
-            Interlocked.Increment(ref _clientCount);
+            serverReplyContext = RegisterClient(workerSocket);
 
-            // Add the workerSocket reference to the list
-            _clientList.GetOrAdd(_clientCount, workerSocket);
-
-            serverReplyContext = new ServerReplyContext(this, workerSocket, _clientCount);
-
-            Log4.Debug("Opened Socket #" + _clientCount);
+            Log4.Debug("Opened Socket #" + serverReplyContext.ClientNumber);
 
             SetStatus(ServiceStatus.Connected);
             SendNotification(ServiceNotification.ClientConnected, CurrentStatus, serverReplyContext);
@@ -146,6 +149,24 @@ sealed public class SocketServer : ServiceBase, IDisposable {
         _mainSocket?.BeginAccept(OnClientConnect, null);
     }
 
+    // Tracks a newly connected client. Internal so tests can exercise the
+    // client-tracking logic without a live listener (InternalsVisibleTo).
+    internal ServerReplyContext RegisterClient(Socket workerSocket) {
+        // Now increment the client count for this client
+        // in a thread safe manner
+        Interlocked.Increment(ref _clientCount);
+
+        // Allocate a unique, never-reused id for this client. Using _clientCount
+        // here would repeat keys under connect/disconnect churn, leaking the new
+        // socket and later closing the wrong client (#147).
+        int clientId = Interlocked.Increment(ref _nextClientId);
+
+        // Add the workerSocket reference to the list
+        _clientList.GetOrAdd(clientId, workerSocket);
+
+        return new ServerReplyContext(this, workerSocket, clientId);
+    }
+
     // Start waiting for data from the client
     private void BeginReceive(ServerReplyContext serverReplyContext) {
         Log4.Debug("SocketServer BeginReceive");
@@ -162,7 +183,8 @@ sealed public class SocketServer : ServiceBase, IDisposable {
         }
     }
 
-    private void CloseSocket(ServerReplyContext serverReplyContext) {
+    // Internal so tests can exercise the client-tracking logic (InternalsVisibleTo).
+    internal void CloseSocket(ServerReplyContext serverReplyContext) {
         Log4.Debug("SocketServer CloseSocket");
         if (serverReplyContext == null) {
             return;

--- a/tests/MCEControl.xUnit/Services/SocketServerClientTrackingTests.cs
+++ b/tests/MCEControl.xUnit/Services/SocketServerClientTrackingTests.cs
@@ -70,6 +70,21 @@ public class SocketServerClientTrackingTests : IDisposable
     }
 
     [Fact]
+    public void Dispose_WithConnectedClients_ResetsConnectedClientCount()
+    {
+        _ = _server.RegisterClient(NewSocket());
+        _ = _server.RegisterClient(NewSocket());
+        Assert.Equal(2, _server.ConnectedClientCount);
+
+        _server.Stop();
+
+        // Stop force-closes every tracked socket; the connected tally must
+        // drain with them or a later Start reports a stale count.
+        Assert.Empty(_server.TrackedClients);
+        Assert.Equal(0, _server.ConnectedClientCount);
+    }
+
+    [Fact]
     public void ConnectedClientCount_TracksOnlyCurrentlyConnectedClients()
     {
         var contextA = _server.RegisterClient(NewSocket());

--- a/tests/MCEControl.xUnit/Services/SocketServerClientTrackingTests.cs
+++ b/tests/MCEControl.xUnit/Services/SocketServerClientTrackingTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Net.Sockets;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Regression tests for issue #147: SocketServer must not reuse the connected-client
+/// tally as the client-list key. Keys must be unique for the lifetime of the server,
+/// otherwise under connect/disconnect churn a new client's socket is never tracked
+/// (handle leak) and closing one client closes another, still-active client.
+/// </summary>
+public class SocketServerClientTrackingTests : IDisposable
+{
+    private readonly SocketServer _server = new();
+
+    public void Dispose()
+    {
+        _server.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static Socket NewSocket() =>
+        new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+    [Fact]
+    public void RegisterClient_AssignsUniqueClientNumbers_AcrossChurn()
+    {
+        // A connects, B connects, A disconnects, C connects.
+        var contextA = _server.RegisterClient(NewSocket());
+        var contextB = _server.RegisterClient(NewSocket());
+        _server.CloseSocket(contextA);
+        var contextC = _server.RegisterClient(NewSocket());
+
+        // With the buggy _clientCount-as-key scheme, C gets B's client number.
+        Assert.NotEqual(contextB.ClientNumber, contextC.ClientNumber);
+    }
+
+    [Fact]
+    public void RegisterClient_AfterChurn_TracksNewClientSocket()
+    {
+        var contextA = _server.RegisterClient(NewSocket());
+        _ = _server.RegisterClient(NewSocket());
+        _server.CloseSocket(contextA);
+
+        using var socketC = NewSocket();
+        _ = _server.RegisterClient(socketC);
+
+        // With the bug, GetOrAdd hits B's existing key and silently drops
+        // socketC — it is never tracked and thus never closed (handle leak).
+        Assert.Contains(socketC, _server.TrackedClients.Values);
+    }
+
+    [Fact]
+    public void CloseSocket_AfterChurn_DoesNotCloseOtherActiveClient()
+    {
+        var contextA = _server.RegisterClient(NewSocket());
+        using var socketB = NewSocket();
+        _ = _server.RegisterClient(socketB);
+        _server.CloseSocket(contextA);
+        var contextC = _server.RegisterClient(NewSocket());
+
+        // Disconnect C. With the bug, C shares B's key, so this removes
+        // and forcibly closes B's still-active socket instead.
+        _server.CloseSocket(contextC);
+
+        Assert.Contains(socketB, _server.TrackedClients.Values);
+        Assert.False(socketB.SafeHandle.IsClosed);
+    }
+
+    [Fact]
+    public void ConnectedClientCount_TracksOnlyCurrentlyConnectedClients()
+    {
+        var contextA = _server.RegisterClient(NewSocket());
+        var contextB = _server.RegisterClient(NewSocket());
+        _server.CloseSocket(contextA);
+        var contextC = _server.RegisterClient(NewSocket());
+
+        Assert.Equal(2, _server.ConnectedClientCount);
+        Assert.Equal(2, _server.TrackedClients.Count);
+
+        _server.CloseSocket(contextB);
+        _server.CloseSocket(contextC);
+
+        Assert.Equal(0, _server.ConnectedClientCount);
+        Assert.Empty(_server.TrackedClients);
+    }
+}


### PR DESCRIPTION
## The bug (Security P2)

`SocketServer` used `_clientCount` as **both** the currently-connected tally and the `_clientList` dictionary key. Because `_clientCount` is decremented on every disconnect, keys were not unique over time. Under connect/disconnect churn (A connects → B connects → A disconnects → C connects):

- `GetOrAdd(2, socketC)` hit B's existing key, returned B's socket, and **silently dropped socketC** — the new client was never tracked, so it was never closed on shutdown → **socket/handle leak**, repeatable to resource exhaustion.
- C's `ClientNumber` collided with B's, so when C disconnected, `CloseSocket` removed and `Close()`d **B's still-active socket** → the wrong client was forcibly disconnected.

## The fix

Add a dedicated `_nextClientId` counter that is monotonically increased with `Interlocked.Increment` and **never decremented**. It is now the `_clientList` key and `ServerReplyContext.ClientNumber`. `_clientCount` remains solely the connected tally (incremented on connect, decremented on disconnect).

The add/track logic was extracted from `OnClientConnect` into internal `RegisterClient(Socket)`, and `CloseSocket` was made internal, so the churn scenario is directly unit-testable via the existing `InternalsVisibleTo("MCEControl.xUnit")`. Two read-only internal seams (`ConnectedClientCount`, `TrackedClients`) expose state for assertions. No behavior change beyond the key allocation.

## Tests (written first; all 4 failed on the buggy code for the expected reasons)

`tests/MCEControl.xUnit/Services/SocketServerClientTrackingTests.cs`:

- `RegisterClient_AssignsUniqueClientNumbers_AcrossChurn` — after A/B connect, A disconnects, C connects, C's `ClientNumber` must differ from B's (previously both were 2).
- `RegisterClient_AfterChurn_TracksNewClientSocket` — C's socket must actually be present in the client list (previously dropped by `GetOrAdd` → the leak).
- `CloseSocket_AfterChurn_DoesNotCloseOtherActiveClient` — disconnecting C must not remove/close B's socket; asserts B is still tracked and its handle is open (previously B was closed).
- `ConnectedClientCount_TracksOnlyCurrentlyConnectedClients` — the tally reflects live connections through churn and drains to 0; the tracked list stays consistent with it.

Full suite: 339 passed, 0 failed, 22 skipped (pre-existing skips).

## Review follow-up (0627966)

Independent review approved with three findings, resolved test-first:

1. **Stale tally after Stop** — `Dispose(bool)` force-closed every tracked socket but never decremented `_clientCount`, so `ConnectedClientCount` stayed inflated after Stop and a later Start reported a stale count. Now decremented per removed socket. New test (written first, failed with tally 2 instead of 0): `Dispose_WithConnectedClients_ResetsConnectedClientCount`.
2. **Stale comment** — the `_clientCount` comment still described the old cumulative-key role and contradicted the `_nextClientId` comment; reworded to match its actual role (currently connected tally).
3. **Silent `GetOrAdd`** — `RegisterClient` now uses `TryAdd` and fails loudly (`Debug.Assert` + `Log4.Error`) if a key collision ever regresses, instead of silently dropping the socket — the exact failure mode that hid #147.

Full suite after follow-up: 340 passed, 0 failed, 22 skipped.

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU
