### PR TITLE
fix(security): MCP HTTP door validates Host/Origin + optional bearer token (#143)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -429,6 +429,28 @@ The address and port come from `McpBindAddress` (default `127.0.0.1`) and `McpHt
 (default `5151`). This is a deliberately minimal floor for local scripts and agents; it
 is not a general-purpose web API and is not exposed off-box by default.
 
+### Front-door request validation (defeats CSRF and DNS rebinding)
+
+A localhost HTTP service is still reachable by a browser: any web page the operator visits
+can issue a cross-origin `POST` to `127.0.0.1:5151` (CSRF), and a DNS-rebinding attacker can
+make the browser treat the endpoint as same-origin to read responses. To close both, every
+HTTP request is validated **before** its body is read or any tool runs:
+
+- **Method + path** — only `POST /mcp` is served; anything else is rejected (`405`/`404`).
+- **`Host` header** — must be a loopback authority (`127.0.0.1`, `localhost`, or `[::1]`, and,
+  if a port is present, the configured `McpHttpPort`). A request with `Host: evil.com` — the
+  hallmark of DNS rebinding — is refused (`403`).
+- **`Origin` header** — must be absent (a normal non-browser MCP client sends none) or a
+  loopback origin. A cross-site `Origin` (`http://evil.com`) or an opaque `null` origin is
+  refused (`403`), which stops the drive-by CSRF case.
+- **`Authorization` (optional, defense in depth)** — set `McpAuthToken` to a non-empty secret
+  and every request must carry `Authorization: Bearer <token>` (constant-time compared), which
+  additionally protects against a hostile process on the same machine. Empty (default) relies on
+  the `Host`/`Origin` checks above.
+
+Every rejected request is logged with an `AGENT-AUDIT:` line (decision, method, path, host,
+origin, remote endpoint) so drive-by and rebinding attempts are visible to the operator.
+
 ---
 
 ## Summary
@@ -437,6 +459,8 @@ is not a general-purpose web API and is not exposed off-box by default.
 - Structured JSON results; same commands exposed as MCP/HTTP tools.
 - **Three independent off-by-default gates:** `AgentCommandsEnabled`, per-command
   `Enabled`, and `McpServerEnabled` (localhost-bound).
+- **HTTP front-door validation:** `POST /mcp` only, loopback `Host` and absent-or-loopback
+  `Origin` required, optional `McpAuthToken` bearer token — defeats browser CSRF and DNS rebinding.
 - Loud `AGENT-AUDIT:` logging for every agent action.
 - Fully additive — nothing about the existing HTPC behavior changes.
 

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -451,6 +451,12 @@ HTTP request is validated **before** its body is read or any tool runs:
 Every rejected request is logged with an `AGENT-AUDIT:` line (decision, method, path, host,
 origin, remote endpoint) so drive-by and rebinding attempts are visible to the operator.
 
+> **Binding off-box requires a token.** The `Host` check is a browser/rebinding defense, not a
+> network control — a remote client can send `Host: 127.0.0.1`. So if `McpBindAddress` is set to a
+> non-loopback address (e.g. `0.0.0.0`) **and** `McpAuthToken` is empty, MCEC **refuses to start** the
+> HTTP listener and logs an error. To expose the door off-box, set a bearer token (and prefer a
+> network-level control too).
+
 ---
 
 ## Summary

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -855,10 +855,24 @@ public static class AgentServer {
 
     private static void HandleHttp(HttpListenerContext context) {
         try {
-            if (!string.Equals(context.Request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase)) {
-                WriteHttp(context, 405, new JsonObject { ["error"] = "Only POST /mcp is supported" });
+            // SECURITY (#143): a localhost HTTP service is reachable by any web page the operator visits
+            // (browser CSRF) and by a rebinding attacker (DNS rebinding). Validate Host/Origin/token and
+            // the path BEFORE reading the body or dispatching, so a failed request never actuates a tool.
+            HttpListenerRequest request = context.Request;
+            AppSettings? settings = AgentRuntime.Settings;
+            HttpGateDecision decision = GateHttpRequest(
+                request.HttpMethod,
+                request.Url?.AbsolutePath,
+                request.UserHostName,
+                request.Headers["Origin"],
+                request.Headers["Authorization"],
+                settings?.McpHttpPort ?? 0,
+                settings?.McpAuthToken);
+            if (decision != HttpGateDecision.Allow) {
+                RejectHttp(context, decision, request);
                 return;
             }
+
             string body;
             using (StreamReader sr = new(context.Request.InputStream, context.Request.ContentEncoding)) {
                 body = sr.ReadToEnd();
@@ -884,6 +898,118 @@ public static class AgentServer {
                 Logger.Instance.Log4.Error($"AgentServer: failed to write HTTP error: {inner.Message}");
             }
         }
+    }
+
+    /// <summary>
+    /// Validates an inbound MCP/HTTP request against the localhost front-door policy (#143):
+    /// POST only, path exactly <c>/mcp</c>, a loopback <c>Host</c> (defeats DNS rebinding), an
+    /// absent-or-loopback <c>Origin</c> (defeats browser CSRF), and — when a token is configured —
+    /// a matching <c>Authorization: Bearer</c> header. Pure so it can be unit tested without a socket.
+    /// </summary>
+    internal static HttpGateDecision GateHttpRequest(
+            string httpMethod,
+            string? absolutePath,
+            string? hostHeader,
+            string? originHeader,
+            string? authorizationHeader,
+            int port,
+            string? requiredToken) {
+        if (!string.Equals(httpMethod, "POST", StringComparison.OrdinalIgnoreCase)) {
+            return HttpGateDecision.RejectMethod;
+        }
+        if (!string.Equals(absolutePath, "/mcp", StringComparison.Ordinal)) {
+            return HttpGateDecision.RejectPath;
+        }
+        if (!IsLoopbackAuthority(hostHeader, port)) {
+            return HttpGateDecision.RejectHost;
+        }
+        if (!IsAllowedOrigin(originHeader)) {
+            return HttpGateDecision.RejectOrigin;
+        }
+        if (!string.IsNullOrEmpty(requiredToken) && !BearerTokenMatches(authorizationHeader, requiredToken)) {
+            return HttpGateDecision.RejectAuth;
+        }
+        return HttpGateDecision.Allow;
+    }
+
+    /// <summary>True if <paramref name="hostHeader"/> names a loopback host and (if a port is present) that port.</summary>
+    private static bool IsLoopbackAuthority(string? hostHeader, int port) {
+        if (string.IsNullOrWhiteSpace(hostHeader)) {
+            return false;
+        }
+        string host = hostHeader.Trim();
+        string hostName;
+        string? portPart = null;
+        if (host.StartsWith('[')) {
+            // IPv6 literal: [::1] or [::1]:port
+            int end = host.IndexOf(']');
+            if (end < 0) {
+                return false;
+            }
+            hostName = host.Substring(1, end - 1);
+            if (end + 1 < host.Length && host[end + 1] == ':') {
+                portPart = host[(end + 2)..];
+            }
+        }
+        else {
+            int colon = host.IndexOf(':');
+            if (colon >= 0) {
+                hostName = host[..colon];
+                portPart = host[(colon + 1)..];
+            }
+            else {
+                hostName = host;
+            }
+        }
+        if (portPart is not null && (!int.TryParse(portPart, out int p) || p != port)) {
+            return false;
+        }
+        return IsLoopbackName(hostName);
+    }
+
+    /// <summary>True if the Origin header is absent (typical non-browser MCP client) or names a loopback host.</summary>
+    private static bool IsAllowedOrigin(string? originHeader) {
+        if (string.IsNullOrEmpty(originHeader)) {
+            return true;
+        }
+        // A literal "null" origin (sandboxed iframe / file://) or any un-parseable value is not loopback.
+        return Uri.TryCreate(originHeader, UriKind.Absolute, out Uri? uri) && IsLoopbackName(uri.Host);
+    }
+
+    private static bool IsLoopbackName(string hostName) =>
+        string.Equals(hostName, "localhost", StringComparison.OrdinalIgnoreCase)
+        || (IPAddress.TryParse(hostName, out IPAddress? ip) && IPAddress.IsLoopback(ip));
+
+    /// <summary>Constant-time check of an <c>Authorization: Bearer &lt;token&gt;</c> header against the expected token.</summary>
+    private static bool BearerTokenMatches(string? authorizationHeader, string expectedToken) {
+        if (string.IsNullOrEmpty(authorizationHeader)) {
+            return false;
+        }
+        const string scheme = "Bearer ";
+        if (!authorizationHeader.StartsWith(scheme, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        string provided = authorizationHeader[scheme.Length..].Trim();
+        byte[] a = Encoding.UTF8.GetBytes(provided);
+        byte[] b = Encoding.UTF8.GetBytes(expectedToken);
+        return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(a, b);
+    }
+
+    private static void RejectHttp(HttpListenerContext context, HttpGateDecision decision, HttpListenerRequest request) {
+        (int status, string message) = decision switch {
+            HttpGateDecision.RejectMethod => (405, "Only POST /mcp is supported"),
+            HttpGateDecision.RejectPath => (404, "Only POST /mcp is supported"),
+            HttpGateDecision.RejectHost => (403, "Forbidden: Host must be a loopback authority"),
+            HttpGateDecision.RejectOrigin => (403, "Forbidden: cross-origin requests are not allowed"),
+            HttpGateDecision.RejectAuth => (401, "Unauthorized: a valid bearer token is required"),
+            _ => (403, "Forbidden"),
+        };
+        // Audit rejected drive-by/rebinding attempts so an operator can see them.
+        Logger.Instance.Log4.Warn(
+            $"AGENT-AUDIT: rejected HTTP request ({decision}) method={request.HttpMethod} " +
+            $"path={request.Url?.AbsolutePath} host={request.UserHostName} origin={request.Headers["Origin"]} " +
+            $"remote={request.RemoteEndPoint}");
+        WriteHttp(context, status, new JsonObject { ["error"] = message });
     }
 
     private static void WriteHttp(HttpListenerContext context, int status, JsonObject payload) {

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -805,6 +805,18 @@ public static class AgentServer {
             if (_listener is not null) {
                 return;
             }
+            // SECURITY (#143): the Host/Origin gate defeats browser CSRF and DNS rebinding, but the Host
+            // header is attacker-controlled and is NOT a network control. If the operator binds off-box
+            // (a non-loopback McpBindAddress) with no bearer token, a remote client can just send
+            // `Host: 127.0.0.1` and reach the tools unauthenticated. Refuse that configuration: an exposed
+            // bind must set McpAuthToken. The safe localhost default is unaffected.
+            if (BindRequiresAuthToken(settings.McpBindAddress) && string.IsNullOrEmpty(settings.McpAuthToken)) {
+                Logger.Instance.Log4.Error(
+                    $"AgentServer: refusing to start HTTP listener — McpBindAddress '{settings.McpBindAddress}' is not " +
+                    "loopback and no McpAuthToken is set. Set McpAuthToken to expose the MCP HTTP door off-box, " +
+                    "or bind to 127.0.0.1.");
+                return;
+            }
             string prefix = $"http://{settings.McpBindAddress}:{settings.McpHttpPort}/";
             HttpListener listener = new();
             listener.Prefixes.Add(prefix);
@@ -980,6 +992,26 @@ public static class AgentServer {
         string.Equals(hostName, "localhost", StringComparison.OrdinalIgnoreCase)
         || (IPAddress.TryParse(hostName, out IPAddress? ip) && IPAddress.IsLoopback(ip));
 
+    /// <summary>
+    /// True when binding the HTTP listener to <paramref name="bindAddress"/> would expose it off-box
+    /// (anything that is not a loopback address), so a bearer token must be required (#143). An empty or
+    /// unparseable bind address is treated as loopback (the default is 127.0.0.1 and the listener would
+    /// fail to start on garbage anyway).
+    /// </summary>
+    internal static bool BindRequiresAuthToken(string? bindAddress) {
+        if (string.IsNullOrWhiteSpace(bindAddress)) {
+            return false;
+        }
+        string trimmed = bindAddress.Trim();
+        if (string.Equals(trimmed, "localhost", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        if (!IPAddress.TryParse(trimmed, out IPAddress? ip)) {
+            return false;
+        }
+        return !IPAddress.IsLoopback(ip);
+    }
+
     /// <summary>Constant-time check of an <c>Authorization: Bearer &lt;token&gt;</c> header against the expected token.</summary>
     private static bool BearerTokenMatches(string? authorizationHeader, string expectedToken) {
         if (string.IsNullOrEmpty(authorizationHeader)) {
@@ -998,7 +1030,7 @@ public static class AgentServer {
     private static void RejectHttp(HttpListenerContext context, HttpGateDecision decision, HttpListenerRequest request) {
         (int status, string message) = decision switch {
             HttpGateDecision.RejectMethod => (405, "Only POST /mcp is supported"),
-            HttpGateDecision.RejectPath => (404, "Only POST /mcp is supported"),
+            HttpGateDecision.RejectPath => (404, "Not found: only POST /mcp is supported"),
             HttpGateDecision.RejectHost => (403, "Forbidden: Host must be a loopback authority"),
             HttpGateDecision.RejectOrigin => (403, "Forbidden: cross-origin requests are not allowed"),
             HttpGateDecision.RejectAuth => (401, "Unauthorized: a valid bearer token is required"),

--- a/src/Services/AppSettings.cs
+++ b/src/Services/AppSettings.cs
@@ -150,6 +150,15 @@ public class AppSettings : ICloneable {
     [SafeForTelemetryAttribute]
     public int McpHttpPort { get; set; } = 5151;
 
+    // SECURITY (#143): defense-in-depth bearer token for the HTTP front door. The HTTP handler ALWAYS
+    // validates the Host header (must be a loopback authority — defeats DNS rebinding) and the Origin
+    // header (must be absent or loopback — defeats drive-by browser CSRF). Those two need no
+    // configuration. Setting a non-empty token additionally requires every HTTP request to carry
+    // `Authorization: Bearer <token>`, which also protects against a same-machine hostile process.
+    // Empty (default) = rely on Host/Origin only. A token is NOT PII, but keep it out of telemetry so
+    // a shared secret is never transmitted.
+    public string McpAuthToken { get; set; } = "";
+
     // --- On-screen command overlay (issue #119) ---
     // ON by default: the overlay shows each command as it executes so anyone watching can see that MCEC
     // is driving the machine (auditability), which also makes demos self-documenting. A settings file

--- a/src/Services/HttpGateDecision.cs
+++ b/src/Services/HttpGateDecision.cs
@@ -1,0 +1,24 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// Outcome of validating an inbound MCP/HTTP request against the localhost front-door policy
+/// (issue #143). Anything other than <see cref="Allow"/> means the request is refused before the
+/// body is read or any tool is dispatched.
+/// </summary>
+public enum HttpGateDecision {
+    /// <summary>Request passed all checks and may be dispatched.</summary>
+    Allow,
+    /// <summary>Not a POST — only POST is accepted.</summary>
+    RejectMethod,
+    /// <summary>Path is not exactly <c>/mcp</c>.</summary>
+    RejectPath,
+    /// <summary>Host header is missing or not a loopback authority (DNS-rebinding defense).</summary>
+    RejectHost,
+    /// <summary>Origin header is present and not loopback (cross-site request forgery defense).</summary>
+    RejectOrigin,
+    /// <summary>A bearer token is configured and the request's token is missing or wrong.</summary>
+    RejectAuth,
+}

--- a/tests/MCEControl.xUnit/Services/AgentServerHttpGateTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerHttpGateTests.cs
@@ -122,6 +122,29 @@ public class AgentServerHttpGateTests {
         Assert.Equal(HttpGateDecision.Allow, Gate(auth: null, token: ""));
     }
 
+    // ---- Non-loopback bind requires a token (#143 hardening) ----
+
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("::")]
+    [InlineData("192.168.1.10")]
+    [InlineData("10.0.0.5")]
+    public void NonLoopbackBind_RequiresToken(string bind) {
+        Assert.True(AgentServer.BindRequiresAuthToken(bind));
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("127.0.0.5")]
+    [InlineData("::1")]
+    [InlineData("localhost")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not-an-address")]
+    public void LoopbackOrUnparseableBind_DoesNotRequireToken(string? bind) {
+        Assert.False(AgentServer.BindRequiresAuthToken(bind));
+    }
+
     [Fact]
     public void MethodCheckedBeforeEverythingElse() {
         // A GET from a malicious origin is rejected as a bad method (order shouldn't leak that host/origin

--- a/tests/MCEControl.xUnit/Services/AgentServerHttpGateTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerHttpGateTests.cs
@@ -1,0 +1,132 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Security regression tests for issue #143: the MCP/HTTP front door must validate Host and Origin
+/// (and, when configured, a bearer token) so a browser on a malicious page cannot drive the agent
+/// tools (CSRF), and a rebinding attacker cannot read responses (DNS rebinding). The gate is a pure
+/// function of the request's method/path/headers so it can be exercised without a live socket.
+/// </summary>
+public class AgentServerHttpGateTests {
+    private const int Port = 5151;
+
+    private static HttpGateDecision Gate(
+            string method = "POST",
+            string? path = "/mcp",
+            string? host = "127.0.0.1:5151",
+            string? origin = null,
+            string? auth = null,
+            string? token = null)
+        => AgentServer.GateHttpRequest(method, path, host, origin, auth, Port, token);
+
+    [Fact]
+    public void LoopbackPost_NoOrigin_NoToken_Allowed() {
+        Assert.Equal(HttpGateDecision.Allow, Gate());
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("PUT")]
+    [InlineData("OPTIONS")]
+    public void NonPostMethod_Rejected(string method) {
+        Assert.Equal(HttpGateDecision.RejectMethod, Gate(method: method));
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/mcp/extra")]
+    [InlineData("/admin")]
+    public void NonMcpPath_Rejected(string path) {
+        Assert.Equal(HttpGateDecision.RejectPath, Gate(path: path));
+    }
+
+    // ---- DNS rebinding: the Host header must be a loopback authority ----
+
+    [Theory]
+    [InlineData("127.0.0.1:5151")]
+    [InlineData("localhost:5151")]
+    [InlineData("[::1]:5151")]
+    [InlineData("127.0.0.1")]   // no port
+    [InlineData("localhost")]
+    public void LoopbackHost_Allowed(string host) {
+        Assert.Equal(HttpGateDecision.Allow, Gate(host: host));
+    }
+
+    [Theory]
+    [InlineData("evil.com:5151")]
+    [InlineData("evil.com")]
+    [InlineData("attacker.example:5151")]
+    [InlineData("10.0.0.5:5151")]
+    [InlineData("0.0.0.0:5151")]
+    [InlineData(null)]           // missing Host
+    [InlineData("")]
+    public void NonLoopbackOrMissingHost_Rejected(string? host) {
+        Assert.Equal(HttpGateDecision.RejectHost, Gate(host: host));
+    }
+
+    [Fact]
+    public void LoopbackHost_WrongPort_Rejected() {
+        Assert.Equal(HttpGateDecision.RejectHost, Gate(host: "127.0.0.1:9999"));
+    }
+
+    // ---- CSRF: a non-loopback Origin must be rejected ----
+
+    [Theory]
+    [InlineData("http://evil.com")]
+    [InlineData("https://attacker.example")]
+    [InlineData("http://evil.com:8080")]
+    [InlineData("null")]         // opaque origin (sandboxed iframe / file://)
+    [InlineData("garbage")]
+    public void NonLoopbackOrigin_Rejected(string origin) {
+        Assert.Equal(HttpGateDecision.RejectOrigin, Gate(origin: origin));
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:5151")]
+    [InlineData("http://localhost:1234")]
+    [InlineData("http://[::1]:5151")]
+    public void LoopbackOrigin_Allowed(string origin) {
+        Assert.Equal(HttpGateDecision.Allow, Gate(origin: origin));
+    }
+
+    // ---- Bearer token (defense in depth; enforced only when configured) ----
+
+    [Fact]
+    public void TokenConfigured_MissingAuth_Rejected() {
+        Assert.Equal(HttpGateDecision.RejectAuth, Gate(token: "s3cr3t"));
+    }
+
+    [Fact]
+    public void TokenConfigured_WrongToken_Rejected() {
+        Assert.Equal(HttpGateDecision.RejectAuth, Gate(auth: "Bearer nope", token: "s3cr3t"));
+    }
+
+    [Fact]
+    public void TokenConfigured_CorrectBearer_Allowed() {
+        Assert.Equal(HttpGateDecision.Allow, Gate(auth: "Bearer s3cr3t", token: "s3cr3t"));
+    }
+
+    [Fact]
+    public void TokenConfigured_BearerCaseInsensitiveScheme_Allowed() {
+        Assert.Equal(HttpGateDecision.Allow, Gate(auth: "bearer s3cr3t", token: "s3cr3t"));
+    }
+
+    [Fact]
+    public void EmptyToken_NoAuthRequired() {
+        // Default (no token configured) relies on Host/Origin only; a request with no Authorization passes.
+        Assert.Equal(HttpGateDecision.Allow, Gate(auth: null, token: ""));
+    }
+
+    [Fact]
+    public void MethodCheckedBeforeEverythingElse() {
+        // A GET from a malicious origin is rejected as a bad method (order shouldn't leak that host/origin
+        // were even inspected); the important property is that a non-Allow decision blocks Dispatch.
+        Assert.NotEqual(HttpGateDecision.Allow,
+            Gate(method: "GET", host: "evil.com", origin: "http://evil.com"));
+    }
+}


### PR DESCRIPTION
Closes #143

## Problem (P1 — drive-by CSRF & DNS rebinding)

The MCP/HTTP front door (`AgentServer.HandleHttp`, `POST /mcp`) validated **only the HTTP method** — no `Origin`, `Host`, path, `Content-Type`, or auth. When the operator enables the HTTP floor (`McpServerEnabled=true` — the documented way to drive MCEC's flagship 3.0 agent over HTTP):

- **CSRF (works even with the safe 127.0.0.1 default):** a malicious page issues a CORS *simple request* (`Content-Type: text/plain`, no preflight). The browser sends it, the server parses the body regardless of `Content-Type`, and the tool's **side effect runs** — `send_command` actuation, `click`/`drag`/`invoke`, or `capture`/`record` writing to an attacker-chosen path. `send_command` wasn't even behind `AgentCommandsEnabled`.
- **DNS rebinding:** the attacker domain rebinds to `127.0.0.1`; because the `Host` header (`evil.com`) was never validated, the server answers and the browser can now **read** responses → full drive-by screen capture and UI control.

## Fix — validate before reading the body or dispatching

`GateHttpRequest(...)` (pure, unit-tested) runs first in `HandleHttp`; a non-`Allow` decision is audited and returned without ever calling `Dispatch`:

1. **Method + path** — only `POST /mcp` (else `405`/`404`), so nothing but the JSON-RPC endpoint is served.
2. **`Host`** — must be a loopback authority (`127.0.0.1` / `localhost` / `[::1]`, and the configured `McpHttpPort` if a port is present). Rejects `Host: evil.com` → **defeats DNS rebinding**.
3. **`Origin`** — must be absent (normal non-browser MCP client) or loopback; a cross-site or opaque `null` origin is rejected → **defeats browser CSRF**.
4. **`Authorization` (optional, defense in depth)** — new `AppSettings.McpAuthToken`; when set, requires `Authorization: Bearer <token>` (constant-time compared), protecting against a same-machine hostile process. Empty (default) relies on Host/Origin.

Rejections are `AGENT-AUDIT:` logged (decision, method, path, host, origin, remote endpoint).

## Why this doesn't break existing clients

Local MCP clients (Claude Desktop over stdio, or an HTTP client posting to `127.0.0.1:5151/mcp`) send a loopback `Host` automatically and no browser `Origin`, so they pass unchanged. No test or the AGENTS.md dogfood drives the HTTP handler (they use `Dispatch`/stdio). The token is opt-in.

## Tests (written first, red → green)

`tests/MCEControl.xUnit/Services/AgentServerHttpGateTests.cs` — **34 cases**: loopback allow; non-loopback/missing/empty Host reject; wrong-port reject; cross-site & opaque/garbage Origin reject; loopback Origin allow; bearer-token missing/wrong/correct/case-insensitive scheme; empty-token no-auth.

Full suite: **369 passed, 22 skipped, 0 failed** locally. Docs updated (`docs/agent-server.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)