### PR TITLE
fix(security): embedded commands bypass the Enabled gate (#145)

### DIFF
--- a/src/Commands/CommandInvoker.cs
+++ b/src/Commands/CommandInvoker.cs
@@ -198,11 +198,22 @@ public class CommandInvoker : Hashtable {
     /// <param name="cmd">Command to enqueue</param>
     internal void EnqueueCommand(ICommand cmd) {
         executeQueue.Enqueue(cmd);
-        if (((Command)cmd).EmbeddedCommands is null) {
+        Command command = (Command)cmd;
+        if (command.EmbeddedCommands is null) {
             return;
         }
 
-        foreach (Command embedded in ((Command)cmd).EmbeddedCommands) {
+        // SECURITY (#145): a disabled parent must suppress its entire embedded subtree. Embedded
+        // commands are flattened into the execute queue as independent siblings and each is gated
+        // only on its OWN Enabled flag, so descending into a disabled parent would let its
+        // Enabled=true children run — bypassing the per-command gate that "disabled by default"
+        // depends on. Stop descending unless this command is itself enabled. (An enabled parent
+        // with a disabled child still stops at that child, because the recursion re-checks here.)
+        if (!command.Enabled) {
+            return;
+        }
+
+        foreach (Command embedded in command.EmbeddedCommands) {
             EnqueueCommand(embedded);
         }
     }

--- a/src/Commands/StartProcessCommand.cs
+++ b/src/Commands/StartProcessCommand.cs
@@ -48,24 +48,28 @@ public class StartProcessCommand : Command {
               //    </ Chars >
               //    </ SendInput >
               //</ StartProcess >                  
-              new StartProcessCommand() { 
+              new StartProcessCommand() {
                   // Start notepad.exe
+                  // SECURITY (#145): every embedded child below is Enabled=false ON PURPOSE. This is a
+                  // *demo* users copy and enable deliberately; shipping enabled children means a single
+                  // remote command string actuates synthetic input on the secure default install. Do not
+                  // set these back to Enabled=true.
                   Cmd = "type_into_notepad", File="notepad.exe", EmbeddedCommands = [
                         // pause 100ms
-                        new PauseCommand() { Args = "100", Enabled = true },
+                        new PauseCommand() { Args = "100", Enabled = false },
                         // send some text
-                        new CharsCommand() { Args="this is a test typed into Notepad.", Enabled = true  },
+                        new CharsCommand() { Args="this is a test typed into Notepad.", Enabled = false  },
                         // hit retrun
-                        new SendInputCommand() { Vk = "VK_RETURN", Enabled = true  },
+                        new SendInputCommand() { Vk = "VK_RETURN", Enabled = false  },
                         // hit win-shirt-right to put notepad on the other monitor
-                        new SendInputCommand() { Vk = "VK_RIGHT", Win = true, Shift = true, Enabled = true  },
-                        new SendMessageCommand() { Msg=274, WParam=61488, LParam=0, Enabled = true  },
-                        new CharsCommand() { Args="Second ", Enabled = true  },
-                        new CharsCommand() { Args="line...", Enabled = true, EmbeddedCommands = [
+                        new SendInputCommand() { Vk = "VK_RIGHT", Win = true, Shift = true, Enabled = false  },
+                        new SendMessageCommand() { Msg=274, WParam=61488, LParam=0, Enabled = false  },
+                        new CharsCommand() { Args="Second ", Enabled = false  },
+                        new CharsCommand() { Args="line...", Enabled = false, EmbeddedCommands = [
                             // Bring up help, about
-                            new PauseCommand() { Args = "250", Enabled = true },
-                            new SendInputCommand() { Vk = "h", Alt=true, Enabled = true  },
-                            new SendInputCommand() { Vk = "a", Alt=false, Enabled = true  }
+                            new PauseCommand() { Args = "250", Enabled = false },
+                            new SendInputCommand() { Vk = "h", Alt=true, Enabled = false  },
+                            new SendInputCommand() { Vk = "a", Alt=false, Enabled = false  }
                         ]},
                    ]
               }

--- a/tests/MCEControl.xUnit/Commands/EmbeddedCommandGateTests.cs
+++ b/tests/MCEControl.xUnit/Commands/EmbeddedCommandGateTests.cs
@@ -1,0 +1,101 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Security regression tests for issue #145: embedded (nested) commands must not bypass the
+/// per-command <see cref="Command.Enabled"/> gate. A disabled parent must suppress its children;
+/// flattening enabled children into the queue as independent siblings would let an unauthenticated
+/// remote client fire them from a single command string against the secure default install.
+/// Uses the serial collection because <see cref="CommandInvoker.ExecuteNext"/> reads the global
+/// emergency-stop latch.
+/// </summary>
+[Collection("AgentSerial")]
+public class EmbeddedCommandGateTests {
+    [Fact]
+    public void DisabledParent_DoesNotRunEnabledChildren() {
+        // The #145 shape: a disabled parent (StartProcess gated off) carrying Enabled=true children.
+        var childA = new TestCommand { Cmd = "childA" };
+        var childB = new TestCommand { Cmd = "childB" };
+        var parent = new TestCommand {
+            Cmd = "parent",
+            Enabled = false,
+            EmbeddedCommands = [childA, childB]
+        };
+
+        CommandInvoker invoker = [];
+        invoker.EnqueueCommand(parent);
+        invoker.ExecuteNext();
+
+        Assert.False(parent.ExecuteCalled, "the disabled parent must not run");
+        Assert.False(childA.ExecuteCalled, "an enabled child of a disabled parent must NOT run (#145)");
+        Assert.False(childB.ExecuteCalled, "an enabled child of a disabled parent must NOT run (#145)");
+    }
+
+    [Fact]
+    public void EnabledParent_RunsEnabledChildren() {
+        var child = new TestCommand { Cmd = "child" };
+        var parent = new TestCommand {
+            Cmd = "parent",
+            Enabled = true,
+            EmbeddedCommands = [child]
+        };
+
+        CommandInvoker invoker = [];
+        invoker.EnqueueCommand(parent);
+        invoker.ExecuteNext();
+
+        Assert.True(parent.ExecuteCalled);
+        Assert.True(child.ExecuteCalled, "an enabled child of an enabled parent should run");
+    }
+
+    [Fact]
+    public void EnabledParent_DisabledChild_SuppressesGrandchildren() {
+        // A disabled command anywhere in the chain must stop its subtree from executing,
+        // even if the grandchildren are individually Enabled=true.
+        var grandchild = new TestCommand { Cmd = "grandchild" };
+        var disabledChild = new TestCommand {
+            Cmd = "child",
+            Enabled = false,
+            EmbeddedCommands = [grandchild]
+        };
+        var parent = new TestCommand {
+            Cmd = "parent",
+            Enabled = true,
+            EmbeddedCommands = [disabledChild]
+        };
+
+        CommandInvoker invoker = [];
+        invoker.EnqueueCommand(parent);
+        invoker.ExecuteNext();
+
+        Assert.True(parent.ExecuteCalled);
+        Assert.False(disabledChild.ExecuteCalled, "the disabled child must not run");
+        Assert.False(grandchild.ExecuteCalled, "a grandchild under a disabled child must NOT run (#145)");
+    }
+
+    [Fact]
+    public void ShippedTypeIntoNotepad_HasNoEnabledDescendants() {
+        // Defense in depth: the shipped demo (disabled parent, previously Enabled=true children)
+        // must be inert until the user deliberately enables it.
+        var typeIntoNotepad = StartProcessCommand.BuiltInCommands
+            .Find(c => c.Cmd == "type_into_notepad");
+        Assert.NotNull(typeIntoNotepad);
+        Assert.False(typeIntoNotepad!.Enabled, "the shipped parent is disabled by default");
+        AssertNoEnabledDescendants(typeIntoNotepad);
+    }
+
+    private static void AssertNoEnabledDescendants(Command command) {
+        if (command.EmbeddedCommands is null) {
+            return;
+        }
+        foreach (Command child in command.EmbeddedCommands) {
+            Assert.False(child.Enabled, $"shipped embedded command '{child.Cmd}' must be disabled by default (#145)");
+            AssertNoEnabledDescendants(child);
+        }
+    }
+}


### PR DESCRIPTION
Closes #145

## Problem (P1 — remote synthetic-input injection on the secure default install)

`CommandInvoker.EnqueueCommand` flattened a command's `EmbeddedCommands` into the execute queue as **independent siblings**, and `ExecuteNext` gated each dequeued item on its **own** `Enabled` flag:

```csharp
internal void EnqueueCommand(ICommand cmd) {
    executeQueue.Enqueue(cmd);
    if (((Command)cmd).EmbeddedCommands is null) return;
    foreach (Command embedded in ((Command)cmd).EmbeddedCommands)
        EnqueueCommand(embedded);   // children queued unconditionally
}
```

So a **disabled parent** (which `Execute()`s to a no-op) did **not** suppress its children. The shipped `type_into_notepad` built-in is exactly this shape — a disabled `StartProcess` parent with hard-coded `Enabled=true` children. On an MCEC install in its **secure default** configuration (nothing enabled), an unauthenticated network/serial client sending the single string `type_into_notepad` would **not** launch Notepad (parent correctly gated) but **would** run the 9 enabled children against the current foreground window: `Chars` types text, `SendInput` presses Enter / Win+Shift+Right / Alt+H / Alt+A, `SendMessage(WM_SYSCOMMAND, 61488)` maximizes. That is unauthenticated remote synthetic-input injection — precisely what "disabled by default" is meant to prevent.

## Fix

- **`EnqueueCommand` stops descending unless the command is itself `Enabled`.** A disabled parent suppresses its entire embedded subtree; an enabled parent with a disabled child still stops at that child (the recursion re-checks the gate per level). This ANDs each child's effective-enabled against its parent chain.
- **Shipped demo made inert.** Every embedded child of `type_into_notepad` is now `Enabled=false`, with a comment warning against re-enabling. The demo remains a copy-and-enable example, but ships safe.

This also removes the latent correctness bug where a disabled/failed parent still fired its children.

## Tests (written first, red → green)

`tests/MCEControl.xUnit/Commands/EmbeddedCommandGateTests.cs`:

| Test | Guards |
|------|--------|
| `DisabledParent_DoesNotRunEnabledChildren` | the #145 exploit — disabled parent, `Enabled=true` children must NOT run |
| `EnabledParent_RunsEnabledChildren` | legitimate nested execution still works |
| `EnabledParent_DisabledChild_SuppressesGrandchildren` | a disabled node stops its whole subtree |
| `ShippedTypeIntoNotepad_HasNoEnabledDescendants` | shipped demo is inert by default |

Full suite: **339 passed, 22 skipped, 0 failed** locally.

## Scope

Fixes the P1 gate bypass. The general form (any user-defined disabled parent with enabled children) is covered by the same `EnqueueCommand` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)