### PR TITLE
ci(security): least-privilege GITHUB_TOKEN permissions for workflows (#163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [develop, main]
   workflow_dispatch:
 
+# Least-privilege token (#163): read-only by default; jobs elevate only what they need.
+permissions:
+  contents: read
+
 env:
   SOLUTION: 'MCEControl.slnx'
   CONFIGURATION: 'Release'
@@ -31,6 +35,9 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: windows-latest
+    permissions:
+      contents: read
+      checks: write   # EnricoMi/publish-unit-test-result-action creates a check run
 
     steps:
       - name: Checkout

--- a/.github/workflows/real-windows.yml
+++ b/.github/workflows/real-windows.yml
@@ -17,6 +17,10 @@ on:
     branches: [develop, main]
   workflow_dispatch:
 
+# Least-privilege token (#163): read-only by default; jobs elevate only what they need.
+permissions:
+  contents: read
+
 env:
   SOLUTION: 'MCEControl.slnx'
   CONFIGURATION: 'Release'
@@ -42,6 +46,9 @@ jobs:
     if: needs.preflight.outputs.ready == 'true'
     runs-on: [self-hosted, Windows, interactive]   # label your self-hosted runner accordingly
     timeout-minutes: 60                             # backstop so a misconfigured runner fails fast, never the 24h await-runner hang
+    permissions:
+      contents: read
+      checks: write   # EnricoMi/publish-unit-test-result-action creates a check run
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Risk

The repo's `default_workflow_permissions` is **write**, and `ci.yml` / `real-windows.yml` declared no `permissions:` block — so every run of those workflows got a read/write-scoped `GITHUB_TOKEN` across the repo. A write-scoped default token widens the blast radius of any compromised step or third-party action (complements the SHA-pinning done in #172): a hijacked action could push commits, tamper with releases, or rewrite checks. These workflows only actually need `contents: read` plus `checks: write` in the one job that publishes test results.

## Permission mapping

| Workflow | Top-level permissions | Job-level elevations | Why |
|---|---|---|---|
| `ci.yml` | `contents: read` | `build-and-test`: `contents: read`, `checks: write` | Checkout needs `contents: read`; `EnricoMi/publish-unit-test-result-action` creates a check run (`checks: write`). Both workflows run it with `comment_mode: off`, so per the action's README no `pull-requests: write` is needed. `conflict-markers` job only checks out + greps → inherits read-only top level. |
| `real-windows.yml` | `contents: read` | `real-windows`: `contents: read`, `checks: write` | Same pattern: checkout + EnricoMi check run (`comment_mode: off`). `preflight` only echoes a repo variable → inherits read-only top level. |
| `release.yml` | *(unchanged)* `contents: write`, `id-token: write` | none (pre-existing) | Already declares an explicit top-level block and does not rely on the repo default: `contents: write` for `gh release create`, `id-token: write` for Azure OIDC signing. Scoping those down to job level is #166 (P3, out of scope here). |

## Note on the repo default

After this merges, the repo setting `default_workflow_permissions` will be flipped to **read** via the API (not done in this PR). The explicit blocks added here make all three workflows independent of that default, so the flip is a no-op for them.

## Verification

- All three workflow files parse with `yaml.safe_load`; top-level and job-level `permissions` verified programmatically.
- Confirmed via the EnricoMi action README that with `comment_mode: off` only `checks: write` is required (`pull-requests: write` is only for PR comments).

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU