### PR TITLE
fix(settings): never fail-to-start on a bad mcec.settings or junk registry value

### DIFF
--- a/src/Services/AppSettings.cs
+++ b/src/Services/AppSettings.cs
@@ -36,6 +36,27 @@ public class AppSettings : ICloneable {
         return val;
     }
 
+    /// <summary>
+    /// Converts a raw registry value to a bool, tolerating junk (issue #155). A REG_SZ like "banana"
+    /// makes <see cref="Convert.ToBoolean(object?, IFormatProvider)"/> throw FormatException (and a
+    /// REG_BINARY blob throws InvalidCastException) — a machine-policy value that cannot be parsed
+    /// must not crash startup. Falls back to <paramref name="defaultValue"/> and logs the bad value
+    /// so an admin can fix it.
+    /// </summary>
+    public static bool RegistryValueToBoolean(object? value, bool defaultValue) {
+        if (value is null) {
+            return defaultValue;
+        }
+        try {
+            return Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+        }
+        catch (Exception e) when (e is FormatException || e is InvalidCastException) {
+            Logger.Instance.Log4.Error(
+                $"Settings: Ignoring invalid registry value '{value}' (expected a boolean); using default ({defaultValue}). {e.Message}");
+            return defaultValue;
+        }
+    }
+
     // Global
     [XmlIgnore] public bool DisableInternalCommands;
 
@@ -244,7 +265,10 @@ public class AppSettings : ICloneable {
     }
 
     /// <summary>
-    /// DeSerializes settings from XML
+    /// DeSerializes settings from XML.
+    /// SECURITY (issue #155): a bad settings file must never put MCEC into a fail-to-start state
+    /// (GUI or headless --mcp). Missing file → defaults are created; corrupt/unreadable file →
+    /// defaults are used for this run and the file is left untouched so the user can recover it.
     /// </summary>
     /// <param name="settingsFile">full path to settings file</param>
     public static AppSettings Deserialize(String settingsFile) {
@@ -258,9 +282,6 @@ public class AppSettings : ICloneable {
             fs = new FileStream(settingsFile, FileMode.Open, FileAccess.Read);
             reader = new XmlTextReader(fs);
             settings = (AppSettings?)serializer.Deserialize(reader);
-
-            settings!.DisableInternalCommands = Convert.ToBoolean(
-                GetRegistryValue("DisableInternalCommands", false), new NumberFormatInfo());
             Logger.Instance.Log4.Info("Settings: Loaded settings from " + settingsFile);
         }
         catch (FileNotFoundException) {
@@ -268,15 +289,38 @@ public class AppSettings : ICloneable {
             Logger.Instance.Log4.Info($"Settings: Creating settings file with defaults: {settingsFile}");
             settings = new AppSettings();
             settings.Serialize(settingsFile);
-
-            // even if it's first run, read global commands
-            settings.DisableInternalCommands = Convert.ToBoolean(
-                GetRegistryValue("DisableInternalCommands", false), new NumberFormatInfo());
         }
         catch (UnauthorizedAccessException e) {
-            Logger.Instance.Log4.Error($"Settings: Settings file could not be loaded. {e.Message}");
+            // File exists but cannot be read (ACLs). Use defaults for this run; do NOT try to
+            // overwrite a file we cannot even read.
+            Logger.Instance.Log4.Error(
+                $"Settings: Settings file could not be loaded ({settingsFile}); using default settings for this run. {e.Message}");
+            settings = new AppSettings();
             if (!AgentRuntime.Headless) {
-                MessageBox.Show($"Settings file could not be loaded. {e.Message}");
+                MessageBox.Show($"Settings file could not be loaded. {e.Message}\n\nMCE Controller will use default settings for this run.");
+            }
+        }
+        catch (Exception e) when (e is XmlException || e is InvalidOperationException) {
+            // Malformed XML (mid-write crash, disk error, hand-edit). XmlSerializer wraps the
+            // XmlException in an InvalidOperationException. Use defaults for this run and
+            // deliberately do NOT overwrite the corrupt file, so the user can inspect/repair it.
+            string detail = (e.InnerException ?? e).Message;
+            Logger.Instance.Log4.Error(
+                $"Settings: Settings file is corrupt or invalid ({settingsFile}); using default settings for this run. " +
+                $"The file was NOT overwritten - fix or delete it to recover. {detail}");
+            settings = new AppSettings();
+            if (!AgentRuntime.Headless) {
+                MessageBox.Show($"Settings file is corrupt or invalid: {settingsFile}\n\n{detail}\n\n" +
+                    "MCE Controller will use default settings for this run. The file was not overwritten - fix or delete it to recover your settings.");
+            }
+        }
+        catch (Exception e) {
+            // Last resort: a settings problem must never prevent startup.
+            Logger.Instance.Log4.Error(
+                $"Settings: Unexpected error loading settings file ({settingsFile}); using default settings for this run. {e.Message}");
+            settings = new AppSettings();
+            if (!AgentRuntime.Headless) {
+                MessageBox.Show($"Settings file could not be loaded. {e.Message}\n\nMCE Controller will use default settings for this run.");
             }
         }
         finally {
@@ -289,11 +333,20 @@ public class AppSettings : ICloneable {
             }
         }
 
-        // TELEMETRY: 
+        // XmlSerializer.Deserialize contractually returns non-null here, but guard anyway (#155):
+        // this method must always hand back usable settings.
+        settings ??= new AppSettings();
+
+        // Machine policy: read the registry override regardless of how (or whether) the file
+        // loaded. RegistryValueToBoolean tolerates junk values (see #155).
+        settings.DisableInternalCommands = RegistryValueToBoolean(
+            GetRegistryValue("DisableInternalCommands", false), false);
+
+        // TELEMETRY:
         // what: Settings
         // why: To understand what settings get changed and which dont
         // how is PII protected: only settings clearly identified as not containing PII are collected
-        TelemetryService.Instance.TrackEvent("Settings", settings!.GetTelemetryDictionary());
+        TelemetryService.Instance.TrackEvent("Settings", settings.GetTelemetryDictionary());
 
         return settings;
     }

--- a/src/Services/AppSettings.cs
+++ b/src/Services/AppSettings.cs
@@ -27,13 +27,31 @@ public class AppSettings : ICloneable {
 
     /// <summary>
     /// Read a registry value preferring the current (Kindel) key, falling back to legacy (Kindel Systems) key.
+    /// SECURITY (issue #155): a registry problem (deny-read ACE, key marked for deletion) must never
+    /// crash startup — such failures return <paramref name="defaultValue"/> and are logged.
     /// </summary>
     public static object? GetRegistryValue(string valueName, object? defaultValue) {
-        object? val = Registry.GetValue(RegistryKeyPath, valueName, null);
-        if (val == null) {
-            val = Registry.GetValue(LegacyRegistryKeyPath, valueName, defaultValue);
+        return GetRegistryValue(valueName, defaultValue, Registry.GetValue);
+    }
+
+    /// <summary>
+    /// Seam for <see cref="GetRegistryValue(string, object?)"/>: <paramref name="getValue"/> stands in
+    /// for <see cref="Registry.GetValue(string, string?, object?)"/> so the failure path is testable
+    /// without touching the real registry.
+    /// </summary>
+    internal static object? GetRegistryValue(string valueName, object? defaultValue, Func<string, string?, object?, object?> getValue) {
+        try {
+            object? val = getValue(RegistryKeyPath, valueName, null);
+            if (val == null) {
+                val = getValue(LegacyRegistryKeyPath, valueName, defaultValue);
+            }
+            return val;
         }
-        return val;
+        catch (Exception e) when (e is System.Security.SecurityException || e is IOException || e is UnauthorizedAccessException) {
+            Logger.Instance.Log4.Error(
+                $"Settings: Could not read registry value '{valueName}'; using default ({defaultValue ?? "null"}). {e.Message}");
+            return defaultValue;
+        }
     }
 
     /// <summary>
@@ -43,7 +61,7 @@ public class AppSettings : ICloneable {
     /// must not crash startup. Falls back to <paramref name="defaultValue"/> and logs the bad value
     /// so an admin can fix it.
     /// </summary>
-    public static bool RegistryValueToBoolean(object? value, bool defaultValue) {
+    internal static bool RegistryValueToBoolean(object? value, bool defaultValue) {
         if (value is null) {
             return defaultValue;
         }

--- a/tests/MCEControl.xUnit/AppSettingsTests.cs
+++ b/tests/MCEControl.xUnit/AppSettingsTests.cs
@@ -64,6 +64,94 @@ public class AppSettingsTests
         Assert.True(readSettings.AutoStart == true);
     }
 
+    /// <summary>
+    /// Issue #155: a settings file corrupted by a mid-write crash, disk error, or hand-edit must not
+    /// put the app into a fail-to-start state (GUI or headless --mcp). Deserialize must fall back to
+    /// defaults AND must not silently overwrite the corrupt file (so the user can recover it).
+    /// </summary>
+    [Theory]
+    [InlineData("<?xml version=\"1.0\"?><AppSettings><AutoStart>tru")] // truncated mid-write
+    [InlineData("this is not xml at all")] // hand-edit / wrong file
+    [InlineData("<?xml version=\"1.0\"?><NotAppSettings/>")] // wrong root element
+    public void Deserialize_CorruptSettingsFile_ReturnsDefaults_AndPreservesFile(string content)
+    {
+        bool priorHeadless = AgentRuntime.Headless;
+        AgentRuntime.Headless = true; // never pop a modal dialog in tests
+        string settingsFullPath = Path.Combine(Path.GetTempPath(), $"mcec-corrupt-{Guid.NewGuid():N}.settings");
+        try
+        {
+            File.WriteAllText(settingsFullPath, content);
+
+            AppSettings settings = AppSettings.Deserialize(settingsFullPath);
+
+            Assert.NotNull(settings);
+            // Defaults were used
+            Assert.Equal("localhost", settings.ClientHost);
+            Assert.True(settings.ActAsServer);
+            // Recovery: the corrupt file must NOT have been overwritten
+            Assert.Equal(content, File.ReadAllText(settingsFullPath));
+        }
+        finally
+        {
+            AgentRuntime.Headless = priorHeadless;
+            File.Delete(settingsFullPath);
+        }
+    }
+
+    /// <summary>
+    /// Issue #155 (second bug): the UnauthorizedAccessException path left settings null and then
+    /// dereferenced it (settings!.GetTelemetryDictionary()) — the "handled" branch itself crashed
+    /// with an NRE. Opening a directory as a file throws UnauthorizedAccessException — the same
+    /// exception type as an ACL-denied settings file — without touching real ACLs.
+    /// </summary>
+    [Fact]
+    public void Deserialize_UnauthorizedAccess_ReturnsDefaults_NoNullReference()
+    {
+        bool priorHeadless = AgentRuntime.Headless;
+        AgentRuntime.Headless = true; // never pop a modal dialog in tests
+        string dirPath = Path.Combine(Path.GetTempPath(), $"mcec-uae-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dirPath);
+        try
+        {
+            AppSettings settings = AppSettings.Deserialize(dirPath);
+
+            Assert.NotNull(settings);
+            Assert.Equal("localhost", settings.ClientHost);
+        }
+        finally
+        {
+            AgentRuntime.Headless = priorHeadless;
+            Directory.Delete(dirPath);
+        }
+    }
+
+    /// <summary>
+    /// Issue #155 (third bug): Convert.ToBoolean on a junk DisableInternalCommands registry value
+    /// (e.g. REG_SZ "banana") threw FormatException and crashed startup. The conversion seam must
+    /// tolerate junk and fall back to the default — no real registry involved here.
+    /// </summary>
+    [Theory]
+    [InlineData(null, false, false)] // absent value -> default
+    [InlineData(null, true, true)]
+    [InlineData("banana", false, false)] // junk REG_SZ -> default (FormatException path)
+    [InlineData("banana", true, true)]
+    [InlineData("true", false, true)] // valid values still parse
+    [InlineData("False", true, false)]
+    [InlineData(1, false, true)] // REG_DWORD
+    [InlineData(0, true, false)]
+    public void RegistryValueToBoolean_ToleratesJunk(object? value, bool defaultValue, bool expected)
+    {
+        Assert.Equal(expected, AppSettings.RegistryValueToBoolean(value, defaultValue));
+    }
+
+    [Fact]
+    public void RegistryValueToBoolean_BinaryJunk_ReturnsDefault()
+    {
+        // REG_BINARY comes back as byte[] -> InvalidCastException path
+        Assert.False(AppSettings.RegistryValueToBoolean(new byte[] { 1, 2, 3 }, false));
+        Assert.True(AppSettings.RegistryValueToBoolean(new byte[] { 1, 2, 3 }, true));
+    }
+
     [Fact]
     public void DeserializeNotExists_Test()
     {

--- a/tests/MCEControl.xUnit/AppSettingsTests.cs
+++ b/tests/MCEControl.xUnit/AppSettingsTests.cs
@@ -152,6 +152,48 @@ public class AppSettingsTests
         Assert.True(AppSettings.RegistryValueToBoolean(new byte[] { 1, 2, 3 }, true));
     }
 
+    /// <summary>
+    /// Issue #155 review follow-up (M1): Registry.GetValue itself can throw SecurityException
+    /// (deny-read ACE) or IOException (key marked for deletion). GetRegistryValue must swallow
+    /// these and return the supplied default — a registry problem must never crash startup
+    /// (this also covers the TelemetryService opt-in read). Exercised through the injectable
+    /// seam; the real registry is never touched.
+    /// </summary>
+    [Fact]
+    public void GetRegistryValue_SecurityException_ReturnsDefault()
+    {
+        object? result = AppSettings.GetRegistryValue("Whatever", "fallback",
+            (key, name, def) => throw new System.Security.SecurityException("deny-read ACE"));
+        Assert.Equal("fallback", result);
+    }
+
+    [Fact]
+    public void GetRegistryValue_IOException_ReturnsDefault()
+    {
+        object? result = AppSettings.GetRegistryValue("Whatever", 42,
+            (key, name, def) => throw new IOException("key has been marked for deletion"));
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void GetRegistryValue_UnauthorizedAccessException_ReturnsDefault()
+    {
+        object? result = AppSettings.GetRegistryValue("Whatever", null,
+            (key, name, def) => throw new UnauthorizedAccessException("no read access"));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetRegistryValue_LegacyKeyThrows_ReturnsDefault()
+    {
+        // Current key reads fine (absent -> null); the legacy fallback key is the one that throws.
+        object? result = AppSettings.GetRegistryValue("Whatever", false,
+            (key, name, def) => key == AppSettings.RegistryKeyPath
+                ? null
+                : throw new System.Security.SecurityException("deny-read ACE on legacy key"));
+        Assert.Equal(false, result);
+    }
+
     [Fact]
     public void DeserializeNotExists_Test()
     {


### PR DESCRIPTION
## Failure modes fixed (Security P2, #155)

1. **Corrupt settings file = fail-to-start denial of service.** `AppSettings.Deserialize` caught only `FileNotFoundException` and `UnauthorizedAccessException`. `XmlSerializer.Deserialize` throws `InvalidOperationException` (wrapping `XmlException`) on malformed XML, which propagated and terminated startup — both the GUI path (`MainWindow.cs:138`) and the headless `--mcp` path (`Program.cs:116`). A settings file corrupted by a mid-write crash, disk error, or hand-edit bricked the app until manually deleted.
2. **The "handled" `UnauthorizedAccessException` branch itself crashed.** It left `settings` null, then `settings!.GetTelemetryDictionary()` dereferenced it → `NullReferenceException`.
3. **Junk registry value crashed startup.** `Convert.ToBoolean` on a non-boolean `DisableInternalCommands` value (e.g. REG_SZ `"banana"`, or a REG_BINARY blob) threw `FormatException`/`InvalidCastException`.

## The fix (`src/Services/AppSettings.cs`)

- `Deserialize` now catches `XmlException`/`InvalidOperationException` (corrupt XML) and a last-resort `Exception`, logging loudly (`Log4.Error`) and falling back to default settings, mirroring the `FileNotFound` branch. A modal `MessageBox` explains the fallback in GUI mode only (`AgentRuntime.Headless` suppresses it, as elsewhere).
- The `UnauthorizedAccessException` branch now also falls back to defaults, and a defensive `settings ??= new AppSettings()` before the telemetry call removes the NRE seam entirely.
- The `DisableInternalCommands` registry read is hoisted out of the try body so it runs once for every path (previously the UAE branch skipped it), and goes through a new `RegistryValueToBoolean(object?, bool)` seam that tolerates junk (`FormatException`/`InvalidCastException` → default, logged with the offending value). Happy path and `FileNotFound` behavior are unchanged.

## Recovery behavior for corrupt files

The corrupt file is **deliberately NOT overwritten** (the pre-fix code never overwrote it either — it just crashed). MCEC starts with defaults for the run, and the error log + dialog say exactly that: *"The file was not overwritten — fix or delete it to recover your settings."* Only the `FileNotFound` branch writes a fresh defaults file, as before.

## Tests (`tests/MCEControl.xUnit/AppSettingsTests.cs`, written first and verified failing for the right reasons)

- `Deserialize_CorruptSettingsFile_ReturnsDefaults_AndPreservesFile` (Theory ×3: truncated mid-write XML, non-XML text, wrong root element) — returns defaults, no throw, corrupt file byte-for-byte preserved. Previously failed with `InvalidOperationException`.
- `Deserialize_UnauthorizedAccess_ReturnsDefaults_NoNullReference` — triggers a real `UnauthorizedAccessException` by pointing `Deserialize` at a directory (same exception type as an ACL-denied file, no real ACL changes). Previously failed with `NullReferenceException` at the telemetry call.
- `RegistryValueToBoolean_ToleratesJunk` (Theory ×8: null, junk REG_SZ, valid strings, REG_DWORD ints) and `RegistryValueToBoolean_BinaryJunk_ReturnsDefault` (byte[] → `InvalidCastException` path) — exercise the conversion seam directly; the real registry is never touched.

Full suite: **348 passed, 0 failed** (22 pre-existing skips for desktop/input-simulation tests). `dotnet build MCEControl.slnx` clean under `TreatWarningsAsErrors` and MCEC0001/MCEC0002 (no new types or files; only methods added).

## Review follow-up (commit 7a34b78)

- **M1:** `Registry.GetValue` itself can throw `SecurityException` (deny-read ACE) or `IOException` (key marked for deletion), and the hoisted registry read sits after `Deserialize`'s try/finally — so those would still have crashed startup. `GetRegistryValue` now catches `SecurityException`/`IOException`/`UnauthorizedAccessException`, logs, and returns the supplied default, covering **all** call sites (including the `TelemetryService` opt-in read at `TelemetryService.cs:37`). The registry access is injectable via an internal overload taking a `Func` matching `Registry.GetValue`, so the failure path is unit-tested without touching the real registry. Tests written first and verified failing with the raw exceptions propagating: `GetRegistryValue_SecurityException_ReturnsDefault`, `GetRegistryValue_IOException_ReturnsDefault`, `GetRegistryValue_UnauthorizedAccessException_ReturnsDefault`, `GetRegistryValue_LegacyKeyThrows_ReturnsDefault`.
- **N1:** `RegistryValueToBoolean` and the new seam overload are now `internal` (the test project has `InternalsVisibleTo`). The pre-existing `GetRegistryValue(string, object?)` wrapper keeps its `public` visibility — it predates this PR and shrinking its surface is out of scope here.

Full suite after follow-up: **352 passed, 0 failed** (22 pre-existing skips).

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU
