### PR TITLE
fix(telemetry): scrub username-bearing paths from exception telemetry (#156)

### DIFF
--- a/src/Services/TelemetryScrubber.cs
+++ b/src/Services/TelemetryScrubber.cs
@@ -20,12 +20,24 @@ namespace MCEControl;
 /// <c>%USERPROFILE%</c> and the bare username, where it appears as a path segment, with
 /// <c>%USERNAME%</c> — preserving the rest of the message, exception types, and method names.
 /// </summary>
+/// <remarks>
+/// Accepted limitations (by design, to avoid over-redacting diagnostics): the username embedded
+/// inside a longer hyphenated/munged segment (e.g. worktree/cache artifacts like
+/// <c>C--Users-Tig-...</c>), DOS 8.3 short names for long usernames (e.g.
+/// <c>C:\Users\LONGUS~1</c>), and prose mentions outside a path context (e.g.
+/// <c>USERNAME=tig</c>) are not redacted.
+/// </remarks>
 public static class TelemetryScrubber {
     private const string UserProfileToken = "%USERPROFILE%";
     private const string UserNameToken = "%USERNAME%";
 
-    // Cap the inner-exception chain so a pathological exception graph can't bloat the payload.
+    // Cap on the number of exception details shipped. When a chain exceeds this, the outermost
+    // details plus the deepest one (the root cause) are kept — see CreateScrubbedExceptionTelemetry.
     private const int MaxExceptionChainLength = 10;
+
+    // Hard safety bound when walking a pathological exception graph (e.g. huge AggregateException
+    // fan-out) so flattening always terminates quickly.
+    private const int MaxFlattenedChainLength = 128;
 
     /// <summary>
     /// Scrubs user-identifying paths for the current environment
@@ -78,8 +90,40 @@ public static class TelemetryScrubber {
     public static ExceptionTelemetry CreateScrubbedExceptionTelemetry(Exception ex) {
         ArgumentNullException.ThrowIfNull(ex);
 
-        var details = new List<ExceptionDetailsInfo>();
-        AddExceptionDetails(details, ex, outerId: 0);
+        var chain = new List<(Exception Exception, int ParentIndex)>();
+        FlattenExceptionChain(chain, ex, parentIndex: -1);
+
+        // When the chain exceeds the cap, keep the outermost details plus the deepest one: the
+        // leaf is the root cause and must survive truncation (PR #180 review). The kept leaf is
+        // marked so it is obvious that intermediate wrappers were dropped.
+        List<int> keptIndexes;
+        int omitted = 0;
+        if (chain.Count <= MaxExceptionChainLength) {
+            keptIndexes = [.. Enumerable.Range(0, chain.Count)];
+        }
+        else {
+            keptIndexes = [.. Enumerable.Range(0, MaxExceptionChainLength - 1), chain.Count - 1];
+            omitted = chain.Count - MaxExceptionChainLength;
+        }
+
+        var idByIndex = new Dictionary<int, int>();
+        for (int i = 0; i < keptIndexes.Count; i++) {
+            idByIndex[keptIndexes[i]] = i + 1;
+        }
+
+        var details = new List<ExceptionDetailsInfo>(keptIndexes.Count);
+        foreach (int index in keptIndexes) {
+            (Exception e, int parentIndex) = chain[index];
+            int id = idByIndex[index];
+            // If this detail's parent was truncated away, chain it to the previous kept detail
+            // so it stays attached to the tree.
+            int outerId = parentIndex < 0 ? 0
+                : idByIndex.TryGetValue(parentIndex, out int parentId) ? parentId : id - 1;
+            string? messagePrefix = omitted > 0 && index == chain.Count - 1
+                ? $"[{omitted} inner exception(s) omitted] "
+                : null;
+            details.Add(ToDetailsInfo(e, id, outerId, messagePrefix));
+        }
 
         var frames = GetScrubbedStackFrames(ex);
         string topMethod = frames.Count > 0 ? frames[0].Method : "<unknown>";
@@ -113,25 +157,30 @@ public static class TelemetryScrubber {
         return result;
     }
 
-    private static void AddExceptionDetails(List<ExceptionDetailsInfo> details, Exception ex, int outerId) {
-        if (details.Count >= MaxExceptionChainLength) {
+    /// <summary>
+    /// Depth-first flattening of the exception tree (following <see cref="AggregateException"/>
+    /// inners and <see cref="Exception.InnerException"/>) into visitation order with parent links.
+    /// </summary>
+    private static void FlattenExceptionChain(List<(Exception Exception, int ParentIndex)> chain,
+        Exception ex, int parentIndex) {
+        if (chain.Count >= MaxFlattenedChainLength) {
             return;
         }
 
-        int id = details.Count + 1;
-        details.Add(ToDetailsInfo(ex, id, outerId));
+        int index = chain.Count;
+        chain.Add((ex, parentIndex));
 
         if (ex is AggregateException aggregate) {
             foreach (Exception inner in aggregate.InnerExceptions) {
-                AddExceptionDetails(details, inner, id);
+                FlattenExceptionChain(chain, inner, index);
             }
         }
         else if (ex.InnerException != null) {
-            AddExceptionDetails(details, ex.InnerException, id);
+            FlattenExceptionChain(chain, ex.InnerException, index);
         }
     }
 
-    private static ExceptionDetailsInfo ToDetailsInfo(Exception ex, int id, int outerId) {
+    private static ExceptionDetailsInfo ToDetailsInfo(Exception ex, int id, int outerId, string? messagePrefix = null) {
         var frames = GetScrubbedStackFrames(ex);
         var parsedStack = new List<AiStackFrame>(frames.Count);
         for (int level = 0; level < frames.Count; level++) {
@@ -142,6 +191,10 @@ public static class TelemetryScrubber {
         string message = ScrubUserPaths(ex.Message);
         if (string.IsNullOrWhiteSpace(message)) {
             message = "n/a";
+        }
+
+        if (messagePrefix != null) {
+            message = messagePrefix + message;
         }
 
         return new ExceptionDetailsInfo(id, outerId, ex.GetType().FullName ?? ex.GetType().Name, message,

--- a/src/Services/TelemetryScrubber.cs
+++ b/src/Services/TelemetryScrubber.cs
@@ -1,0 +1,150 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.ApplicationInsights.DataContracts;
+using AiStackFrame = Microsoft.ApplicationInsights.DataContracts.StackFrame;
+
+namespace MCEControl;
+
+/// <summary>
+/// Redacts user-identifying filesystem paths from exception telemetry before it is shipped to
+/// Application Insights (#156). Telemetry pseudonymizes the user (User.Id is a hash of
+/// username/machine), but exception messages and stack traces routinely contain paths under
+/// <c>C:\Users\&lt;username&gt;\AppData\...</c>, which would leak the cleartext Windows username
+/// and defeat that anonymization. The scrubber replaces the user-profile directory with
+/// <c>%USERPROFILE%</c> and the bare username, where it appears as a path segment, with
+/// <c>%USERNAME%</c> — preserving the rest of the message, exception types, and method names.
+/// </summary>
+public static class TelemetryScrubber {
+    private const string UserProfileToken = "%USERPROFILE%";
+    private const string UserNameToken = "%USERNAME%";
+
+    // Cap the inner-exception chain so a pathological exception graph can't bloat the payload.
+    private const int MaxExceptionChainLength = 10;
+
+    /// <summary>
+    /// Scrubs user-identifying paths for the current environment
+    /// (<see cref="Environment.SpecialFolder.UserProfile"/> and <see cref="Environment.UserName"/>).
+    /// </summary>
+    public static string ScrubUserPaths(string? text) =>
+        ScrubUserPaths(text, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), Environment.UserName);
+
+    /// <summary>
+    /// Pure overload for testability: replaces <paramref name="userProfilePath"/> with
+    /// <c>%USERPROFILE%</c> and <paramref name="userName"/>, where it appears as a path segment,
+    /// with <c>%USERNAME%</c>. Matching is case-insensitive (Windows paths) and accepts both
+    /// <c>\</c> and <c>/</c> separators. Returns <see cref="string.Empty"/> for null/empty input.
+    /// </summary>
+    public static string ScrubUserPaths(string? text, string? userProfilePath, string? userName) {
+        if (string.IsNullOrEmpty(text)) {
+            return string.Empty;
+        }
+
+        string result = text;
+
+        if (!string.IsNullOrEmpty(userProfilePath)) {
+            // Match the profile dir with either separator style. Require a segment boundary after
+            // it so C:\Users\tig does not match inside C:\Users\tigger.
+            string profilePattern = Regex.Escape(userProfilePath).Replace(@"\\", @"[\\/]") + @"(?![\w\-])";
+            result = Regex.Replace(result, profilePattern, UserProfileToken,
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
+
+        if (!string.IsNullOrEmpty(userName)) {
+            // The bare username as a path segment: either preceded by a separator and ending at a
+            // segment boundary, or starting a relative path that continues with a separator.
+            // Word-ish characters ([\w-]) on the boundary mean it is part of a longer name
+            // (e.g. "tigger") and must not be redacted.
+            string escaped = Regex.Escape(userName);
+            string namePattern = $@"(?<=[\\/]){escaped}(?=$|[^\w\-])|(?<=^|[^\w\-]){escaped}(?=[\\/])";
+            result = Regex.Replace(result, namePattern, UserNameToken,
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Builds an <see cref="ExceptionTelemetry"/> for <paramref name="ex"/> (including its inner
+    /// exceptions) whose messages, stack strings, and stack-frame file names have been scrubbed
+    /// with <see cref="ScrubUserPaths(string?)"/>. Exception types, method names, and line numbers
+    /// are preserved so the telemetry stays diagnosable.
+    /// </summary>
+    public static ExceptionTelemetry CreateScrubbedExceptionTelemetry(Exception ex) {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        var details = new List<ExceptionDetailsInfo>();
+        AddExceptionDetails(details, ex, outerId: 0);
+
+        var frames = GetScrubbedStackFrames(ex);
+        string topMethod = frames.Count > 0 ? frames[0].Method : "<unknown>";
+        string problemId = $"{ex.GetType().FullName} at {topMethod}";
+
+        return new ExceptionTelemetry(details, severityLevel: null, problemId,
+            new Dictionary<string, string>(), new Dictionary<string, double>());
+    }
+
+    /// <summary>
+    /// Extracts the stack frames of <paramref name="ex"/> with any source file names scrubbed.
+    /// Internal so tests can verify frames survive scrubbing (method names and line numbers are
+    /// kept; only file paths are redacted).
+    /// </summary>
+    internal static IReadOnlyList<(string Method, string Assembly, string? FileName, int Line)> GetScrubbedStackFrames(Exception ex) {
+        var result = new List<(string Method, string Assembly, string? FileName, int Line)>();
+        foreach (System.Diagnostics.StackFrame frame in new StackTrace(ex, fNeedFileInfo: true).GetFrames()) {
+            MethodBase? method = frame.GetMethod();
+            string methodName = method == null
+                ? "<unknown>"
+                : method.DeclaringType == null ? method.Name : $"{method.DeclaringType.FullName}.{method.Name}";
+            string assembly = method?.Module.Assembly.FullName ?? string.Empty;
+            string? fileName = frame.GetFileName();
+            if (fileName != null) {
+                fileName = ScrubUserPaths(fileName);
+            }
+
+            result.Add((methodName, assembly, fileName, frame.GetFileLineNumber()));
+        }
+
+        return result;
+    }
+
+    private static void AddExceptionDetails(List<ExceptionDetailsInfo> details, Exception ex, int outerId) {
+        if (details.Count >= MaxExceptionChainLength) {
+            return;
+        }
+
+        int id = details.Count + 1;
+        details.Add(ToDetailsInfo(ex, id, outerId));
+
+        if (ex is AggregateException aggregate) {
+            foreach (Exception inner in aggregate.InnerExceptions) {
+                AddExceptionDetails(details, inner, id);
+            }
+        }
+        else if (ex.InnerException != null) {
+            AddExceptionDetails(details, ex.InnerException, id);
+        }
+    }
+
+    private static ExceptionDetailsInfo ToDetailsInfo(Exception ex, int id, int outerId) {
+        var frames = GetScrubbedStackFrames(ex);
+        var parsedStack = new List<AiStackFrame>(frames.Count);
+        for (int level = 0; level < frames.Count; level++) {
+            (string method, string assembly, string? fileName, int line) = frames[level];
+            parsedStack.Add(new AiStackFrame(assembly, fileName, level, line, method));
+        }
+
+        string message = ScrubUserPaths(ex.Message);
+        if (string.IsNullOrWhiteSpace(message)) {
+            message = "n/a";
+        }
+
+        return new ExceptionDetailsInfo(id, outerId, ex.GetType().FullName ?? ex.GetType().Name, message,
+            hasFullStack: true, ScrubUserPaths(ex.StackTrace), parsedStack);
+    }
+}

--- a/src/Services/TelemetryService.cs
+++ b/src/Services/TelemetryService.cs
@@ -29,7 +29,8 @@ public partial class TelemetryService {
     public bool TelemetryEnabled { get; set; }
     public Stopwatch? RunTime { get; set; }
 
-    public TelemetryClient? TelemetryClient { get; private set; }
+    // internal setter so tests can substitute a client backed by a stub channel (#156).
+    public TelemetryClient? TelemetryClient { get; internal set; }
 
     public void Start(string appName, IDictionary<string, string>? startProperties = null) {
         RunTime = Stopwatch.StartNew();
@@ -99,10 +100,6 @@ public partial class TelemetryService {
         Task.Delay(1000).Wait();
     }
 
-    public void SetUser(string user) {
-        TelemetryClient!.Context.User.AuthenticatedUserId = user;
-    }
-
     public void TrackEvent(string key, IDictionary<string, string>? properties = null,
         IDictionary<string, double>? metrics = null) {
         if (TelemetryEnabled && TelemetryClient != null) {
@@ -116,7 +113,13 @@ public partial class TelemetryService {
         }
 
         if (TelemetryClient != null && ex != null && TelemetryEnabled) {
-            ExceptionTelemetry telex = new ExceptionTelemetry(ex);
+            // TELEMETRY:
+            // what: exception type, scrubbed message, and scrubbed stack
+            // why: to diagnose crashes and failures in the field
+            // how is PII protected: user-profile paths and username path segments in the
+            // message/stack are redacted (#156) so the cleartext Windows username never leaves
+            // the machine; User.Id stays pseudonymized.
+            ExceptionTelemetry telex = TelemetryScrubber.CreateScrubbedExceptionTelemetry(ex);
             TelemetryClient.TrackException(telex);
             Flush();
         }

--- a/tests/MCEControl.xUnit/Services/StubTelemetryChannel.cs
+++ b/tests/MCEControl.xUnit/Services/StubTelemetryChannel.cs
@@ -1,0 +1,32 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// In-memory Application Insights channel for tests. Captures telemetry items locally so tests
+/// can assert on the outgoing payload; nothing ever leaves the process.
+/// </summary>
+internal sealed class StubTelemetryChannel : ITelemetryChannel {
+    private readonly ConcurrentQueue<ITelemetry> _sent = new();
+
+    public IReadOnlyList<ITelemetry> SentItems => _sent.ToList();
+
+    public bool? DeveloperMode { get; set; }
+    public string? EndpointAddress { get; set; }
+
+    public void Send(ITelemetry item) => _sent.Enqueue(item);
+
+    public void Flush() {
+        // Nothing to flush; items are captured synchronously in Send.
+    }
+
+    public void Dispose() {
+        // Nothing to dispose.
+    }
+}

--- a/tests/MCEControl.xUnit/Services/TelemetryScrubberTests.cs
+++ b/tests/MCEControl.xUnit/Services/TelemetryScrubberTests.cs
@@ -1,0 +1,166 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.IO;
+using Microsoft.ApplicationInsights.DataContracts;
+using Xunit;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Tests for #156: exception telemetry must not leak the cleartext Windows username via
+/// user-profile paths in exception messages/stacks. The scrubber is pure/static so these
+/// tests exercise it directly with injected profile/username values (deterministic), plus
+/// a few tests against the real environment values.
+/// </summary>
+public class TelemetryScrubberTests {
+    private const string Profile = @"C:\Users\testuser";
+    private const string User = "testuser";
+
+    private static string Scrub(string text) => TelemetryScrubber.ScrubUserPaths(text, Profile, User);
+
+    private static Exception Thrown(Exception ex) {
+        try {
+            throw ex;
+        }
+        catch (Exception caught) {
+            return caught;
+        }
+    }
+
+    [Theory]
+    [InlineData(@"Could not find file 'C:\Users\testuser\AppData\Roaming\MCEControl\MCEControl.settings'.",
+                @"Could not find file '%USERPROFILE%\AppData\Roaming\MCEControl\MCEControl.settings'.")]
+    // Windows paths are case-insensitive; the scrub must be too.
+    [InlineData(@"Access to the path 'c:\users\TESTUSER\AppData\Local\Temp\x.tmp' is denied.",
+                @"Access to the path '%USERPROFILE%\AppData\Local\Temp\x.tmp' is denied.")]
+    // URI/forward-slash form of the same path.
+    [InlineData("file:///C:/Users/testuser/AppData/Roaming/MCEControl/MCEControl.commands",
+                "file:///%USERPROFILE%/AppData/Roaming/MCEControl/MCEControl.commands")]
+    public void ScrubUserPaths_RedactsUserProfileDirectory(string input, string expected) {
+        Assert.Equal(expected, Scrub(input));
+    }
+
+    [Theory]
+    // Username as a segment of a non-profile path.
+    [InlineData(@"D:\Temp\testuser\cache\a.txt", @"D:\Temp\%USERNAME%\cache\a.txt")]
+    // Terminal segment (UNC share).
+    [InlineData(@"\\server\share\testuser", @"\\server\share\%USERNAME%")]
+    // Case-insensitive.
+    [InlineData(@"D:\TESTUSER\x", @"D:\%USERNAME%\x")]
+    // Relative path starting with the username.
+    [InlineData(@"testuser\AppData\Roaming", @"%USERNAME%\AppData\Roaming")]
+    // Username as a file base name.
+    [InlineData(@"C:\logs\testuser.log", @"C:\logs\%USERNAME%.log")]
+    public void ScrubUserPaths_RedactsUserNamePathSegments(string input, string expected) {
+        Assert.Equal(expected, Scrub(input));
+    }
+
+    [Theory]
+    // A different user whose name merely starts with ours must survive intact.
+    [InlineData(@"C:\Users\testuser2\file.txt")]
+    [InlineData(@"C:\Users\testusers\file.txt")]
+    [InlineData(@"D:\Temp\testuserdata\x")]
+    // Bare word outside a path context is left alone (don't destroy prose).
+    [InlineData("testuser encountered an error")]
+    // Ordinary messages and type/method names are untouched.
+    [InlineData("Object reference not set to an instance of an object.")]
+    [InlineData(@"   at MCEControl.TelemetryService.TrackException(Exception ex)")]
+    public void ScrubUserPaths_DoesNotOverRedact(string input) {
+        Assert.Equal(input, Scrub(input));
+    }
+
+    [Fact]
+    public void ScrubUserPaths_StackTraceLine_RedactsPathButKeepsMethodName() {
+        string line = @"   at MCEControl.MainWindow.SaveSettings() in C:\Users\testuser\s\mcec\src\MainWindow.cs:line 123";
+        string scrubbed = Scrub(line);
+        Assert.Contains("MCEControl.MainWindow.SaveSettings()", scrubbed, StringComparison.Ordinal);
+        Assert.Contains(@"%USERPROFILE%\s\mcec\src\MainWindow.cs:line 123", scrubbed, StringComparison.Ordinal);
+        Assert.DoesNotContain(User, scrubbed, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ScrubUserPaths_NullOrEmpty_ReturnsEmpty() {
+        Assert.Equal(string.Empty, TelemetryScrubber.ScrubUserPaths(null, Profile, User));
+        Assert.Equal(string.Empty, TelemetryScrubber.ScrubUserPaths(string.Empty, Profile, User));
+    }
+
+    [Fact]
+    public void ScrubUserPaths_NoUserInfoAvailable_ReturnsInputUnchanged() {
+        Assert.Equal(@"C:\Users\someone\x", TelemetryScrubber.ScrubUserPaths(@"C:\Users\someone\x", null, null));
+    }
+
+    [Fact]
+    public void ScrubUserPaths_DefaultOverload_RedactsCurrentEnvironmentUser() {
+        string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string input = $@"Access to the path '{profile}\AppData\Roaming\MCEControl\MCEControl.log' is denied.";
+
+        string scrubbed = TelemetryScrubber.ScrubUserPaths(input);
+
+        Assert.DoesNotContain(profile, scrubbed, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("%USERPROFILE%", scrubbed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateScrubbedExceptionTelemetry_RedactsMessage_PreservesExceptionType() {
+        string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Exception ex = Thrown(new FileNotFoundException(
+            $@"Could not find file '{profile}\AppData\Roaming\MCEControl\MCEControl.commands'."));
+
+        ExceptionTelemetry telex = TelemetryScrubber.CreateScrubbedExceptionTelemetry(ex);
+
+        ExceptionDetailsInfo details = Assert.Single(telex.ExceptionDetailsInfoList);
+        Assert.Equal(typeof(FileNotFoundException).FullName, details.TypeName);
+        Assert.DoesNotContain(profile, details.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("%USERPROFILE%", details.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateScrubbedExceptionTelemetry_RedactsInnerExceptionMessages() {
+        string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Exception inner = Thrown(new UnauthorizedAccessException(
+            $@"Access to the path '{profile}\AppData\Roaming\MCEControl\MCEControl.settings' is denied."));
+        Exception outer = Thrown(new InvalidOperationException(
+            $@"Failed to load settings from {profile}\AppData\Roaming\MCEControl", inner));
+
+        ExceptionTelemetry telex = TelemetryScrubber.CreateScrubbedExceptionTelemetry(outer);
+
+        Assert.Equal(2, telex.ExceptionDetailsInfoList.Count);
+        Assert.All(telex.ExceptionDetailsInfoList, d => {
+            Assert.DoesNotContain(profile, d.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("%USERPROFILE%", d.Message, StringComparison.Ordinal);
+        });
+        Assert.Equal(typeof(InvalidOperationException).FullName, telex.ExceptionDetailsInfoList[0].TypeName);
+        Assert.Equal(typeof(UnauthorizedAccessException).FullName, telex.ExceptionDetailsInfoList[1].TypeName);
+    }
+
+    [Fact]
+    public void CreateScrubbedExceptionTelemetry_AggregateException_IncludesAllInners() {
+        Exception ex = Thrown(new AggregateException(
+            Thrown(new InvalidOperationException("first")),
+            Thrown(new IOException("second"))));
+
+        ExceptionTelemetry telex = TelemetryScrubber.CreateScrubbedExceptionTelemetry(ex);
+
+        Assert.Equal(3, telex.ExceptionDetailsInfoList.Count);
+    }
+
+    [Fact]
+    public void GetScrubbedStackFrames_KeepsMethodNames_RedactsFileNames() {
+        string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Exception ex = Thrown(new InvalidOperationException("boom"));
+
+        var frames = TelemetryScrubber.GetScrubbedStackFrames(ex);
+
+        Assert.NotEmpty(frames);
+        // The throwing helper must still be identifiable by method name (don't destroy frames).
+        Assert.Contains(frames, f => f.Method.Contains(nameof(Thrown), StringComparison.Ordinal));
+        // Any source file names (present when PDBs are available) must not leak the profile path.
+        Assert.All(frames, f => {
+            if (f.FileName != null) {
+                Assert.DoesNotContain(profile, f.FileName, StringComparison.OrdinalIgnoreCase);
+            }
+        });
+    }
+}

--- a/tests/MCEControl.xUnit/Services/TelemetryScrubberTests.cs
+++ b/tests/MCEControl.xUnit/Services/TelemetryScrubberTests.cs
@@ -147,6 +147,29 @@ public class TelemetryScrubberTests {
     }
 
     [Fact]
+    public void CreateScrubbedExceptionTelemetry_LongChain_TruncationPreservesRootCause() {
+        // 15-deep chain: 14 wrappers around a distinctive root cause. Truncation to the cap (10)
+        // must keep the deepest exception (the root cause), not silently drop it, and must say
+        // that something was omitted.
+        Exception ex = Thrown(new FileNotFoundException("ROOT-CAUSE: the actual failure"));
+        for (int i = 0; i < 14; i++) {
+            ex = Thrown(new InvalidOperationException($"wrapper {i}", ex));
+        }
+
+        ExceptionTelemetry telex = TelemetryScrubber.CreateScrubbedExceptionTelemetry(ex);
+
+        Assert.Equal(10, telex.ExceptionDetailsInfoList.Count);
+        // Outermost detail first, unchanged.
+        Assert.Equal(typeof(InvalidOperationException).FullName, telex.ExceptionDetailsInfoList[0].TypeName);
+        Assert.Contains("wrapper 13", telex.ExceptionDetailsInfoList[0].Message, StringComparison.Ordinal);
+        // The leaf (root cause) survives, marked as a truncated chain.
+        ExceptionDetailsInfo leaf = telex.ExceptionDetailsInfoList[^1];
+        Assert.Equal(typeof(FileNotFoundException).FullName, leaf.TypeName);
+        Assert.Contains("ROOT-CAUSE: the actual failure", leaf.Message, StringComparison.Ordinal);
+        Assert.Contains("omitted", leaf.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void GetScrubbedStackFrames_KeepsMethodNames_RedactsFileNames() {
         string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         Exception ex = Thrown(new InvalidOperationException("boom"));

--- a/tests/MCEControl.xUnit/Services/TelemetryServiceTrackExceptionTests.cs
+++ b/tests/MCEControl.xUnit/Services/TelemetryServiceTrackExceptionTests.cs
@@ -2,8 +2,12 @@
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -30,6 +34,44 @@ public class TelemetryServiceTrackExceptionTests {
         }
     }
 
+    /// <summary>
+    /// Asserts <paramref name="text"/> contains neither the user-profile path nor the username
+    /// as a path segment (the two forms TelemetryScrubber must redact).
+    /// </summary>
+    private static void AssertScrubbed(string? text, string profile, string userName) {
+        if (string.IsNullOrEmpty(text)) {
+            return;
+        }
+
+        Assert.DoesNotContain(profile, text, StringComparison.OrdinalIgnoreCase);
+        if (!string.IsNullOrEmpty(userName)) {
+            Assert.DoesNotMatch($@"(?i)[\\/]{Regex.Escape(userName)}(?=$|[^\w\-])", text);
+            Assert.DoesNotMatch($@"(?i)(?<=^|[^\w\-]){Regex.Escape(userName)}(?=[\\/])", text);
+        }
+    }
+
+    /// <summary>
+    /// Reads the wire-level stack data of an <see cref="ExceptionDetailsInfo"/> (its internal
+    /// ExceptionDetails: the <c>stack</c> string and each parsedStack frame's <c>fileName</c>),
+    /// which the public API does not expose, so the test can verify what actually serializes.
+    /// </summary>
+    private static (string? Stack, List<string?> FileNames) GetInternalStackData(ExceptionDetailsInfo details) {
+        PropertyInfo detailsProp = typeof(ExceptionDetailsInfo).GetProperty(
+            "ExceptionDetails", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        object internalDetails = detailsProp.GetValue(details)!;
+        Type detailsType = internalDetails.GetType();
+
+        string? stack = (string?)detailsType.GetProperty("stack")!.GetValue(internalDetails);
+
+        var fileNames = new List<string?>();
+        var parsedStack = (IEnumerable)detailsType.GetProperty("parsedStack")!.GetValue(internalDetails)!;
+        foreach (object? frame in parsedStack) {
+            fileNames.Add((string?)frame!.GetType().GetProperty("fileName")!.GetValue(frame));
+        }
+
+        return (stack, fileNames);
+    }
+
     [Fact]
     public void TrackException_WhenEnabled_ScrubsUserPathsFromOutgoingPayload() {
         TelemetryService svc = TelemetryService.Instance;
@@ -47,16 +89,39 @@ public class TelemetryServiceTrackExceptionTests {
             svc.TelemetryEnabled = true;
 
             string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string userName = Environment.UserName;
+            Exception inner = Thrown(new UnauthorizedAccessException(
+                $@"Access to the path '{profile}\AppData\Local\Temp\mcec.tmp' is denied."));
             Exception ex = Thrown(new IOException(
-                $@"The process cannot access the file '{profile}\AppData\Roaming\MCEControl\MCEControl.settings'."));
+                $@"The process cannot access the file '{profile}\AppData\Roaming\MCEControl\MCEControl.settings'.",
+                inner));
 
             svc.TrackException(ex);
 
             ExceptionTelemetry sent = Assert.Single(channel.SentItems.OfType<ExceptionTelemetry>());
-            ExceptionDetailsInfo details = Assert.Single(sent.ExceptionDetailsInfoList);
-            Assert.Equal(typeof(IOException).FullName, details.TypeName);
-            Assert.DoesNotContain(profile, details.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("%USERPROFILE%", details.Message, StringComparison.Ordinal);
+            // The sanitized payload must not carry the original exception object.
+            Assert.NotSame(ex, sent.Exception);
+
+            Assert.Equal(2, sent.ExceptionDetailsInfoList.Count);
+            Assert.Equal(typeof(IOException).FullName, sent.ExceptionDetailsInfoList[0].TypeName);
+            Assert.Contains("%USERPROFILE%", sent.ExceptionDetailsInfoList[0].Message, StringComparison.Ordinal);
+
+            // Every detail of the outgoing item — message, wire stack string, and every
+            // parsedStack frame fileName — must be free of the profile path and username.
+            bool sawStackData = false;
+            foreach (ExceptionDetailsInfo details in sent.ExceptionDetailsInfoList) {
+                AssertScrubbed(details.Message, profile, userName);
+
+                (string? stack, List<string?> fileNames) = GetInternalStackData(details);
+                sawStackData |= !string.IsNullOrEmpty(stack) || fileNames.Count > 0;
+                AssertScrubbed(stack, profile, userName);
+                foreach (string? fileName in fileNames) {
+                    AssertScrubbed(fileName, profile, userName);
+                }
+            }
+
+            // Guard against vacuously passing: thrown exceptions must have produced stack data.
+            Assert.True(sawStackData, "expected the captured telemetry to include stack data");
         }
         finally {
             svc.TelemetryEnabled = originalEnabled;

--- a/tests/MCEControl.xUnit/Services/TelemetryServiceTrackExceptionTests.cs
+++ b/tests/MCEControl.xUnit/Services/TelemetryServiceTrackExceptionTests.cs
@@ -1,0 +1,92 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Xunit;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// End-to-end tests for #156: <see cref="TelemetryService.TrackException"/> must route the
+/// exception through the scrubber so the payload handed to the telemetry channel contains no
+/// user-profile paths. Uses a stub channel — no telemetry leaves the process.
+/// Joins the "AgentSerial" collection because tests in that collection initialize the
+/// TelemetryService singleton (AgentTestSupport.EnsureTelemetry); this test temporarily swaps
+/// the singleton's client and must not race with them.
+/// </summary>
+[Collection("AgentSerial")]
+public class TelemetryServiceTrackExceptionTests {
+    private static Exception Thrown(Exception ex) {
+        try {
+            throw ex;
+        }
+        catch (Exception caught) {
+            return caught;
+        }
+    }
+
+    [Fact]
+    public void TrackException_WhenEnabled_ScrubsUserPathsFromOutgoingPayload() {
+        TelemetryService svc = TelemetryService.Instance;
+        TelemetryClient? originalClient = svc.TelemetryClient;
+        bool originalEnabled = svc.TelemetryEnabled;
+
+        using StubTelemetryChannel channel = new();
+        using TelemetryConfiguration config = new() {
+            TelemetryChannel = channel,
+            ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        };
+
+        try {
+            svc.TelemetryClient = new TelemetryClient(config);
+            svc.TelemetryEnabled = true;
+
+            string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            Exception ex = Thrown(new IOException(
+                $@"The process cannot access the file '{profile}\AppData\Roaming\MCEControl\MCEControl.settings'."));
+
+            svc.TrackException(ex);
+
+            ExceptionTelemetry sent = Assert.Single(channel.SentItems.OfType<ExceptionTelemetry>());
+            ExceptionDetailsInfo details = Assert.Single(sent.ExceptionDetailsInfoList);
+            Assert.Equal(typeof(IOException).FullName, details.TypeName);
+            Assert.DoesNotContain(profile, details.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("%USERPROFILE%", details.Message, StringComparison.Ordinal);
+        }
+        finally {
+            svc.TelemetryEnabled = originalEnabled;
+            svc.TelemetryClient = originalClient;
+        }
+    }
+
+    [Fact]
+    public void TrackException_WhenDisabled_SendsNothing() {
+        TelemetryService svc = TelemetryService.Instance;
+        TelemetryClient? originalClient = svc.TelemetryClient;
+        bool originalEnabled = svc.TelemetryEnabled;
+
+        using StubTelemetryChannel channel = new();
+        using TelemetryConfiguration config = new() {
+            TelemetryChannel = channel,
+            ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        };
+
+        try {
+            svc.TelemetryClient = new TelemetryClient(config);
+            svc.TelemetryEnabled = false;
+
+            svc.TrackException(Thrown(new InvalidOperationException("boom")));
+
+            Assert.Empty(channel.SentItems);
+        }
+        finally {
+            svc.TelemetryEnabled = originalEnabled;
+            svc.TelemetryClient = originalClient;
+        }
+    }
+}


### PR DESCRIPTION
## The leak

`TelemetryService` pseudonymizes the user (`User.Id = base64(SHA256(username + "/" + machine))`), but `TrackException` shipped the raw `ExceptionTelemetry(ex)` — message + stack trace. MCEC's exception messages and stacks routinely contain paths under `C:\Users\<username>\AppData\...` (settings/log/commands IO, the global unhandled-exception handlers), so the **cleartext Windows username** went to Application Insights, defeating the anonymization design. Only affects users who opted in to telemetry (per-machine `Telemetry` registry value) — but once opted in, every tracked exception leaked.

## The fix

New `src/Services/TelemetryScrubber.cs` — a pure static scrubber, and `TrackException` now builds a fully sanitized `ExceptionTelemetry` from it:

- The user-profile directory is replaced with `%USERPROFILE%` (case-insensitive, `\` or `/` separators, segment-boundary aware so `C:\Users\tig` never matches inside `C:\Users\tigger`).
- The bare `Environment.UserName` appearing as a path segment anywhere else (e.g. `D:\Temp\tig\cache`, `\server\share\tig`, `tig.log`) is replaced with `%USERNAME%`. Plain prose mentions outside a path context are left alone.
- Scrubbing is applied to the message, the stack string, and stack-frame source file names for the **entire inner-exception chain** (including `AggregateException` inners). Exception types, method names, and line numbers are preserved — redaction over data loss.
- If a chain exceeds the 10-detail cap, the outermost 9 details **plus the deepest exception (the root cause)** are kept, with a `[N inner exception(s) omitted]` marker on the leaf.

**Before:**
```
System.IO.FileNotFoundException: Could not find file 'C:\Users\tig\AppData\Roaming\MCEControl\MCEControl.settings'.
   at MCEControl.MainWindow.LoadSettings() in C:\Users\tig\s\mcec\src\MainWindow.cs:line 123
```

**After:**
```
System.IO.FileNotFoundException: Could not find file '%USERPROFILE%\AppData\Roaming\MCEControl\MCEControl.settings'.
   at MCEControl.MainWindow.LoadSettings() in %USERPROFILE%\s\mcec\src\MainWindow.cs:line 123
```

**Accepted limitations** (documented on the class, by design to avoid over-redaction): username embedded in longer hyphenated/munged segments (e.g. `C--Users-Tig-...` artifacts), DOS 8.3 short names for long usernames, and non-path prose like `USERNAME=tig` are not redacted.

## SetUser disposition

Removed. It stored a raw `AuthenticatedUserId`, bypassing the hash, and a repo-wide grep confirmed it had **no callers** — a dead footgun waiting for someone to wire it up.

## Tests (test-first)

- `TelemetryScrubberTests` (23 tests): profile-dir redaction (case-insensitive, forward-slash/URI form), username-in-any-path-segment (mid-path, terminal/UNC, relative-path start, file base name), no over-redaction (`testuser2`, `testusers`, bare prose, method/type names, ordinary messages), null/empty handling, real-environment overload, scrubbed `ExceptionTelemetry` construction (type preserved, inner chain, `AggregateException`), long-chain truncation preserving the root cause, and stack frames keeping method names while redacting file paths.
- `TelemetryServiceTrackExceptionTests` (2 tests): end-to-end through `TelemetryService.TrackException` with an in-memory `StubTelemetryChannel` — walks **every** detail of the actual outgoing item asserting the profile path and username appear in no message, wire stack string, or parsedStack `fileName`, asserts the sent item does not carry the original exception object, and asserts nothing is sent when telemetry is disabled. Nothing ever leaves the process; the e2e tests join the `AgentSerial` collection to avoid racing tests that initialize the telemetry singleton.

Full suite: 360 passed, 22 skipped (pre-existing input-simulation skips), 0 failed. Solution builds clean under `TreatWarningsAsErrors`.

## Review follow-up (second commit)

Independent review approved the PR (empirically verified the serialized App Insights payload contains no username, including parsedStack fileNames) with minors, addressed test-first in `9d6e653`:

- **MINOR-1**: chain truncation kept the outermost 10 details and silently dropped the deepest exceptions — the root cause. Now keeps outermost 9 + the leaf, re-linked to the last kept detail and marked `[N inner exception(s) omitted]` (red test first: 15-deep chain with a distinctive leaf).
- **MINOR-2**: the e2e test asserted only `details[0].Message`; it now walks all details of the captured item (message + internal wire stack + every parsedStack `fileName` via reflection) and asserts `sent.Exception` is not the original exception object, with a guard that stack data was actually observed.
- **MINOR-3**: accepted-limitations note added to the scrubber XML docs.
- **NIT-1**: test count above corrected (was stated 23 when it was 22; now genuinely 23 after adding the truncation test).

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU