### PR TITLE
fix(agent): cap HTTP request body at 1 MB and bound worker fan-out (#151)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -429,6 +429,13 @@ The address and port come from `McpBindAddress` (default `127.0.0.1`) and `McpHt
 (default `5151`). This is a deliberately minimal floor for local scripts and agents; it
 is not a general-purpose web API and is not exposed off-box by default.
 
+The floor is hardened against resource exhaustion ([#151]): a request body larger than
+**1 MB** is refused with `413` (the cap is enforced by a bounded read, so chunked bodies
+without a `Content-Length` can't bypass it), and at most **16** requests are served
+concurrently — past that the server answers `503` rather than queueing.
+
+[#151]: https://github.com/tig/mcec/issues/151
+
 ---
 
 ## Summary

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -28,6 +28,31 @@ namespace MCEControl;
 public static class AgentServer {
     public const string ProtocolVersion = "2025-06-18";
 
+    /// <summary>
+    /// Largest HTTP request body the /mcp endpoint accepts, in bytes (#151). Real JSON-RPC requests
+    /// are a few KB; 1 MB leaves generous headroom while making a memory-exhaustion POST impossible
+    /// (the old unbounded read buffered the whole body, then JsonNode.Parse built a second copy).
+    /// Oversized requests are refused with HTTP 413.
+    /// </summary>
+    public const long MaxHttpBodyBytes = 1024 * 1024;
+
+    /// <summary>
+    /// Upper bound on HTTP requests served concurrently (#151). Each accepted request runs on its own
+    /// worker task (#113); without a bound, a request flood spawns unbounded tasks each holding a
+    /// buffered body. Legitimate agent traffic is a handful of in-flight calls; past this cap the
+    /// server answers 503 instead of queueing.
+    /// </summary>
+    public const int MaxConcurrentHttpRequests = 16;
+
+    private static readonly SemaphoreSlim HttpWorkerSlots = new(MaxConcurrentHttpRequests, MaxConcurrentHttpRequests);
+
+    /// <summary>
+    /// Test seam: when set, <see cref="HandleHttp"/> dispatches through this instead of
+    /// <see cref="Dispatch"/> (mirrors the dispatch delegate <see cref="RunStdioLoop"/> takes).
+    /// Production leaves it null.
+    /// </summary>
+    internal static Func<JsonObject, JsonObject?>? HttpDispatchOverride;
+
     private static readonly object HttpLock = new();
     private static HttpListener? _listener;
     private static Thread? _httpThread;
@@ -848,8 +873,27 @@ public static class AgentServer {
             }
             // Serve each request on a worker so a slow call (a long wait-for, a deep query) doesn't block
             // accepting or serving other requests (#113). Each context owns its own response stream, so no
-            // cross-request correlation is needed.
-            _ = Task.Run(() => HandleHttp(context));
+            // cross-request correlation is needed. The fan-out is bounded (#151): past
+            // MaxConcurrentHttpRequests in-flight requests the server answers 503 instead of spawning
+            // unbounded tasks. (WriteHttp here is safe on the accept thread: http.sys buffers the small
+            // response in the kernel, so a slow client can't stall the accept loop.)
+            if (!HttpWorkerSlots.Wait(0)) {
+                try {
+                    WriteHttp(context, 503, new JsonObject { ["error"] = $"Server busy: more than {MaxConcurrentHttpRequests} requests in flight" });
+                }
+                catch (Exception e) {
+                    Logger.Instance.Log4.Error($"AgentServer: failed to write HTTP 503: {e.Message}");
+                }
+                continue;
+            }
+            _ = Task.Run(() => {
+                try {
+                    HandleHttp(context);
+                }
+                finally {
+                    HttpWorkerSlots.Release();
+                }
+            });
         }
     }
 
@@ -859,15 +903,23 @@ public static class AgentServer {
                 WriteHttp(context, 405, new JsonObject { ["error"] = "Only POST /mcp is supported" });
                 return;
             }
-            string body;
-            using (StreamReader sr = new(context.Request.InputStream, context.Request.ContentEncoding)) {
-                body = sr.ReadToEnd();
+            // #151: refuse an oversized body from the header alone — never buffer it. ContentLength64
+            // is -1 for chunked transfer, which passes here and is caught by the bounded read below.
+            if (context.Request.ContentLength64 > MaxHttpBodyBytes) {
+                WriteHttp(context, 413, new JsonObject { ["error"] = $"Request body exceeds {MaxHttpBodyBytes} bytes" });
+                return;
+            }
+            // Bounded read, so a chunked (or lying) client without an honest Content-Length still
+            // cannot make the server buffer more than the cap.
+            if (!TryReadBoundedBody(context.Request.InputStream, context.Request.ContentEncoding, out string body)) {
+                WriteHttp(context, 413, new JsonObject { ["error"] = $"Request body exceeds {MaxHttpBodyBytes} bytes" });
+                return;
             }
             JsonObject response;
             try {
                 JsonNode? node = JsonNode.Parse(body);
                 response = node is JsonObject req
-                    ? Dispatch(req) ?? new JsonObject { ["jsonrpc"] = "2.0" }
+                    ? (HttpDispatchOverride ?? Dispatch)(req) ?? new JsonObject { ["jsonrpc"] = "2.0" }
                     : Error(null, -32600, "Invalid Request")!;
             }
             catch (JsonException e) {
@@ -884,6 +936,27 @@ public static class AgentServer {
                 Logger.Instance.Log4.Error($"AgentServer: failed to write HTTP error: {inner.Message}");
             }
         }
+    }
+
+    /// <summary>
+    /// Reads <paramref name="input"/> to its end into <paramref name="body"/>, refusing to buffer more
+    /// than <see cref="MaxHttpBodyBytes"/> (#151). Returns false — with <paramref name="body"/> empty
+    /// and the stream abandoned — the moment the cap is crossed, so a chunked or lying client cannot
+    /// bypass the Content-Length check and exhaust memory.
+    /// </summary>
+    internal static bool TryReadBoundedBody(Stream input, Encoding encoding, out string body) {
+        using MemoryStream buffer = new();
+        byte[] chunk = new byte[64 * 1024];
+        int read;
+        while ((read = input.Read(chunk, 0, chunk.Length)) > 0) {
+            if (buffer.Length + read > MaxHttpBodyBytes) {
+                body = "";
+                return false;
+            }
+            buffer.Write(chunk, 0, read);
+        }
+        body = encoding.GetString(buffer.GetBuffer(), 0, (int)buffer.Length);
+        return true;
     }
 
     private static void WriteHttp(HttpListenerContext context, int status, JsonObject payload) {

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -51,7 +51,7 @@ public static class AgentServer {
     /// <see cref="Dispatch"/> (mirrors the dispatch delegate <see cref="RunStdioLoop"/> takes).
     /// Production leaves it null.
     /// </summary>
-    internal static Func<JsonObject, JsonObject?>? HttpDispatchOverride;
+    internal static volatile Func<JsonObject, JsonObject?>? HttpDispatchOverride;
 
     private static readonly object HttpLock = new();
     private static HttpListener? _listener;
@@ -955,6 +955,8 @@ public static class AgentServer {
             }
             buffer.Write(chunk, 0, read);
         }
+        // Unlike the StreamReader this replaced, GetString does not strip a leading BOM; a
+        // BOM-prefixed body now fails JSON parsing with a normal JSON-RPC parse error.
         body = encoding.GetString(buffer.GetBuffer(), 0, (int)buffer.Length);
         return true;
     }

--- a/tests/MCEControl.xUnit/Services/AgentServerHttpTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerHttpTests.cs
@@ -1,0 +1,174 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Tests for the HTTP transport hardening (#151): the request body is capped (a huge POST must be
+/// rejected with 413 instead of being buffered into memory twice), the cap holds even for a chunked
+/// body that carries no Content-Length header, and the per-request worker fan-out is bounded (a
+/// saturated server answers 503 instead of spawning unbounded tasks). These drive a REAL
+/// HttpListener on a free loopback port — the same code path production uses.
+/// </summary>
+[Collection("AgentSerial")]
+public class AgentServerHttpTests {
+    /// <summary>Asks the OS for a free loopback TCP port by binding to port 0 and reading the assignment.</summary>
+    private static int FindFreeLoopbackPort() {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        try {
+            listener.Start();
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally {
+            listener.Stop();
+        }
+    }
+
+    private static string StartServer() {
+        int port = FindFreeLoopbackPort();
+        AgentRuntime.Settings = new AppSettings { McpBindAddress = "127.0.0.1", McpHttpPort = port };
+        AgentServer.StartHttp();
+        return $"http://127.0.0.1:{port}/mcp";
+    }
+
+    private static void StopServer() {
+        AgentServer.StopHttp();
+        AgentRuntime.Settings = null;
+    }
+
+    [Fact]
+    public async Task Http_NormalRequest_StillWorks_Returns200WithJsonRpcResult() {
+        string url = StartServer();
+        try {
+            using HttpClient client = new() { Timeout = TimeSpan.FromSeconds(30) };
+            StringContent content = new("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}", Encoding.UTF8, "application/json");
+
+            using HttpResponseMessage resp = await client.PostAsync(url, content);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            JsonObject body = JsonNode.Parse(await resp.Content.ReadAsStringAsync())!.AsObject();
+            Assert.Equal(1, body["id"]!.GetValue<int>());
+            Assert.NotNull(body["result"]);
+        }
+        finally {
+            StopServer();
+        }
+    }
+
+    [Fact]
+    public async Task Http_ContentLengthOverCap_Returns413_NotParsedOrDispatched() {
+        // A body one byte over the cap, declared honestly via Content-Length. The handler must refuse
+        // it from the header alone (413) WITHOUT buffering it. Under the old unbounded code this body
+        // would be read whole and fed to JsonNode.Parse, coming back 200 with a -32700 parse error —
+        // so a 413 here proves the reject path ran instead of the read-everything path.
+        string url = StartServer();
+        try {
+            using HttpClient client = new() { Timeout = TimeSpan.FromSeconds(30) };
+            byte[] payload = new byte[AgentServer.MaxHttpBodyBytes + 1];
+            Array.Fill(payload, (byte)'x');
+            ByteArrayContent content = new(payload);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+            using HttpResponseMessage resp = await client.PostAsync(url, content);
+
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, resp.StatusCode);
+        }
+        finally {
+            StopServer();
+        }
+    }
+
+    [Fact]
+    public void TryReadBoundedBody_AtTheCap_ReadsWholeBody() {
+        byte[] payload = new byte[AgentServer.MaxHttpBodyBytes];
+        Array.Fill(payload, (byte)'a');
+
+        bool ok = AgentServer.TryReadBoundedBody(new System.IO.MemoryStream(payload), Encoding.UTF8, out string body);
+
+        Assert.True(ok);
+        Assert.Equal(AgentServer.MaxHttpBodyBytes, body.Length);
+    }
+
+    [Fact]
+    public void TryReadBoundedBody_OneByteOverTheCap_RefusesWithoutBuffering() {
+        byte[] payload = new byte[AgentServer.MaxHttpBodyBytes + 1];
+        Array.Fill(payload, (byte)'a');
+
+        bool ok = AgentServer.TryReadBoundedBody(new System.IO.MemoryStream(payload), Encoding.UTF8, out string body);
+
+        Assert.False(ok);
+        Assert.Equal("", body);
+    }
+
+    [Fact]
+    public async Task Http_MoreConcurrentRequestsThanWorkerSlots_OverflowGets503_OthersComplete() {
+        // #151 fan-out bound: saturate every worker slot with a request parked inside dispatch, then
+        // send one more — it must be refused with 503 rather than spawn an unbounded worker. Releasing
+        // the parked dispatches lets all the saturating requests finish normally (200). Deterministic:
+        // the overflow request is only sent after the CountdownEvent proves all slots are occupied.
+        string url = StartServer();
+        using System.Threading.CountdownEvent allParked = new(AgentServer.MaxConcurrentHttpRequests);
+        using System.Threading.ManualResetEventSlim release = new(false);
+        AgentServer.HttpDispatchOverride = req => {
+            allParked.Signal();
+            release.Wait(30000);
+            return new JsonObject { ["jsonrpc"] = "2.0", ["id"] = req["id"]?.DeepClone(), ["result"] = new JsonObject() };
+        };
+        try {
+            using HttpClient client = new() { Timeout = TimeSpan.FromSeconds(60) };
+            Task<HttpResponseMessage>[] saturating = new Task<HttpResponseMessage>[AgentServer.MaxConcurrentHttpRequests];
+            for (int i = 0; i < saturating.Length; i++) {
+                StringContent content = new($"{{\"jsonrpc\":\"2.0\",\"id\":{i},\"method\":\"ping\"}}", Encoding.UTF8, "application/json");
+                saturating[i] = client.PostAsync(url, content);
+            }
+            Assert.True(allParked.Wait(30000), "worker slots never all filled");
+
+            StringContent overflowContent = new("{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"ping\"}", Encoding.UTF8, "application/json");
+            using HttpResponseMessage overflow = await client.PostAsync(url, overflowContent);
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, overflow.StatusCode);
+
+            release.Set();
+            foreach (Task<HttpResponseMessage> t in saturating) {
+                using HttpResponseMessage resp = await t;
+                Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            }
+        }
+        finally {
+            release.Set();
+            AgentServer.HttpDispatchOverride = null;
+            StopServer();
+        }
+    }
+
+    [Fact]
+    public async Task Http_ChunkedBodyOverCap_NoContentLength_Returns413FromBoundedReader() {
+        // Chunked transfer carries no Content-Length header (ContentLength64 == -1), so the header
+        // check alone can't refuse it — this proves the READER is bounded: it must stop and reject as
+        // soon as the cap is crossed, not buffer the whole stream. Old code returned 200 (-32700).
+        string url = StartServer();
+        try {
+            using HttpClient client = new() { Timeout = TimeSpan.FromSeconds(30) };
+            byte[] payload = new byte[(AgentServer.MaxHttpBodyBytes * 2) + 1];
+            Array.Fill(payload, (byte)'x');
+            using HttpRequestMessage request = new(HttpMethod.Post, url) { Content = new ByteArrayContent(payload) };
+            request.Headers.TransferEncodingChunked = true;
+
+            using HttpResponseMessage resp = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, resp.StatusCode);
+        }
+        finally {
+            StopServer();
+        }
+    }
+}


### PR DESCRIPTION
## Vulnerability

`AgentServer.HandleHttp` read the entire `/mcp` request body with `StreamReader.ReadToEnd()` and no `Content-Length` cap; `JsonNode.Parse(body)` then built a second full in-memory copy. A single large POST — from any local process, or from a remote/rebound attacker per the #143 chaining — could exhaust the host's memory (P2 memory DoS). The per-request `Task.Run` fan-out in `HttpLoop` was also unbounded, so a request flood multiplied the damage: N concurrent oversized bodies, N workers.

## Fix

All in `src/Services/AgentServer.cs`:

- **1 MB body cap (`MaxHttpBodyBytes`)** — real JSON-RPC requests are a few KB, so 1 MB (the value the issue suggests) leaves generous headroom while making a memory-exhaustion POST impossible. A request whose `Content-Length` exceeds the cap is refused with **HTTP 413** before a single body byte is read, using the file's existing transport-level rejection shape (`{"error": "..."}`, same as the 405 path).
- **Bounded read (`TryReadBoundedBody`)** — the body is read in 64 KB chunks into a capped buffer; the moment the cap is crossed the read is abandoned and the request refused with 413. This closes the bypass where a chunked client (`ContentLength64 == -1`) or one lying about `Content-Length` sails past the header check.
- **Bounded fan-out (`MaxConcurrentHttpRequests = 16` + `SemaphoreSlim`)** — the related hardening from the issue: at most 16 requests are served concurrently; overflow is answered **503** from the accept loop (safe there — http.sys buffers the small response in the kernel) instead of spawning unbounded workers.

Dispatch semantics for well-formed requests are unchanged. `docs/agent-server.md` (HTTP floor section) documents the new limits.

## Tests

New `tests/MCEControl.xUnit/Services/AgentServerHttpTests.cs` — drives a **real** `HttpListener` on a free loopback port (the production code path), in the `AgentSerial` collection:

- `Http_NormalRequest_StillWorks_Returns200WithJsonRpcResult` — a normal `ping` still returns 200 with a JSON-RPC result (no regression).
- `Http_ContentLengthOverCap_Returns413_NotParsedOrDispatched` — a body one byte over the cap with an honest `Content-Length` is refused 413 from the header alone (old code returned 200 with a `-32700` parse error, proving it buffered and parsed the whole body — this test failed against the old code for exactly that reason).
- `Http_ChunkedBodyOverCap_NoContentLength_Returns413FromBoundedReader` — a 2 MB chunked body with no `Content-Length` is refused 413, proving the reader itself is bounded and the header check can't be bypassed.
- `TryReadBoundedBody_AtTheCap_ReadsWholeBody` / `TryReadBoundedBody_OneByteOverTheCap_RefusesWithoutBuffering` — deterministic unit tests of the cap boundary.
- `Http_MoreConcurrentRequestsThanWorkerSlots_OverflowGets503_OthersComplete` — parks 16 requests inside dispatch (via a test seam mirroring the dispatch delegate `RunStdioLoop` already takes), proves the 17th gets 503, then releases and proves all 16 parked requests complete 200. Deterministic: the overflow request is only sent after a `CountdownEvent` confirms every slot is occupied.

Both new 413 tests were written first and failed against the old code with `Expected: RequestEntityTooLarge / Actual: OK`. Full suite: **341 passed, 0 failed** (22 pre-existing environment skips); full solution builds clean with warnings-as-errors and the MCEC0001/MCEC0002 house analyzers.

## Review follow-up (c00bd26)

Independent review approved with two notes, both applied: (1) documented a subtle behavior change — the bounded reader no longer strips a leading UTF-8 BOM the way the old `StreamReader` did, so a BOM-prefixed JSON body now gets a well-formed JSON-RPC parse error instead of being silently accepted (real MCP clients do not send BOMs); (2) the `HttpDispatchOverride` test seam is now `volatile` to make its cross-thread publication explicit.

Fixes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU
