### PR TITLE
fix(record): transition auto-stopped recordings to a completed state (#157)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -198,6 +198,17 @@ Two ways to bound a recording:
 - **Segment:** `action: "start"` begins recording and returns immediately; `action: "stop"`
   ends it, encodes, writes the file, and returns metadata. Only one recording runs at a time.
 
+**Recording lifecycle.** An open `start` is never unbounded: the capture loop *auto-stops*
+when it hits the operator's max duration or max frames (or the target vanishes mid-record).
+An auto-stopped recording is **completed, not lost**:
+
+- `action: "stop"` still returns the buffered GIF — exactly once. A second `stop` fails with
+  "No recording is in progress or awaiting fetch", and fetching releases the buffered frames.
+- A new `start` is allowed after an auto-stop. If the auto-stopped GIF was never fetched, the
+  new recording **replaces** it: the discarded output is gone, and the `start` result carries
+  an `unfetched-recording-discarded` warning (also audit-logged). Fetch with `stop` promptly
+  if you want the output.
+
 Safety limits (operator-configurable in `mcec.settings`, requests above them are *clamped*,
 not failed) keep an agent from producing an unbounded file:
 

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -204,10 +204,11 @@ An auto-stopped recording is **completed, not lost**:
 
 - `action: "stop"` still returns the buffered GIF — exactly once. A second `stop` fails with
   "No recording is in progress or awaiting fetch", and fetching releases the buffered frames.
-- A new `start` is allowed after an auto-stop. If the auto-stopped GIF was never fetched, the
-  new recording **replaces** it: the discarded output is gone, and the `start` result carries
-  an `unfetched-recording-discarded` warning (also audit-logged). Fetch with `stop` promptly
-  if you want the output.
+- A new recording (`start` **or** a one-shot) is allowed after an auto-stop. If the
+  auto-stopped GIF was never fetched, the new recording **replaces** it: the discarded output
+  is gone, and that command's result carries an `unfetched-recording-discarded` warning (for
+  a one-shot, on its single final reply) — also audit-logged. Fetch with `stop` promptly if
+  you want the output.
 
 Safety limits (operator-configurable in `mcec.settings`, requests above them are *clamped*,
 not failed) keep an agent from producing an unbounded file:

--- a/docs/design/gif-recording.md
+++ b/docs/design/gif-recording.md
@@ -29,7 +29,15 @@ is resolved and fixed at `start`/`oneshot`; `stop` needs no target.
 (downscale longest side, default 1280 to keep GIFs bounded).
 
 Only one recording may be active at a time; `start` while recording returns an error, and
-`stop` with nothing recording returns an error.
+`stop` with nothing recording (and nothing awaiting fetch) returns an error.
+
+State machine (#157): `idle → (start) → recording → (stop) → idle`, or
+`recording → (auto-stop: max duration/frames hit, or the grab fails) → completed`. While
+completed, `stop` still fetches the buffered GIF exactly once (releasing the frames), and a
+new `start` is allowed — it discards an unfetched completed GIF and warns
+(`unfetched-recording-discarded`). The capture loop performs the recording→completed
+transition under the same lock as start/stop, so a self-terminating loop can never leave
+the recorder stuck reporting "a recording is already in progress".
 
 ## Result envelope
 
@@ -95,5 +103,3 @@ animation, a repro of a transient/flicker), and keep it short.
 - ✅ Docs + built-in MCP guidance on GIF-record vs still-`capture`.
 - ✅ Tests for argument validation and the disabled gate; an opt-in manual desktop test for
   real capture.
-</content>
-</invoke>

--- a/docs/design/gif-recording.md
+++ b/docs/design/gif-recording.md
@@ -34,8 +34,9 @@ Only one recording may be active at a time; `start` while recording returns an e
 State machine (#157): `idle → (start) → recording → (stop) → idle`, or
 `recording → (auto-stop: max duration/frames hit, or the grab fails) → completed`. While
 completed, `stop` still fetches the buffered GIF exactly once (releasing the frames), and a
-new `start` is allowed — it discards an unfetched completed GIF and warns
-(`unfetched-recording-discarded`). The capture loop performs the recording→completed
+new recording (`start` or `oneshot`) is allowed — it discards an unfetched completed GIF
+and its result carries an `unfetched-recording-discarded` warning (a oneshot surfaces it on
+its single final reply). The capture loop performs the recording→completed
 transition under the same lock as start/stop, so a self-terminating loop can never leave
 the recorder stuck reporting "a recording is already in progress".
 

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -14,9 +14,9 @@ composited WinUI/WPF surfaces). Use `capture` for a single state check; use `rec
 over time — a bounded one-shot (`durationMs`) or `action:start` then `action:stop`; keep recordings short
 (fps/duration are capped and frames downscaled), and remember it captures whatever is on screen for the
 whole duration. An open `start` auto-stops at the operator's limits (default 60 s / 600 frames); `stop`
-still returns that buffered GIF — exactly once — and after an auto-stop a new `start` is allowed: it
-discards an unfetched GIF with an `unfetched-recording-discarded` warning, so `stop` promptly to collect
-your output. Check results for trouble: a `capture` with errorCategory `capture-blank` is a black/empty
+still returns that buffered GIF — exactly once — and after an auto-stop a new recording (`start` or a
+one-shot) is allowed: it discards the unfetched GIF, carrying an `unfetched-recording-discarded` warning
+on its result, so `stop` promptly to collect your output. Check results for trouble: a `capture` with errorCategory `capture-blank` is a black/empty
 frame (minimized, cloaked, occluded, or a locked session) — restore/foreground the window and retry
 instead of trusting the image; a `capture-fallback` warning means PrintWindow was refused and the picture
 may be wrong. If `query` returns `truncated:true` (a `tree-truncated` warning), the tree hit the node cap

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -13,7 +13,10 @@ so you can pick a control instead of guessing pixels; `capture` returns a PNG of
 composited WinUI/WPF surfaces). Use `capture` for a single state check; use `record` ONLY to show CHANGE
 over time — a bounded one-shot (`durationMs`) or `action:start` then `action:stop`; keep recordings short
 (fps/duration are capped and frames downscaled), and remember it captures whatever is on screen for the
-whole duration. Check results for trouble: a `capture` with errorCategory `capture-blank` is a black/empty
+whole duration. An open `start` auto-stops at the operator's limits (default 60 s / 600 frames); `stop`
+still returns that buffered GIF — exactly once — and after an auto-stop a new `start` is allowed: it
+discards an unfetched GIF with an `unfetched-recording-discarded` warning, so `stop` promptly to collect
+your output. Check results for trouble: a `capture` with errorCategory `capture-blank` is a black/empty
 frame (minimized, cloaked, occluded, or a locked session) — restore/foreground the window and retry
 instead of trusting the image; a `capture-fallback` warning means PrintWindow was refused and the picture
 may be wrong. If `query` returns `truncated:true` (a `tree-truncated` warning), the tree hit the node cap

--- a/src/Agent/GifRecorder.cs
+++ b/src/Agent/GifRecorder.cs
@@ -21,10 +21,20 @@ namespace MCEControl;
 /// hard-bounded by fps, max frames, max duration, and a max width (frames are downscaled) so an agent
 /// cannot create an unbounded file. The owning <see cref="RecordCommand"/> applies the security gate
 /// and audit; this type is the mechanism only.
+///
+/// LIFECYCLE (#157): <c>idle → (Start) → recording → (Stop) → idle</c>, or
+/// <c>recording → (loop self-terminates on max frames/duration/grab failure) → completed</c>. In the
+/// completed state <see cref="IsRecording"/> is false, so a new <see cref="Start"/> is allowed — it
+/// discards the unfetched GIF (and reports that it did) — while <see cref="Stop"/> still returns the
+/// buffered GIF exactly once; fetching releases the frames so they are not pinned for the process
+/// lifetime.
 /// </summary>
 public sealed class GifRecorder {
     private static readonly object Gate = new();
     private static GifRecorder? _active;
+
+    /// <summary>A recording whose capture loop self-terminated and whose GIF has not been fetched yet.</summary>
+    private static GifRecorder? _completed;
 
     private readonly Func<Bitmap> _grab;
     private readonly int _fps;
@@ -50,9 +60,15 @@ public sealed class GifRecorder {
         _target = target;
     }
 
-    /// <summary>True while a recording is in progress.</summary>
+    /// <summary>True while a recording is in progress. False once the capture loop has
+    /// self-terminated (auto-stop), even before the buffered GIF is fetched via <see cref="Stop"/>.</summary>
     public static bool IsRecording {
         get { lock (Gate) { return _active is not null; } }
+    }
+
+    /// <summary>True when a recording auto-stopped and its buffered GIF has not been fetched yet.</summary>
+    public static bool HasCompletedRecording {
+        get { lock (Gate) { return _completed is not null; } }
     }
 
     /// <summary>The effective fps of the in-progress recording, or 0 when idle.</summary>
@@ -68,14 +84,20 @@ public sealed class GifRecorder {
     /// <summary>
     /// Starts a recording. <paramref name="grab"/> is invoked once per frame and must return a fresh
     /// bitmap the recorder will dispose. The caller has already clamped fps/limits to operator policy.
+    /// A completed-but-unfetched recording (auto-stop whose GIF was never fetched) does NOT block a
+    /// new start: it is discarded and replaced.
     /// </summary>
+    /// <returns>True when a completed-but-unfetched recording was discarded to make room; the caller
+    /// should surface that as a warning.</returns>
     /// <exception cref="InvalidOperationException">Thrown when a recording is already in progress.</exception>
-    public static void Start(Func<Bitmap> grab, int fps, int maxFrames, int maxWidth, long maxDurationMs, JsonNode? target) {
+    public static bool Start(Func<Bitmap> grab, int fps, int maxFrames, int maxWidth, long maxDurationMs, JsonNode? target) {
         ArgumentNullException.ThrowIfNull(grab);
         lock (Gate) {
             if (_active is not null) {
                 throw new InvalidOperationException("A recording is already in progress.");
             }
+            bool discardedUnfetched = _completed is not null;
+            _completed = null; // an auto-stopped recording nobody fetched — replaced by the new one
             GifRecorder recorder = new(grab, Math.Max(1, fps), Math.Max(1, maxFrames), Math.Max(1, maxWidth), Math.Max(1, maxDurationMs), target);
             recorder._thread = new Thread(recorder.CaptureLoop) {
                 IsBackground = true,
@@ -84,18 +106,22 @@ public sealed class GifRecorder {
             _active = recorder;
             recorder._clock.Start();
             recorder._thread.Start();
+            return discardedUnfetched;
         }
     }
 
     /// <summary>
-    /// Stops the in-progress recording, waits for the capture thread to drain, assembles the GIF, and
-    /// returns the result. Returns null when no recording is active.
+    /// Stops the in-progress recording (or claims a completed one whose loop already self-terminated),
+    /// waits for the capture thread to drain, assembles the GIF, and returns the result. Fetching a
+    /// completed recording releases it — a second call returns null, so the buffered frames are never
+    /// pinned past the fetch. Returns null when there is nothing to stop or fetch.
     /// </summary>
     public static RecordingResult? Stop(bool loop = true) {
         GifRecorder? recorder;
         lock (Gate) {
-            recorder = _active;
+            recorder = _active ?? _completed;
             _active = null;
+            _completed = null;
         }
         if (recorder is null) {
             return null;
@@ -142,8 +168,36 @@ public sealed class GifRecorder {
         };
     }
 
-    /// <summary>Background capture loop: grab → downscale → encode, paced to fps, until stop or a limit.</summary>
+    /// <summary>Background capture loop: grab → downscale → encode, paced to fps, until stop or a limit.
+    /// On exit it always runs <see cref="TransitionToCompleted"/> so a self-terminating loop (max
+    /// frames/duration/grab failure) cannot leave the recorder stuck in the recording state (#157).</summary>
     private void CaptureLoop() {
+        try {
+            CaptureFrames();
+        }
+        finally {
+            TransitionToCompleted();
+        }
+    }
+
+    /// <summary>
+    /// Moves this recorder from active to completed when its loop exited on its own (a limit was hit
+    /// or the grab failed). Under <see cref="Gate"/> so it cannot race <see cref="Start"/>/<see cref="Stop"/>:
+    /// when <see cref="Stop"/> already claimed this recorder (it clears <see cref="_active"/> before
+    /// requesting the stop), there is nothing to do — Stop owns the frames and will assemble them.
+    /// </summary>
+    private void TransitionToCompleted() {
+        lock (Gate) {
+            if (ReferenceEquals(_active, this)) {
+                _clock.Stop(); // freeze the duration at auto-stop, not at whenever the GIF is fetched
+                _active = null;
+                _completed = this;
+            }
+        }
+    }
+
+    /// <summary>The body of <see cref="CaptureLoop"/>: one iteration per frame, paced to fps.</summary>
+    private void CaptureFrames() {
         double frameIntervalMs = 1000.0 / _fps;
         while (!_stopRequested) {
             long frameStart = _clock.ElapsedMilliseconds;

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -113,7 +113,13 @@ public class RecordCommand : Command {
         }
 
         AgentRuntime.Audit(Cmd, $"start {DescribeTarget(target)} fps={limits.Fps} oneshot={oneshot} durationMs={(oneshot ? limits.LoopDurationMs : 0)}");
-        GifRecorder.Start(grab, limits.Fps, limits.MaxFrames, limits.MaxWidth, limits.LoopDurationMs, target);
+        bool discardedUnfetched = GifRecorder.Start(grab, limits.Fps, limits.MaxFrames, limits.MaxWidth, limits.LoopDurationMs, target);
+        if (discardedUnfetched) {
+            // A prior recording auto-stopped (max duration/frames) and its GIF was never fetched with
+            // action=stop. The new recording replaces it — warn so the loss is visible, not silent.
+            Logger.Instance.Log4.Warn($"{GetType().Name}: a previous recording auto-stopped and was never fetched; its buffered GIF was discarded by this start.");
+            AgentRuntime.Audit(Cmd, "start — discarded an unfetched auto-stopped recording");
+        }
 
         if (!oneshot) {
             JsonObject data = new() {
@@ -122,7 +128,12 @@ public class RecordCommand : Command {
                 ["maxDurationMs"] = limits.LoopDurationMs,
                 ["target"] = target?.DeepClone(),
             };
-            Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
+            CommandResult result = CommandResult.Ok(Cmd, data);
+            if (discardedUnfetched) {
+                result.Warn("unfetched-recording-discarded",
+                    "A previous recording auto-stopped and its GIF was never fetched; it has been discarded and replaced by this recording.");
+            }
+            Reply?.WriteLine(result.ToJson());
             return true;
         }
 
@@ -207,11 +218,12 @@ public class RecordCommand : Command {
         return $"window 0x{obj["handle"]?.GetValue<long>():X} \"{obj["title"]?.GetValue<string>()}\" ({obj["processName"]?.GetValue<string>()})";
     }
 
-    /// <summary>Stops the active recording, encodes the GIF, writes it to disk, and replies metadata.</summary>
+    /// <summary>Stops the active recording (or fetches one that already auto-stopped at its limits),
+    /// encodes the GIF, writes it to disk, and replies metadata.</summary>
     private bool DoStop() {
         RecordingResult? result = GifRecorder.Stop();
         if (result is null) {
-            return FailWith("No recording is in progress.");
+            return FailWith("No recording is in progress or awaiting fetch.");
         }
 
         if (result.Frames == 0 || result.Gif.Length == 0) {

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -43,6 +43,11 @@ public class RecordCommand : Command {
 
     private const int DefaultFps = 5;
 
+    /// <summary>Warning code emitted when starting a new recording discards a completed-but-unfetched GIF.</summary>
+    private const string DiscardedWarningCode = "unfetched-recording-discarded";
+    private const string DiscardedWarningDetail =
+        "A previous recording auto-stopped and its GIF was never fetched; it has been discarded and replaced by this recording.";
+
     public static new List<Command> BuiltInCommands {
         get => [new RecordCommand { Cmd = "record" }];
     }
@@ -116,9 +121,10 @@ public class RecordCommand : Command {
         bool discardedUnfetched = GifRecorder.Start(grab, limits.Fps, limits.MaxFrames, limits.MaxWidth, limits.LoopDurationMs, target);
         if (discardedUnfetched) {
             // A prior recording auto-stopped (max duration/frames) and its GIF was never fetched with
-            // action=stop. The new recording replaces it — warn so the loss is visible, not silent.
-            Logger.Instance.Log4.Warn($"{GetType().Name}: a previous recording auto-stopped and was never fetched; its buffered GIF was discarded by this start.");
-            AgentRuntime.Audit(Cmd, "start — discarded an unfetched auto-stopped recording");
+            // action=stop. The new recording (start OR oneshot) replaces it — warn so the loss is
+            // visible, not silent.
+            Logger.Instance.Log4.Warn($"{GetType().Name}: a previous recording auto-stopped and was never fetched; its buffered GIF was discarded by this new recording.");
+            AgentRuntime.Audit(Cmd, $"{(oneshot ? "oneshot" : "start")} — discarded an unfetched auto-stopped recording");
         }
 
         if (!oneshot) {
@@ -130,17 +136,17 @@ public class RecordCommand : Command {
             };
             CommandResult result = CommandResult.Ok(Cmd, data);
             if (discardedUnfetched) {
-                result.Warn("unfetched-recording-discarded",
-                    "A previous recording auto-stopped and its GIF was never fetched; it has been discarded and replaced by this recording.");
+                result.Warn(DiscardedWarningCode, DiscardedWarningDetail);
             }
             Reply?.WriteLine(result.ToJson());
             return true;
         }
 
         // One-shot: wait for the bounded loop to finish (it auto-stops at loopDurationMs), with a small
-        // grace so the final frame is captured, then stop + encode + write.
+        // grace so the final frame is captured, then stop + encode + write. The oneshot's single reply
+        // comes from DoStop, so the discard warning must ride along or it would be silently dropped.
         Thread.Sleep((int)Math.Min(limits.LoopDurationMs, int.MaxValue) + 200);
-        return DoStop();
+        return DoStop(discardedUnfetched);
     }
 
     /// <summary>Resolves and clamps fps/duration/frames/width against the operator's policy, auditing clamps.</summary>
@@ -174,9 +180,10 @@ public class RecordCommand : Command {
 
     /// <summary>
     /// Builds the per-frame grabber for the requested target (explicit region, else resolved window).
-    /// Returns null with <paramref name="error"/> set when no window matches.
+    /// Returns null with <paramref name="error"/> set when no window matches. Virtual so tests can
+    /// substitute a synthetic in-memory grabber and exercise start/oneshot without touching the desktop.
     /// </summary>
-    private Func<Bitmap>? BuildGrabber(out JsonNode? target, out string? error) {
+    protected virtual Func<Bitmap>? BuildGrabber(out JsonNode? target, out string? error) {
         error = null;
         bool hasWindowTarget = !string.IsNullOrEmpty(Window)
             || Handle > 0
@@ -219,16 +226,18 @@ public class RecordCommand : Command {
     }
 
     /// <summary>Stops the active recording (or fetches one that already auto-stopped at its limits),
-    /// encodes the GIF, writes it to disk, and replies metadata.</summary>
-    private bool DoStop() {
+    /// encodes the GIF, writes it to disk, and replies metadata. <paramref name="warnDiscardedUnfetched"/>
+    /// is set by the oneshot path when its start discarded an unfetched auto-stopped GIF, so the
+    /// warning surfaces on the oneshot's single (stop-produced) reply.</summary>
+    private bool DoStop(bool warnDiscardedUnfetched = false) {
         RecordingResult? result = GifRecorder.Stop();
         if (result is null) {
-            return FailWith("No recording is in progress or awaiting fetch.");
+            return FailWith("No recording is in progress or awaiting fetch.", warnDiscardedUnfetched);
         }
 
         if (result.Frames == 0 || result.Gif.Length == 0) {
             AgentRuntime.Audit(Cmd, $"stop — no output ({result.Error})");
-            return FailWith(result.Error ?? "Recording produced no frames.");
+            return FailWith(result.Error ?? "Recording produced no frames.", warnDiscardedUnfetched);
         }
 
         string path = string.IsNullOrEmpty(File)
@@ -256,17 +265,27 @@ public class RecordCommand : Command {
             // is no usable output — report failure rather than success-with-fileError.
             Logger.Instance.Log4.Error($"{GetType().Name}: could not write GIF to '{path}': {e.Message}");
             AgentRuntime.Audit(Cmd, $"stop — encode ok ({result.Frames} frames) but write failed: {e.Message}");
-            return FailWith($"Recorded {result.Frames} frames but could not write GIF to '{path}': {e.Message}");
+            return FailWith($"Recorded {result.Frames} frames but could not write GIF to '{path}': {e.Message}", warnDiscardedUnfetched);
         }
 
         data["file"] = path;
         AgentRuntime.Audit(Cmd, $"stop — wrote {result.Frames} frames, {result.Gif.Length} bytes, {result.Width}x{result.Height} to {path}");
-        Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
+        CommandResult ok = CommandResult.Ok(Cmd, data);
+        if (warnDiscardedUnfetched) {
+            ok.Warn(DiscardedWarningCode, DiscardedWarningDetail);
+        }
+        Reply?.WriteLine(ok.ToJson());
         return true;
     }
 
-    private bool FailWith(string error) {
-        Reply?.WriteLine(CommandResult.Fail(Cmd, error).ToJson());
+    /// <summary>Writes a failure envelope; the discard warning still rides along when set — warnings
+    /// are valid on failure too, and the discard already happened regardless of this call's outcome.</summary>
+    private bool FailWith(string error, bool warnDiscardedUnfetched = false) {
+        CommandResult result = CommandResult.Fail(Cmd, error);
+        if (warnDiscardedUnfetched) {
+            result.Warn(DiscardedWarningCode, DiscardedWarningDetail);
+        }
+        Reply?.WriteLine(result.ToJson());
         return false;
     }
 

--- a/tests/MCEControl.xUnit/Agent/GifRecorderTests.cs
+++ b/tests/MCEControl.xUnit/Agent/GifRecorderTests.cs
@@ -44,9 +44,11 @@ public class GifRecorderTests {
         try {
             GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 3, maxWidth: 64, maxDurationMs: 60000, target: null);
 
-            // The loop hits maxFrames in ~60 ms; IsRecording must go false without an explicit Stop.
+            // The loop hits maxFrames in ~60 ms; IsRecording must go false without an explicit Stop,
+            // and the buffered GIF must move to the completed (fetchable) slot.
             Assert.True(WaitUntil(() => !GifRecorder.IsRecording),
                 "IsRecording stayed true after the capture loop self-terminated on maxFrames");
+            Assert.True(GifRecorder.HasCompletedRecording);
         }
         finally {
             ResetRecorder();
@@ -61,6 +63,7 @@ public class GifRecorderTests {
 
             Assert.True(WaitUntil(() => !GifRecorder.IsRecording),
                 "IsRecording stayed true after the capture loop self-terminated on maxDurationMs");
+            Assert.True(GifRecorder.HasCompletedRecording);
         }
         finally {
             ResetRecorder();
@@ -76,11 +79,13 @@ public class GifRecorderTests {
 
             Assert.True(WaitUntil(() => !GifRecorder.IsRecording),
                 "IsRecording stayed true after the capture loop self-terminated on a grab exception");
+            Assert.True(GifRecorder.HasCompletedRecording);
 
-            // The failure reason must still be fetchable by a later stop.
+            // The failure reason must still be fetchable by a later stop — and fetching releases it.
             RecordingResult? result = GifRecorder.Stop();
             Assert.NotNull(result);
             Assert.Contains("boom-grab", result!.Error);
+            Assert.False(GifRecorder.HasCompletedRecording);
         }
         finally {
             ResetRecorder();
@@ -93,10 +98,12 @@ public class GifRecorderTests {
         try {
             GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 2, maxWidth: 64, maxDurationMs: 60000, target: null);
             Assert.True(WaitUntil(() => !GifRecorder.IsRecording), "first recording never auto-stopped");
+            Assert.True(GifRecorder.HasCompletedRecording);
 
             // #157: this used to throw "A recording is already in progress." forever.
             GifRecorder.Start(() => new Bitmap(8, 8), fps: 5, maxFrames: 600, maxWidth: 64, maxDurationMs: 60000, target: null);
             Assert.True(GifRecorder.IsRecording);
+            Assert.False(GifRecorder.HasCompletedRecording); // the unfetched GIF was discarded, not kept
         }
         finally {
             ResetRecorder();
@@ -110,6 +117,7 @@ public class GifRecorderTests {
             Stopwatch sw = Stopwatch.StartNew();
             GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 3, maxWidth: 64, maxDurationMs: 60000, target: null);
             Assert.True(WaitUntil(() => !GifRecorder.IsRecording), "recording never auto-stopped");
+            Assert.True(GifRecorder.HasCompletedRecording);
             long completedAtMs = sw.ElapsedMilliseconds;
 
             // Wait a while before fetching: the buffered frames must survive, and the reported
@@ -124,6 +132,7 @@ public class GifRecorderTests {
                 $"DurationMs {result.DurationMs} kept counting after auto-stop (completed at ~{completedAtMs} ms)");
 
             // Exactly once: the completed recording (and its pinned frames) must be released on fetch.
+            Assert.False(GifRecorder.HasCompletedRecording);
             Assert.Null(GifRecorder.Stop());
         }
         finally {

--- a/tests/MCEControl.xUnit/Agent/GifRecorderTests.cs
+++ b/tests/MCEControl.xUnit/Agent/GifRecorderTests.cs
@@ -1,0 +1,157 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Text.Json.Nodes;
+using System.Threading;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// State-machine tests for <see cref="GifRecorder"/> (#157): when the capture loop self-terminates
+/// (max frames, max duration, or a grab exception) the recorder must leave the "recording" state so
+/// a later <c>start</c> is allowed, while a later <c>stop</c> can still fetch the buffered GIF —
+/// exactly once. All tests use a synthetic in-memory grabber; the desktop is never touched.
+/// </summary>
+[Collection("AgentSerial")]
+public class GifRecorderTests {
+    /// <summary>Polls <paramref name="condition"/> until true or <paramref name="timeoutMs"/> elapses.</summary>
+    private static bool WaitUntil(Func<bool> condition, int timeoutMs = 5000) {
+        Stopwatch sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs) {
+            if (condition()) {
+                return true;
+            }
+            Thread.Sleep(10);
+        }
+        return condition();
+    }
+
+    /// <summary>Drains any active or completed recording left behind by a prior test.</summary>
+    private static void ResetRecorder() {
+        while (GifRecorder.Stop() is not null) {
+            // keep draining — an active and a completed slot may both need clearing
+        }
+    }
+
+    [Fact]
+    public void AutoStop_OnMaxFrames_ClearsIsRecording() {
+        ResetRecorder();
+        try {
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 3, maxWidth: 64, maxDurationMs: 60000, target: null);
+
+            // The loop hits maxFrames in ~60 ms; IsRecording must go false without an explicit Stop.
+            Assert.True(WaitUntil(() => !GifRecorder.IsRecording),
+                "IsRecording stayed true after the capture loop self-terminated on maxFrames");
+        }
+        finally {
+            ResetRecorder();
+        }
+    }
+
+    [Fact]
+    public void AutoStop_OnMaxDuration_ClearsIsRecording() {
+        ResetRecorder();
+        try {
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 10, maxFrames: 600, maxWidth: 64, maxDurationMs: 150, target: null);
+
+            Assert.True(WaitUntil(() => !GifRecorder.IsRecording),
+                "IsRecording stayed true after the capture loop self-terminated on maxDurationMs");
+        }
+        finally {
+            ResetRecorder();
+        }
+    }
+
+    [Fact]
+    public void AutoStop_OnGrabException_ClearsIsRecording_AndStopReportsError() {
+        ResetRecorder();
+        try {
+            GifRecorder.Start(() => throw new InvalidOperationException("boom-grab"),
+                fps: 50, maxFrames: 600, maxWidth: 64, maxDurationMs: 60000, target: null);
+
+            Assert.True(WaitUntil(() => !GifRecorder.IsRecording),
+                "IsRecording stayed true after the capture loop self-terminated on a grab exception");
+
+            // The failure reason must still be fetchable by a later stop.
+            RecordingResult? result = GifRecorder.Stop();
+            Assert.NotNull(result);
+            Assert.Contains("boom-grab", result!.Error);
+        }
+        finally {
+            ResetRecorder();
+        }
+    }
+
+    [Fact]
+    public void StartAfterAutoStop_Succeeds() {
+        ResetRecorder();
+        try {
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 2, maxWidth: 64, maxDurationMs: 60000, target: null);
+            Assert.True(WaitUntil(() => !GifRecorder.IsRecording), "first recording never auto-stopped");
+
+            // #157: this used to throw "A recording is already in progress." forever.
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 5, maxFrames: 600, maxWidth: 64, maxDurationMs: 60000, target: null);
+            Assert.True(GifRecorder.IsRecording);
+        }
+        finally {
+            ResetRecorder();
+        }
+    }
+
+    [Fact]
+    public void StopAfterAutoStop_ReturnsBufferedGif_ExactlyOnce() {
+        ResetRecorder();
+        try {
+            Stopwatch sw = Stopwatch.StartNew();
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 3, maxWidth: 64, maxDurationMs: 60000, target: null);
+            Assert.True(WaitUntil(() => !GifRecorder.IsRecording), "recording never auto-stopped");
+            long completedAtMs = sw.ElapsedMilliseconds;
+
+            // Wait a while before fetching: the buffered frames must survive, and the reported
+            // duration must reflect the recording itself, not how long the GIF sat unfetched.
+            Thread.Sleep(500);
+
+            RecordingResult? result = GifRecorder.Stop();
+            Assert.NotNull(result);
+            Assert.Equal(3, result!.Frames);
+            Assert.NotEmpty(result.Gif);
+            Assert.True(result.DurationMs <= completedAtMs + 250,
+                $"DurationMs {result.DurationMs} kept counting after auto-stop (completed at ~{completedAtMs} ms)");
+
+            // Exactly once: the completed recording (and its pinned frames) must be released on fetch.
+            Assert.Null(GifRecorder.Stop());
+        }
+        finally {
+            ResetRecorder();
+        }
+    }
+
+    [Fact]
+    public void StartAfterAutoStop_DiscardsUnfetchedRecording() {
+        ResetRecorder();
+        try {
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 2, maxWidth: 64, maxDurationMs: 60000,
+                target: new JsonObject { ["tag"] = "first" });
+            Assert.True(WaitUntil(() => !GifRecorder.IsRecording), "first recording never auto-stopped");
+
+            // Starting while a completed-but-unfetched GIF exists replaces it (documented behavior).
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 2, maxWidth: 64, maxDurationMs: 60000,
+                target: new JsonObject { ["tag"] = "second" });
+            Assert.True(WaitUntil(() => !GifRecorder.IsRecording), "second recording never auto-stopped");
+
+            // Stop returns the NEW recording; the discarded one is gone (only one fetch total).
+            RecordingResult? result = GifRecorder.Stop();
+            Assert.NotNull(result);
+            Assert.Equal("second", result!.Target?["tag"]?.GetValue<string>());
+            Assert.Null(GifRecorder.Stop());
+        }
+        finally {
+            ResetRecorder();
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
@@ -177,6 +177,50 @@ public class RecordCommandTests {
     }
 
     [Fact]
+    public void Execute_Oneshot_AfterAutoStop_WarnsUnfetchedRecordingDiscarded() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        string outFile = Path.Combine(Path.GetTempPath(), $"mcec-rec-test-{System.Guid.NewGuid():N}.gif");
+        try {
+            GifRecorder.Stop(); // clear any prior recording
+            // Leave a completed-but-unfetched recording behind (tiny maxFrames → immediate auto-stop).
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 2, maxWidth: 64, maxDurationMs: 60000, target: null);
+            System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+            while (GifRecorder.IsRecording && sw.ElapsedMilliseconds < 5000) {
+                Thread.Sleep(10);
+            }
+            Assert.False(GifRecorder.IsRecording);
+            Assert.True(GifRecorder.HasCompletedRecording);
+
+            // A oneshot issued now discards that unfetched GIF — its reply must say so (M1, #157):
+            // the discard warning may not be silently dropped just because the reply comes from stop.
+            CapturingReply reply = new();
+            SyntheticGrabRecordCommand cmd = new() {
+                Cmd = "record", Enabled = true, Reply = reply, Action = "oneshot", DurationMs = 150, Fps = 20, File = outFile,
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.True(result, reply.Captured);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.True(json["success"]!.GetValue<bool>(), reply.Captured);
+            Assert.True(File.Exists(outFile));
+
+            JsonArray? warnings = json["warnings"]?.AsArray();
+            Assert.NotNull(warnings);
+            Assert.Contains(warnings!, w => w?["code"]?.GetValue<string>() == "unfetched-recording-discarded");
+
+            // The discarded recording is gone: nothing else is left to fetch.
+            Assert.False(GifRecorder.HasCompletedRecording);
+        }
+        finally {
+            GifRecorder.Stop();
+            AgentRuntime.Settings = null;
+            try { File.Delete(outFile); } catch (IOException) { /* best effort cleanup */ }
+        }
+    }
+
+    [Fact]
     public void Execute_StopWhenNotRecording_Fails() {
         AgentTestSupport.EnsureTelemetry();
         AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };

--- a/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
@@ -143,6 +143,40 @@ public class RecordCommandTests {
     }
 
     [Fact]
+    public void Execute_StopAfterAutoStop_WritesBufferedGif() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        string outFile = Path.Combine(Path.GetTempPath(), $"mcec-rec-test-{System.Guid.NewGuid():N}.gif");
+        try {
+            GifRecorder.Stop(); // clear any prior recording
+            // A tiny maxFrames makes the capture loop self-terminate almost immediately (#157).
+            GifRecorder.Start(() => new Bitmap(8, 8), fps: 50, maxFrames: 3, maxWidth: 64, maxDurationMs: 60000, target: null);
+            System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+            while (GifRecorder.IsRecording && sw.ElapsedMilliseconds < 5000) {
+                Thread.Sleep(10);
+            }
+            Assert.False(GifRecorder.IsRecording); // auto-stop must clear the recording state
+
+            // `record action=stop` after the auto-stop must still return the buffered GIF.
+            CapturingReply reply = new();
+            RecordCommand cmd = new() { Cmd = "record", Enabled = true, Reply = reply, Action = "stop", File = outFile };
+
+            bool result = cmd.Execute();
+
+            Assert.True(result, reply.Captured);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.True(json["success"]!.GetValue<bool>(), reply.Captured);
+            Assert.Equal(3, json["data"]!["frames"]!.GetValue<int>());
+            Assert.True(File.Exists(outFile));
+        }
+        finally {
+            GifRecorder.Stop();
+            AgentRuntime.Settings = null;
+            try { File.Delete(outFile); } catch (IOException) { /* best effort cleanup */ }
+        }
+    }
+
+    [Fact]
     public void Execute_StopWhenNotRecording_Fails() {
         AgentTestSupport.EnsureTelemetry();
         AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };

--- a/tests/MCEControl.xUnit/Commands/SyntheticGrabRecordCommand.cs
+++ b/tests/MCEControl.xUnit/Commands/SyntheticGrabRecordCommand.cs
@@ -1,0 +1,21 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Drawing;
+using System.Text.Json.Nodes;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// A <see cref="RecordCommand"/> whose grabber returns small in-memory bitmaps instead of capturing
+/// the desktop, so start/oneshot paths can be exercised in a normal (headless-safe) test run.
+/// </summary>
+public class SyntheticGrabRecordCommand : RecordCommand {
+    protected override Func<Bitmap>? BuildGrabber(out JsonNode? target, out string? error) {
+        target = new JsonObject { ["type"] = "synthetic" };
+        error = null;
+        return () => new Bitmap(8, 8);
+    }
+}


### PR DESCRIPTION
## Bug

`GifRecorder.CaptureLoop` exited on any of its limits (max frames, max duration, or a grab exception) **without clearing `_active`** — only `Stop()` cleared it. After the default auto-stop (60 s / 600 frames), the background thread died but `IsRecording` stayed `true` forever:

- every subsequent `record action=start` failed with "A recording is already in progress" until process restart — the record feature was permanently bricked by one forgotten `stop`;
- up to `maxFrames` encoded GIF frame buffers stayed pinned in the dead recorder indefinitely.

## New state machine

```
idle → (start) → recording → (stop) → idle
                 recording → (auto-stop: max frames/duration, or grab failure) → completed
```

- The capture loop performs the `recording → completed` transition in a `finally` block **under the same `Gate` as `Start`/`Stop`**; if a concurrent `Stop()` already claimed the recorder (it clears `_active` before requesting the stop), the loop does nothing — no race, no double-ownership. The clock is stopped at the transition so `durationMs` reflects the recording, not how long the GIF sat unfetched.
- **`stop` after an auto-stop** still returns the buffered GIF — **exactly once**. A second `stop` fails ("No recording is in progress or awaiting fetch"), and fetching releases the completed recorder so the frames are no longer pinned.
- **`start` after an auto-stop** is allowed. If a completed-but-unfetched GIF exists, the new recording **replaces** it: `GifRecorder.Start` reports the discard, and `RecordCommand` surfaces it as an `unfetched-recording-discarded` warning on the shared `CommandResult` envelope (`Warnings`), plus a log warning and an `AGENT-AUDIT` line — the loss is visible, never silent.

## Tests (written first; all failed on the bug before the fix)

`tests/MCEControl.xUnit/Agent/GifRecorderTests.cs` (synthetic in-memory grabber, no desktop):
- auto-stop on max frames / max duration / grab exception → `IsRecording` goes false (polled with timeout)
- `start` after auto-stop succeeds (previously threw forever)
- `stop` after auto-stop returns the buffered GIF exactly once, with `durationMs` frozen at auto-stop; second `stop` returns null (frames released)
- `start` over an unfetched completed GIF discards it — the eventual `stop` returns the new recording only

`tests/MCEControl.xUnit/Commands/RecordCommandTests.cs`:
- command-level `record action=stop` after an auto-stop writes the buffered GIF and returns the success envelope

Full suite: 342 passed, 0 failed, 22 skipped (pre-existing gated/skipped tests).

## Docs / in-product guidance

- `src/Agent/AgentInstructions.md` — agents now told: open `start` auto-stops at operator limits; `stop` still returns that GIF once; a new `start` discards an unfetched GIF with a warning, so fetch promptly.
- `docs/agent-server.md` — "Recording lifecycle" section documenting auto-stop, once-only fetch, and the replace-with-warning rule.
- `docs/design/gif-recording.md` — state machine added; also removed stray `</content></invoke>` artifact lines at the file tail (pre-existing on develop).

## Review follow-up

- **M1 (major) — oneshot discarded an unfetched GIF silently.** `GifRecorder.Start` discards a completed-but-unfetched GIF for **both** `start` and `oneshot`, but only the `start` reply carried the `unfetched-recording-discarded` warning — a oneshot's single reply comes from `DoStop`, which never saw the flag. `DoStop`/`FailWith` now take the flag and attach the warning to the oneshot's final reply (success **or** failure — the discard happened either way). `RecordCommand.BuildGrabber` is now `protected virtual` so a `SyntheticGrabRecordCommand` test double can exercise the start/oneshot paths with in-memory bitmaps (no desktop). New test-first test: `Execute_Oneshot_AfterAutoStop_WarnsUnfetchedRecordingDiscarded` — failed on the missing warning before the fix.
- **M2 (minor) — `HasCompletedRecording` was dead API.** Kept and now exercised by the tests: asserted set after every auto-stop path (max frames / max duration / grab exception) and cleared by fetch and by discard/replacement.
- **Docs made exactly true:** `AgentInstructions.md`, `docs/agent-server.md`, and `docs/design/gif-recording.md` now say a new recording (`start` **or** a one-shot) discards the unfetched GIF and carries the warning on its result (for a oneshot, on its single final reply).

Full suite after follow-up: 343 passed, 0 failed, 22 skipped.

Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU

