### PR TITLE
fix(security): cap command execute queue depth and bound embedded fan-out (#154)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -65,10 +65,13 @@ the HTTP floor; it has no bearing on stdio or on which individual tools may run.
 
 **The command queue is bounded.** Commands (from any client — network, serial, or an agent's
 `send_command`) are queued and executed paced (`CommandPacing` delay between items). To prevent a remote
-memory/CPU DoS the queue is capped at **200** pending commands and a single command's embedded-command
-expansion at **20**; anything beyond either bound is **dropped and logged** (a `CommandInvoker` warning in
-the MCEC log). Agents should batch or pace long input sequences (e.g. prefer `drag`/`mouse:drag` over long
-`mouse:mt` streams) rather than flooding the queue.
+memory/CPU DoS the queue is capped at **200** pending commands, and a single command's whole tree — the
+command itself plus all recursively embedded commands — at **50**. Enqueue is **all-or-nothing**: a command
+that breaks either bound, or whose tree doesn't fit in the queue's remaining capacity, is **dropped whole
+and logged** (a `CommandInvoker` warning in the MCEC log) — never partially enqueued, since a split tree
+could separate paired input commands (e.g. `shiftdown:`/`shiftup:`) and leave a modifier key latched.
+Agents should batch or pace long input sequences (e.g. prefer `drag`/`mouse:drag` over long `mouse:mt`
+streams) rather than flooding the queue.
 
 ---
 

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -63,6 +63,13 @@ command engine and does **not** require `AgentCommandsEnabled`; the raw command 
 that command's own `Enabled` flag in `mcec.commands` (the normal MCEC gate). `McpServerEnabled` gates only
 the HTTP floor; it has no bearing on stdio or on which individual tools may run.
 
+**The command queue is bounded.** Commands (from any client — network, serial, or an agent's
+`send_command`) are queued and executed paced (`CommandPacing` delay between items). To prevent a remote
+memory/CPU DoS the queue is capped at **200** pending commands and a single command's embedded-command
+expansion at **20**; anything beyond either bound is **dropped and logged** (a `CommandInvoker` warning in
+the MCEC log). Agents should batch or pace long input sequences (e.g. prefer `drag`/`mouse:drag` over long
+`mouse:mt` streams) rather than flooding the queue.
+
 ---
 
 ## How to enable

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -70,11 +70,13 @@ serialized: it runs one-at-a-time (the desktop has a single input stream), so do
 actions to overlap.
 
 PACING: raw commands (`send_command`) are queued and executed paced — a per-command delay set by the
-operator's CommandPacing — and the queue is BOUNDED: at most 200 commands may be pending, and one command
-expands to at most 20 embedded commands; anything beyond either bound is DROPPED (logged on the host, no
-error returned to you). Don't flood the queue with long raw input streams — prefer one higher-level call
-(`drag`, `click`, or a single `mouse:drag,...`) over a long hand-rolled `mouse:mt` path, and if a long
-sequence is unavoidable, send it in small chunks and verify between chunks so the queue drains.
+operator's CommandPacing — and the queue is BOUNDED: at most 200 commands may be pending, and one command's
+whole tree (the command itself plus all recursively embedded commands) may be at most 50. A command that
+breaks either bound is dropped ALL-OR-NOTHING: the entire tree is discarded (logged on the host, no error
+returned to you) — never partially run, so paired input (e.g. shiftdown:/shiftup:) can't be split. Don't
+flood the queue with long raw input streams — prefer one higher-level call (`drag`, `click`, or a single
+`mouse:drag,...`) over a long hand-rolled `mouse:mt` path, and if a long sequence is unavoidable, send it
+in small chunks and verify between chunks so the queue drains.
 
 OVERLAY: MCEC may show a small on-screen overlay (default on) that narrates each command you run so the
 operator can see MCEC is driving. It is deliberately excluded from `query`/`find`/`capture`/UIA targeting

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -69,6 +69,13 @@ modal — so a slow observation is safe to start. Physical-input actuation (`dra
 serialized: it runs one-at-a-time (the desktop has a single input stream), so don't expect two input
 actions to overlap.
 
+PACING: raw commands (`send_command`) are queued and executed paced — a per-command delay set by the
+operator's CommandPacing — and the queue is BOUNDED: at most 200 commands may be pending, and one command
+expands to at most 20 embedded commands; anything beyond either bound is DROPPED (logged on the host, no
+error returned to you). Don't flood the queue with long raw input streams — prefer one higher-level call
+(`drag`, `click`, or a single `mouse:drag,...`) over a long hand-rolled `mouse:mt` path, and if a long
+sequence is unavoidable, send it in small chunks and verify between chunks so the queue drains.
+
 OVERLAY: MCEC may show a small on-screen overlay (default on) that narrates each command you run so the
 operator can see MCEC is driving. It is deliberately excluded from `query`/`find`/`capture`/UIA targeting
 — you will never see or target it, and it is never a candidate window — but it DOES appear in

--- a/src/Commands/CommandInvoker.cs
+++ b/src/Commands/CommandInvoker.cs
@@ -32,17 +32,20 @@ public class CommandInvoker : Hashtable {
     /// SECURITY (#154): Maximum number of commands the execute queue will hold. The queue is drained
     /// synchronously on the UI thread with `CommandPacing` sleeps between items, so a remote client
     /// that enqueues faster than the paced drain would otherwise grow the queue without bound
-    /// (memory DoS) while freezing the UI. Commands enqueued beyond this depth are dropped and logged.
+    /// (memory DoS) while freezing the UI. A command whose tree does not fit in the remaining
+    /// capacity is dropped WHOLE (all-or-nothing, see `EnqueueCommand`) and logged.
     /// </summary>
     internal const int MaxQueueDepth = 200;
 
     /// <summary>
-    /// SECURITY (#154): Maximum number of commands a single enqueue may expand to via
-    /// `EmbeddedCommands` fan-out. A single received command string can otherwise amplify ~10x or
-    /// more (see #145), letting one packet flood the queue. Expansion beyond this bound is
-    /// truncated and logged. The largest shipped built-in (`type_into_notepad`) expands to 10.
+    /// SECURITY (#154): Maximum size of a single command's whole tree — the command itself plus all
+    /// recursively embedded commands. A single received command string can otherwise amplify ~10x or
+    /// more (see #145), letting one packet flood the queue. A tree over this bound is dropped WHOLE
+    /// (all-or-nothing, see `EnqueueCommand`) and logged. 50 leaves generous headroom for authored
+    /// macros (the largest shipped built-in, `type_into_notepad`, expands to 10) while still
+    /// bounding the amplification.
     /// </summary>
-    internal const int MaxEmbeddedExpansion = 20;
+    internal const int MaxEmbeddedExpansion = 50;
 
     /// <summary>
     /// Current number of commands waiting to be executed. Exposed for tests.
@@ -190,8 +193,9 @@ public class CommandInvoker : Hashtable {
             // For example sending a will result in the A key being pressed. 
             // 1 will result in the 1 key being pressed. There is no difference between sending a and A. 
             // Use shiftdown:/shiftup: to simulate the pressing of the shift, control, alt, and windows keys.
-            SendInputCommand siCmd = new SendInputCommand() { Vk = cmdString, Enabled = true, Reply = reply };
-            TryEnqueue(siCmd);
+            // Cmd is set so a drop of this command (queue full, #154) logs something identifiable.
+            SendInputCommand siCmd = new SendInputCommand() { Cmd = cmdString, Vk = cmdString, Enabled = true, Reply = reply };
+            EnqueueCommand(siCmd);
         }
         else {
             // See if we know about this Command - case insensitive
@@ -215,54 +219,54 @@ public class CommandInvoker : Hashtable {
 
     /// <summary>
     /// Enques a Command for execution. Recursively enques embedded commands.
-    /// SECURITY (#154): the total expansion (command plus all recursively embedded commands) is
-    /// bounded by `MaxEmbeddedExpansion` and the overall queue depth by `MaxQueueDepth`; anything
-    /// beyond either bound is dropped and logged.
+    /// SECURITY (#154): enqueue is ALL-OR-NOTHING per command tree. The whole tree (this command
+    /// plus all recursively embedded commands) is counted first; if it exceeds
+    /// `MaxEmbeddedExpansion` or does not fit in the queue's remaining capacity (`MaxQueueDepth`),
+    /// the ENTIRE tree is dropped with a warning and nothing is enqueued. A partial enqueue must
+    /// never happen: it could split paired input commands (e.g. shiftdown:/shiftup:) and leave a
+    /// modifier key latched host-wide.
     /// </summary>
     /// <param name="cmd">Command to enqueue</param>
     internal void EnqueueCommand(ICommand cmd) {
-        int enqueued = 0;
-        bool truncationLogged = false;
-        EnqueueCommandTree(cmd, ref enqueued, ref truncationLogged);
+        int treeSize = CountCommandTree(cmd);
+
+        if (treeSize > MaxEmbeddedExpansion) {
+            Logger.Instance.Log4.Warn($"{GetType().Name}: command expands to {treeSize} commands, over the {MaxEmbeddedExpansion} bound; whole command dropped (nothing enqueued): {((Command)cmd).Cmd}");
+            return;
+        }
+
+        if (executeQueue.Count + treeSize > MaxQueueDepth) {
+            Logger.Instance.Log4.Warn($"{GetType().Name}: execute queue cannot hold {treeSize} more command(s) ({executeQueue.Count}/{MaxQueueDepth} queued); whole command dropped (nothing enqueued): {((Command)cmd).Cmd}");
+            return;
+        }
+
+        EnqueueCommandTree(cmd);
     }
 
-    // Recursively enqueues `cmd` and its EmbeddedCommands, counting every item enqueued from the
-    // single root passed to EnqueueCommand so the fan-out bound applies to the whole tree.
-    private void EnqueueCommandTree(ICommand cmd, ref int enqueued, ref bool truncationLogged) {
-        if (enqueued >= MaxEmbeddedExpansion) {
-            if (!truncationLogged) {
-                Logger.Instance.Log4.Warn($"{GetType().Name}: embedded command expansion exceeded {MaxEmbeddedExpansion}; remaining embedded commands truncated (dropped).");
-                truncationLogged = true;
-            }
-            return;
+    // Counts a command's whole tree: itself plus all recursively embedded commands.
+    private static int CountCommandTree(ICommand cmd) {
+        int count = 1;
+        if (((Command)cmd).EmbeddedCommands is null) {
+            return count;
         }
 
-        if (!TryEnqueue(cmd)) {
-            // Queue is full; don't descend into embedded commands (they'd be dropped anyway).
-            return;
+        foreach (Command embedded in ((Command)cmd).EmbeddedCommands) {
+            count += CountCommandTree(embedded);
         }
-        enqueued++;
+        return count;
+    }
 
+    // Recursively enqueues `cmd` and its EmbeddedCommands. Only called after EnqueueCommand has
+    // verified the whole tree fits both bounds (#154) — never call this directly.
+    private void EnqueueCommandTree(ICommand cmd) {
+        executeQueue.Enqueue(cmd);
         if (((Command)cmd).EmbeddedCommands is null) {
             return;
         }
 
         foreach (Command embedded in ((Command)cmd).EmbeddedCommands) {
-            EnqueueCommandTree(embedded, ref enqueued, ref truncationLogged);
+            EnqueueCommandTree(embedded);
         }
-    }
-
-    // SECURITY (#154): single choke-point for adding to the execute queue. Drops (and logs) the
-    // command if the queue is at `MaxQueueDepth` — the queue drains pacing-limited on the UI
-    // thread, so without a cap a remote sender can grow it without bound (memory/CPU DoS).
-    private bool TryEnqueue(ICommand cmd) {
-        if (executeQueue.Count >= MaxQueueDepth) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: execute queue is full ({MaxQueueDepth}); command dropped: {((Command)cmd).Cmd}");
-            return false;
-        }
-
-        executeQueue.Enqueue(cmd);
-        return true;
     }
 
 

--- a/src/Commands/CommandInvoker.cs
+++ b/src/Commands/CommandInvoker.cs
@@ -29,6 +29,27 @@ public class CommandInvoker : Hashtable {
     private ConcurrentQueue<ICommand> executeQueue = new();
 
     /// <summary>
+    /// SECURITY (#154): Maximum number of commands the execute queue will hold. The queue is drained
+    /// synchronously on the UI thread with `CommandPacing` sleeps between items, so a remote client
+    /// that enqueues faster than the paced drain would otherwise grow the queue without bound
+    /// (memory DoS) while freezing the UI. Commands enqueued beyond this depth are dropped and logged.
+    /// </summary>
+    internal const int MaxQueueDepth = 200;
+
+    /// <summary>
+    /// SECURITY (#154): Maximum number of commands a single enqueue may expand to via
+    /// `EmbeddedCommands` fan-out. A single received command string can otherwise amplify ~10x or
+    /// more (see #145), letting one packet flood the queue. Expansion beyond this bound is
+    /// truncated and logged. The largest shipped built-in (`type_into_notepad`) expands to 10.
+    /// </summary>
+    internal const int MaxEmbeddedExpansion = 20;
+
+    /// <summary>
+    /// Current number of commands waiting to be executed. Exposed for tests.
+    /// </summary>
+    internal int QueuedCommandCount => executeQueue.Count;
+
+    /// <summary>
     /// Creaates a `Commands` instance of default & built-in commands. 
     /// </summary>
     /// <returns></returns>
@@ -170,7 +191,7 @@ public class CommandInvoker : Hashtable {
             // 1 will result in the 1 key being pressed. There is no difference between sending a and A. 
             // Use shiftdown:/shiftup: to simulate the pressing of the shift, control, alt, and windows keys.
             SendInputCommand siCmd = new SendInputCommand() { Vk = cmdString, Enabled = true, Reply = reply };
-            executeQueue.Enqueue(siCmd);
+            TryEnqueue(siCmd);
         }
         else {
             // See if we know about this Command - case insensitive
@@ -194,17 +215,54 @@ public class CommandInvoker : Hashtable {
 
     /// <summary>
     /// Enques a Command for execution. Recursively enques embedded commands.
+    /// SECURITY (#154): the total expansion (command plus all recursively embedded commands) is
+    /// bounded by `MaxEmbeddedExpansion` and the overall queue depth by `MaxQueueDepth`; anything
+    /// beyond either bound is dropped and logged.
     /// </summary>
     /// <param name="cmd">Command to enqueue</param>
     internal void EnqueueCommand(ICommand cmd) {
-        executeQueue.Enqueue(cmd);
+        int enqueued = 0;
+        bool truncationLogged = false;
+        EnqueueCommandTree(cmd, ref enqueued, ref truncationLogged);
+    }
+
+    // Recursively enqueues `cmd` and its EmbeddedCommands, counting every item enqueued from the
+    // single root passed to EnqueueCommand so the fan-out bound applies to the whole tree.
+    private void EnqueueCommandTree(ICommand cmd, ref int enqueued, ref bool truncationLogged) {
+        if (enqueued >= MaxEmbeddedExpansion) {
+            if (!truncationLogged) {
+                Logger.Instance.Log4.Warn($"{GetType().Name}: embedded command expansion exceeded {MaxEmbeddedExpansion}; remaining embedded commands truncated (dropped).");
+                truncationLogged = true;
+            }
+            return;
+        }
+
+        if (!TryEnqueue(cmd)) {
+            // Queue is full; don't descend into embedded commands (they'd be dropped anyway).
+            return;
+        }
+        enqueued++;
+
         if (((Command)cmd).EmbeddedCommands is null) {
             return;
         }
 
         foreach (Command embedded in ((Command)cmd).EmbeddedCommands) {
-            EnqueueCommand(embedded);
+            EnqueueCommandTree(embedded, ref enqueued, ref truncationLogged);
         }
+    }
+
+    // SECURITY (#154): single choke-point for adding to the execute queue. Drops (and logs) the
+    // command if the queue is at `MaxQueueDepth` — the queue drains pacing-limited on the UI
+    // thread, so without a cap a remote sender can grow it without bound (memory/CPU DoS).
+    private bool TryEnqueue(ICommand cmd) {
+        if (executeQueue.Count >= MaxQueueDepth) {
+            Logger.Instance.Log4.Warn($"{GetType().Name}: execute queue is full ({MaxQueueDepth}); command dropped: {((Command)cmd).Cmd}");
+            return false;
+        }
+
+        executeQueue.Enqueue(cmd);
+        return true;
     }
 
 

--- a/tests/MCEControl.xUnit/Commands/CommandInvokerQueueCapTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CommandInvokerQueueCapTests.cs
@@ -1,0 +1,154 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using log4net;
+using log4net.Appender;
+using log4net.Core;
+using log4net.Repository.Hierarchy;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Verifies the command execution queue cap and embedded-expansion fan-out bound (#154).
+/// The queue is drained synchronously on the UI thread with a paced sleep between items, so an
+/// unbounded queue lets a remote client cause memory growth and a UI freeze. Enqueues beyond
+/// <see cref="CommandInvoker.MaxQueueDepth"/> must be dropped and logged; a single command's
+/// embedded fan-out must be truncated at <see cref="CommandInvoker.MaxEmbeddedExpansion"/>.
+/// Uses the serial collection because the log4net hierarchy and Logger are process-global.
+/// </summary>
+[Collection("AgentSerial")]
+public class CommandInvokerQueueCapTests {
+    /// <summary>
+    /// Attaches a MemoryAppender to the root of the (already configured, see Logger) log4net
+    /// hierarchy so tests can assert on what CommandInvoker logged. Caller must detach.
+    /// </summary>
+    private static MemoryAppender AttachLogCapture() {
+        _ = Logger.Instance.Log4; // ensure the hierarchy is configured
+        MemoryAppender appender = new() { Name = "QueueCapTestCapture" };
+        appender.ActivateOptions();
+        Hierarchy hierarchy = (Hierarchy)LogManager.GetRepository();
+        hierarchy.Root.AddAppender(appender);
+        return appender;
+    }
+
+    private static void DetachLogCapture(MemoryAppender appender) {
+        Hierarchy hierarchy = (Hierarchy)LogManager.GetRepository();
+        hierarchy.Root.RemoveAppender(appender);
+    }
+
+    [Fact]
+    public void EnqueueCommand_QueueDepthNeverExceedsCap_ExcessDroppedAndLogged() {
+        MemoryAppender capture = AttachLogCapture();
+        try {
+            CommandInvoker invoker = [];
+            const int overflow = 25;
+
+            for (int i = 0; i < CommandInvoker.MaxQueueDepth + overflow; i++) {
+                invoker.EnqueueCommand(new TestCommand() { Cmd = $"cmd{i}" });
+                Assert.True(invoker.QueuedCommandCount <= CommandInvoker.MaxQueueDepth,
+                    $"queue depth {invoker.QueuedCommandCount} exceeded cap {CommandInvoker.MaxQueueDepth} after enqueue #{i}");
+            }
+
+            Assert.Equal(CommandInvoker.MaxQueueDepth, invoker.QueuedCommandCount);
+
+            LoggingEvent[] events = capture.GetEvents();
+            Assert.Contains(events, e =>
+                e.Level >= Level.Warn &&
+                e.RenderedMessage!.Contains("CommandInvoker", StringComparison.Ordinal) &&
+                e.RenderedMessage!.Contains("dropp", StringComparison.OrdinalIgnoreCase));
+        }
+        finally {
+            DetachLogCapture(capture);
+        }
+    }
+
+    [Fact]
+    public void EnqueueCommand_EmbeddedExpansionBeyondBound_TruncatedAndLogged() {
+        MemoryAppender capture = AttachLogCapture();
+        try {
+            CommandInvoker invoker = [];
+            TestCommand parent = new() { Cmd = "parent", EmbeddedCommands = [] };
+            for (int i = 0; i < CommandInvoker.MaxEmbeddedExpansion + 10; i++) {
+                parent.EmbeddedCommands.Add(new TestCommand() { Cmd = $"child{i}" });
+            }
+
+            invoker.EnqueueCommand(parent);
+
+            Assert.Equal(CommandInvoker.MaxEmbeddedExpansion, invoker.QueuedCommandCount);
+
+            LoggingEvent[] events = capture.GetEvents();
+            Assert.Contains(events, e =>
+                e.Level >= Level.Warn &&
+                e.RenderedMessage!.Contains("CommandInvoker", StringComparison.Ordinal) &&
+                e.RenderedMessage!.Contains("truncat", StringComparison.OrdinalIgnoreCase));
+        }
+        finally {
+            DetachLogCapture(capture);
+        }
+    }
+
+    [Fact]
+    public void EnqueueCommand_NestedEmbeddedExpansion_CountsWholeTreeTowardBound() {
+        CommandInvoker invoker = [];
+
+        // A chain nested deeper than the bound: parent -> child -> grandchild -> ...
+        TestCommand root = new() { Cmd = "root" };
+        TestCommand current = root;
+        for (int i = 0; i < CommandInvoker.MaxEmbeddedExpansion + 5; i++) {
+            TestCommand next = new() { Cmd = $"nested{i}" };
+            current.EmbeddedCommands = [next];
+            current = next;
+        }
+
+        invoker.EnqueueCommand(root);
+
+        Assert.Equal(CommandInvoker.MaxEmbeddedExpansion, invoker.QueuedCommandCount);
+    }
+
+    [Fact]
+    public void EnqueueCommand_WithinBounds_AllCommandsEnqueuedAndExecuted() {
+        CommandInvoker invoker = [];
+        TestCommand parent = new() { Cmd = "parent", EmbeddedCommands = [] };
+        List<TestCommand> children = [];
+        for (int i = 0; i < 5; i++) {
+            TestCommand child = new() { Cmd = $"child{i}" };
+            children.Add(child);
+            parent.EmbeddedCommands.Add(child);
+        }
+
+        invoker.EnqueueCommand(parent);
+        Assert.Equal(6, invoker.QueuedCommandCount);
+
+        AgentRuntime.SetEmergencyStopped(false);
+        invoker.ExecuteNext();
+
+        Assert.Equal(0, invoker.QueuedCommandCount);
+        Assert.True(parent.ExecuteCalled, "parent should have executed");
+        Assert.All(children, c => Assert.True(c.ExecuteCalled, $"{c.Cmd} should have executed"));
+    }
+
+    [Fact]
+    public void EnqueueCommand_QueueDrained_AcceptsNewCommandsAgain() {
+        CommandInvoker invoker = [];
+        for (int i = 0; i < CommandInvoker.MaxQueueDepth; i++) {
+            invoker.EnqueueCommand(new TestCommand() { Cmd = $"cmd{i}" });
+        }
+        Assert.Equal(CommandInvoker.MaxQueueDepth, invoker.QueuedCommandCount);
+
+        AgentRuntime.SetEmergencyStopped(false);
+        invoker.ExecuteNext();
+        Assert.Equal(0, invoker.QueuedCommandCount);
+
+        TestCommand after = new() { Cmd = "after" };
+        invoker.EnqueueCommand(after);
+        Assert.Equal(1, invoker.QueuedCommandCount);
+
+        invoker.ExecuteNext();
+        Assert.True(after.ExecuteCalled, "commands enqueued after a drain must execute normally");
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/CommandInvokerQueueCapTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CommandInvokerQueueCapTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using log4net;
 using log4net.Appender;
@@ -14,11 +15,16 @@ using MCEControl;
 namespace MCEControl.xUnit.Commands;
 
 /// <summary>
-/// Verifies the command execution queue cap and embedded-expansion fan-out bound (#154).
+/// Verifies the command execution queue cap and embedded-expansion bound (#154).
 /// The queue is drained synchronously on the UI thread with a paced sleep between items, so an
-/// unbounded queue lets a remote client cause memory growth and a UI freeze. Enqueues beyond
-/// <see cref="CommandInvoker.MaxQueueDepth"/> must be dropped and logged; a single command's
-/// embedded fan-out must be truncated at <see cref="CommandInvoker.MaxEmbeddedExpansion"/>.
+/// unbounded queue lets a remote client cause memory growth and a UI freeze.
+///
+/// Enqueue is ALL-OR-NOTHING per command tree: a command whose whole tree (itself plus all
+/// recursively embedded commands) exceeds <see cref="CommandInvoker.MaxEmbeddedExpansion"/>, or
+/// does not fit in the queue's remaining capacity (<see cref="CommandInvoker.MaxQueueDepth"/>),
+/// is dropped WHOLE with a warning — never partially enqueued. Partial enqueue could split paired
+/// input commands (e.g. shiftdown:/shiftup:) and leave a modifier key latched host-wide.
+///
 /// Uses the serial collection because the log4net hierarchy and Logger are process-global.
 /// </summary>
 [Collection("AgentSerial")]
@@ -41,6 +47,11 @@ public class CommandInvokerQueueCapTests {
         hierarchy.Root.RemoveAppender(appender);
     }
 
+    private static bool IsInvokerDropWarning(LoggingEvent e) =>
+        e.Level >= Level.Warn &&
+        e.RenderedMessage!.Contains("CommandInvoker", StringComparison.Ordinal) &&
+        e.RenderedMessage!.Contains("dropp", StringComparison.OrdinalIgnoreCase);
+
     [Fact]
     public void EnqueueCommand_QueueDepthNeverExceedsCap_ExcessDroppedAndLogged() {
         MemoryAppender capture = AttachLogCapture();
@@ -55,12 +66,7 @@ public class CommandInvokerQueueCapTests {
             }
 
             Assert.Equal(CommandInvoker.MaxQueueDepth, invoker.QueuedCommandCount);
-
-            LoggingEvent[] events = capture.GetEvents();
-            Assert.Contains(events, e =>
-                e.Level >= Level.Warn &&
-                e.RenderedMessage!.Contains("CommandInvoker", StringComparison.Ordinal) &&
-                e.RenderedMessage!.Contains("dropp", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(capture.GetEvents(), IsInvokerDropWarning);
         }
         finally {
             DetachLogCapture(capture);
@@ -68,7 +74,7 @@ public class CommandInvokerQueueCapTests {
     }
 
     [Fact]
-    public void EnqueueCommand_EmbeddedExpansionBeyondBound_TruncatedAndLogged() {
+    public void EnqueueCommand_TreeBeyondExpansionBound_NothingEnqueuedAndLogged() {
         MemoryAppender capture = AttachLogCapture();
         try {
             CommandInvoker invoker = [];
@@ -79,13 +85,10 @@ public class CommandInvokerQueueCapTests {
 
             invoker.EnqueueCommand(parent);
 
-            Assert.Equal(CommandInvoker.MaxEmbeddedExpansion, invoker.QueuedCommandCount);
-
-            LoggingEvent[] events = capture.GetEvents();
-            Assert.Contains(events, e =>
-                e.Level >= Level.Warn &&
-                e.RenderedMessage!.Contains("CommandInvoker", StringComparison.Ordinal) &&
-                e.RenderedMessage!.Contains("truncat", StringComparison.OrdinalIgnoreCase));
+            // ALL-OR-NOTHING: a tree over the bound must not be partially enqueued — a partial
+            // tree could split paired input (shiftdown:/shiftup:) and latch a modifier key.
+            Assert.Equal(0, invoker.QueuedCommandCount);
+            Assert.Contains(capture.GetEvents(), IsInvokerDropWarning);
         }
         finally {
             DetachLogCapture(capture);
@@ -93,10 +96,11 @@ public class CommandInvokerQueueCapTests {
     }
 
     [Fact]
-    public void EnqueueCommand_NestedEmbeddedExpansion_CountsWholeTreeTowardBound() {
+    public void EnqueueCommand_NestedTreeBeyondBound_NothingEnqueued() {
         CommandInvoker invoker = [];
 
         // A chain nested deeper than the bound: parent -> child -> grandchild -> ...
+        // The bound applies to the whole recursive tree, not just direct children.
         TestCommand root = new() { Cmd = "root" };
         TestCommand current = root;
         for (int i = 0; i < CommandInvoker.MaxEmbeddedExpansion + 5; i++) {
@@ -107,7 +111,43 @@ public class CommandInvokerQueueCapTests {
 
         invoker.EnqueueCommand(root);
 
-        Assert.Equal(CommandInvoker.MaxEmbeddedExpansion, invoker.QueuedCommandCount);
+        Assert.Equal(0, invoker.QueuedCommandCount);
+    }
+
+    [Fact]
+    public void EnqueueCommand_TreeExceedingRemainingCapacity_DroppedWhole_ExistingItemsIntact() {
+        MemoryAppender capture = AttachLogCapture();
+        try {
+            CommandInvoker invoker = [];
+            int preload = CommandInvoker.MaxQueueDepth - 5;
+            for (int i = 0; i < preload; i++) {
+                invoker.EnqueueCommand(new TestCommand() { Cmd = $"cmd{i}" });
+            }
+            Assert.Equal(preload, invoker.QueuedCommandCount);
+
+            // A 10-command tree (root + 9 children) is within the expansion bound but does not
+            // fit in the 5 remaining slots: the WHOLE tree must be dropped, not the first 5.
+            TestCommand tooBig = new() { Cmd = "tooBig", EmbeddedCommands = [] };
+            for (int i = 0; i < 9; i++) {
+                tooBig.EmbeddedCommands.Add(new TestCommand() { Cmd = $"tooBigChild{i}" });
+            }
+            invoker.EnqueueCommand(tooBig);
+
+            Assert.Equal(preload, invoker.QueuedCommandCount); // nothing added, nothing lost
+            Assert.Contains(capture.GetEvents(), IsInvokerDropWarning);
+
+            // A 5-command tree exactly fits the remaining capacity and must be accepted whole.
+            TestCommand fits = new() { Cmd = "fits", EmbeddedCommands = [] };
+            for (int i = 0; i < 4; i++) {
+                fits.EmbeddedCommands.Add(new TestCommand() { Cmd = $"fitsChild{i}" });
+            }
+            invoker.EnqueueCommand(fits);
+
+            Assert.Equal(CommandInvoker.MaxQueueDepth, invoker.QueuedCommandCount);
+        }
+        finally {
+            DetachLogCapture(capture);
+        }
     }
 
     [Fact]
@@ -150,5 +190,32 @@ public class CommandInvokerQueueCapTests {
 
         invoker.ExecuteNext();
         Assert.True(after.ExecuteCalled, "commands enqueued after a drain must execute normally");
+    }
+
+    [Fact]
+    public void Enqueue_SingleCharDroppedWhenFull_LogsIdentifiableCommand() {
+        MemoryAppender capture = AttachLogCapture();
+        try {
+            string tempFile = Path.GetTempFileName();
+            File.Delete(tempFile);
+            CommandInvoker invoker = CommandInvoker.Create(tempFile, "0.0.0.0", false);
+            ((Command)invoker["chars:"]!).Enabled = true; // enable the single-char fast path
+
+            for (int i = 0; i < CommandInvoker.MaxQueueDepth; i++) {
+                invoker.EnqueueCommand(new TestCommand() { Cmd = $"cmd{i}" });
+            }
+
+            invoker.Enqueue(new TestReply(), "z");
+
+            Assert.Equal(CommandInvoker.MaxQueueDepth, invoker.QueuedCommandCount);
+            // The drop log must identify WHAT was dropped — the fast path builds a
+            // SendInputCommand from the raw char, so the log line must carry it.
+            Assert.Contains(capture.GetEvents(), e =>
+                IsInvokerDropWarning(e) &&
+                e.RenderedMessage!.EndsWith(": z", StringComparison.Ordinal));
+        }
+        finally {
+            DetachLogCapture(capture);
+        }
     }
 }


### PR DESCRIPTION
## Vulnerability

`CommandInvoker.executeQueue` was an unbounded `ConcurrentQueue<ICommand>`, drained synchronously on the UI thread with a `Thread.Sleep(CommandPacing)` between every item (`ExecuteNext`). A remote client on the command port that streams known commands enqueues faster than the paced drain — and a single command string amplifies ~10x via embedded-command flattening (#145) — so an attacker could:

- grow the queue without bound (remote memory DoS), and
- keep the UI thread pinned in the paced drain loop (CPU/UI freeze DoS).

There was no queue cap, rate limit, or fan-out bound anywhere on the enqueue path.

## Fix

Minimal cap-based fix (draining off the UI thread is deferred as the larger behavioral change the issue lists as an alternative). Enqueue is **all-or-nothing per command tree**:

- **`MaxQueueDepth = 200`** — a command whose whole tree doesn't fit in the queue's remaining capacity is dropped whole with a `Warn`. 200 keeps generous headroom for legitimate macro bursts while bounding worst-case memory and drain time.
- **`MaxEmbeddedExpansion = 50`** — a single command's whole tree (the command itself plus all recursively embedded commands, nested included) may be at most 50; a larger tree is dropped whole with a `Warn`. 50 leaves generous headroom for authored macros (the largest shipped built-in, `type_into_notepad`, expands to 10) while still bounding the ~10x amplification described in #145.
- The single-character fast path sets `Cmd` on the generated `SendInputCommand` and routes through the same choke-point, so drops log an identifiable command.
- Constants are `internal const` on `CommandInvoker` (with an internal `QueuedCommandCount` accessor) so tests assert against the real values.

Scope note: this only bounds the *fan-out amplification*; the embedded-command `Enabled`-gate bypass itself remains tracked by #145 and is intentionally not fixed here.

## Review follow-up (semantic change: all-or-nothing, bound = 50)

Independent review flagged that the initial implementation truncated an embedded tree at the bound and could drop items mid-tree on queue-full. That's a stuck-modifier hazard: splitting paired input commands (e.g. `shiftdown:`/`shiftup:` — the exact pattern the code's own comment recommends for shifted keys) can leave a modifier key latched host-wide. The fix counts the full tree **before** enqueuing anything; if the tree exceeds `MaxEmbeddedExpansion` **or** won't fit in remaining queue capacity, the **whole tree is dropped** (one `Warn`, nothing enqueued) — a partial tree is never enqueued. `MaxEmbeddedExpansion` was raised 20 → 50 so legitimately authored macros don't hit the bound. Docs and the drop-log wording were aligned (the bound covers the whole tree *including the root*; drops on the single-char path now log the dropped char).

Explicitly out of scope per review triage (separate issues): the MainWindow `BeginInvoke` marshaling backlog, and the pre-existing `Command.cs:88` `clone.Enabled` bug.

## Agent guidance / docs

The cap changes agent-observable behavior (overflow is dropped with only a host-side log), so per the project rule the in-product guidance is updated:

- `src/Agent/AgentInstructions.md` — **PACING** paragraph: commands are queued and paced; the queue is bounded (200 pending; one command's whole tree ≤ 50) and a command breaking either bound is dropped all-or-nothing (never partially run, so paired input can't be split); agents should prefer higher-level calls (`drag`, `click`, `mouse:drag`) over long hand-rolled `mouse:mt` streams and chunk unavoidable long sequences.
- `docs/agent-server.md` — matching operator-facing paragraph ("The command queue is bounded") in the security section, including the all-or-nothing drop semantics and the stuck-modifier rationale.

## Tests (`tests/MCEControl.xUnit/Commands/CommandInvokerQueueCapTests.cs`, written first and confirmed failing before each implementation step)

- `EnqueueCommand_QueueDepthNeverExceedsCap_ExcessDroppedAndLogged` — enqueues cap+25 commands, asserts depth never exceeds `MaxQueueDepth` at any point, lands exactly at the cap, and a `Warn` drop entry was emitted (captured via a log4net `MemoryAppender`).
- `EnqueueCommand_TreeBeyondExpansionBound_NothingEnqueuedAndLogged` — a parent with bound+10 children enqueues **nothing** (all-or-nothing) and logs a drop warning.
- `EnqueueCommand_NestedTreeBeyondBound_NothingEnqueued` — a nesting chain deeper than the bound proves the bound applies to the whole recursive tree, and nothing is enqueued.
- `EnqueueCommand_TreeExceedingRemainingCapacity_DroppedWhole_ExistingItemsIntact` — with 5 slots left, a 10-command tree is dropped whole (existing 195 items intact, warn logged) and a 5-command tree that exactly fits is accepted whole.
- `EnqueueCommand_WithinBounds_AllCommandsEnqueuedAndExecuted` — normal parent+5 children enqueue is unaffected and all execute via `ExecuteNext`.
- `EnqueueCommand_QueueDrained_AcceptsNewCommandsAgain` — after a full drain, capacity is available again and new commands execute normally (the cap is depth-based, not a lifetime quota).
- `Enqueue_SingleCharDroppedWhenFull_LogsIdentifiableCommand` — the single-char fast path drop logs the dropped char (was an empty `Cmd`, log line ended at the colon).

The embedded-instructions format test (`Instructions_LoadsFromEmbeddedResource_CollapsedToParagraphs`) still passes with the PACING paragraph.

Full suite: 342 passed, 0 failed, 22 skipped (pre-existing environment skips). `dotnet build MCEControl.slnx`: 0 errors, no new warnings (MCEC0001/MCEC0002 clean).

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU