### PR TITLE
fix(security): auto-updater verifies signature/publisher before running installer (#146)

### DIFF
--- a/src/Services/AuthenticodeVerifier.cs
+++ b/src/Services/AuthenticodeVerifier.cs
@@ -51,7 +51,12 @@ internal static class AuthenticodeVerifier {
             return false;
         }
         using (signer) {
-            if (signer.Subject.IndexOf(expectedSubjectSubstring, StringComparison.OrdinalIgnoreCase) < 0) {
+            // Anchor the publisher check to the certificate's simple name (the CN / subject common name),
+            // where the publisher identity lives, rather than a substring anywhere in the full DN (which
+            // could match an OU/serial/etc.). The Kindel Trusted Signing certificate's CN is "Kindel LLC".
+            string commonName = signer.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+            if (string.IsNullOrEmpty(commonName)
+                || commonName.IndexOf(expectedSubjectSubstring, StringComparison.OrdinalIgnoreCase) < 0) {
                 reason = $"signer '{signer.Subject}' does not match expected publisher '{expectedSubjectSubstring}'";
                 return false;
             }
@@ -105,6 +110,9 @@ internal static class AuthenticodeVerifier {
             if (pData != IntPtr.Zero) {
                 Marshal.FreeHGlobal(pData);
             }
+            // DestroyStructure first: StructureToPtr marshaled the LPWStr file path into a nested native
+            // allocation that FreeHGlobal(pFileInfo) alone would not release.
+            Marshal.DestroyStructure<WinTrustFileInfo>(pFileInfo);
             Marshal.FreeHGlobal(pFileInfo);
         }
     }

--- a/src/Services/AuthenticodeVerifier.cs
+++ b/src/Services/AuthenticodeVerifier.cs
@@ -1,0 +1,123 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MCEControl;
+
+/// <summary>
+/// Verifies that a file carries a valid Authenticode signature from the expected publisher before the
+/// auto-updater launches it (issue #146). Uses <c>WinVerifyTrust</c> to confirm the signature is
+/// cryptographically valid AND chains to a trusted root (this also validates the PE hash, so a tampered
+/// file fails even if it embeds a copied signature blob), then checks the signer certificate's subject
+/// names the expected publisher.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1060:Move pinvokes to native methods class",
+    Justification = "WinVerifyTrust is grouped with its own verifier, matching the repo's thematic Win32 grouping.")]
+internal static class AuthenticodeVerifier {
+    // WINTRUST_ACTION_GENERIC_VERIFY_V2
+    private static readonly Guid GenericVerifyV2 = new("00AAC56B-CD44-11d0-8CC2-00C04FC295EE");
+
+    private const uint WTD_UI_NONE = 2;
+    private const uint WTD_REVOKE_NONE = 0;
+    private const uint WTD_CHOICE_FILE = 1;
+    private const uint WTD_STATEACTION_VERIFY = 1;
+    private const uint WTD_STATEACTION_CLOSE = 2;
+    private const int TRUST_E_SUCCESS = 0;
+
+    [DllImport("wintrust.dll", ExactSpelling = true, SetLastError = false)]
+    private static extern int WinVerifyTrust(IntPtr hwnd, [In] ref Guid pgActionID, [In] IntPtr pWVTData);
+
+    /// <summary>
+    /// True only if <paramref name="filePath"/> has a valid Authenticode signature that chains to a
+    /// trusted root and whose signer certificate subject contains <paramref name="expectedSubjectSubstring"/>
+    /// (case-insensitive). On any failure, <paramref name="reason"/> explains why and the method returns false.
+    /// </summary>
+    internal static bool Verify(string filePath, string expectedSubjectSubstring, out string reason) {
+        if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath)) {
+            reason = $"file not found: {filePath}";
+            return false;
+        }
+        if (!HasValidSignature(filePath, out int trustResult)) {
+            reason = $"Authenticode signature missing or invalid (WinVerifyTrust=0x{trustResult:X8})";
+            return false;
+        }
+        X509Certificate2? signer = TryGetSigner(filePath);
+        if (signer is null) {
+            reason = "could not read the signer certificate";
+            return false;
+        }
+        using (signer) {
+            if (signer.Subject.IndexOf(expectedSubjectSubstring, StringComparison.OrdinalIgnoreCase) < 0) {
+                reason = $"signer '{signer.Subject}' does not match expected publisher '{expectedSubjectSubstring}'";
+                return false;
+            }
+        }
+        reason = "ok";
+        return true;
+    }
+
+    /// <summary>Runs WinVerifyTrust (no UI) for GENERIC_VERIFY_V2. Returns true iff the result is S_OK.</summary>
+    private static bool HasValidSignature(string filePath, out int trustResult) {
+        WinTrustFileInfo fileInfo = new() {
+            cbStruct = (uint)Marshal.SizeOf<WinTrustFileInfo>(),
+            pcwszFilePath = filePath,
+            hFile = IntPtr.Zero,
+            pgKnownSubject = IntPtr.Zero,
+        };
+        IntPtr pFileInfo = Marshal.AllocHGlobal(Marshal.SizeOf<WinTrustFileInfo>());
+        IntPtr pData = IntPtr.Zero;
+        try {
+            Marshal.StructureToPtr(fileInfo, pFileInfo, false);
+
+            WinTrustData data = new() {
+                cbStruct = (uint)Marshal.SizeOf<WinTrustData>(),
+                pPolicyCallbackData = IntPtr.Zero,
+                pSIPClientData = IntPtr.Zero,
+                dwUIChoice = WTD_UI_NONE,
+                fdwRevocationChecks = WTD_REVOKE_NONE,
+                dwUnionChoice = WTD_CHOICE_FILE,
+                pFile = pFileInfo,
+                dwStateAction = WTD_STATEACTION_VERIFY,
+                hWVTStateData = IntPtr.Zero,
+                pwszURLReference = IntPtr.Zero,
+                dwProvFlags = 0,
+                dwUIContext = 0,
+            };
+            pData = Marshal.AllocHGlobal(Marshal.SizeOf<WinTrustData>());
+            Marshal.StructureToPtr(data, pData, false);
+
+            Guid action = GenericVerifyV2;
+            trustResult = WinVerifyTrust(IntPtr.Zero, ref action, pData);
+
+            // Always release the state data with a CLOSE call.
+            WinTrustData closeData = Marshal.PtrToStructure<WinTrustData>(pData);
+            closeData.dwStateAction = WTD_STATEACTION_CLOSE;
+            Marshal.StructureToPtr(closeData, pData, false);
+            _ = WinVerifyTrust(IntPtr.Zero, ref action, pData);
+
+            return trustResult == TRUST_E_SUCCESS;
+        }
+        finally {
+            if (pData != IntPtr.Zero) {
+                Marshal.FreeHGlobal(pData);
+            }
+            Marshal.FreeHGlobal(pFileInfo);
+        }
+    }
+
+    private static X509Certificate2? TryGetSigner(string filePath) {
+        try {
+#pragma warning disable SYSLIB0057 // CreateFromSignedFile is the supported way to read the Authenticode signer
+            X509Certificate cert = X509Certificate.CreateFromSignedFile(filePath);
+            return new X509Certificate2(cert);
+#pragma warning restore SYSLIB0057
+        }
+        catch (Exception) {
+            return null;
+        }
+    }
+}

--- a/src/Services/UpdateService.cs
+++ b/src/Services/UpdateService.cs
@@ -156,10 +156,22 @@ public class UpdateService {
         if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
             return false;
         }
-        string host = uri.Host;
-        return string.Equals(host, "github.com", StringComparison.OrdinalIgnoreCase)
-            || host.EndsWith(".githubusercontent.com", StringComparison.OrdinalIgnoreCase);
+        // Explicit host allowlist (not a "*.githubusercontent.com" suffix): the release page lives on
+        // github.com and release-asset downloads redirect to the object hosts below. This deliberately
+        // excludes raw.githubusercontent.com and any other subdomain that serves arbitrary user content.
+        foreach (string trusted in TrustedDownloadHosts) {
+            if (string.Equals(uri.Host, trusted, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+        return false;
     }
+
+    private static readonly string[] TrustedDownloadHosts = [
+        "github.com",
+        "objects.githubusercontent.com",
+        "release-assets.githubusercontent.com",
+    ];
 
     internal async void StartUpgrade() {
         if (DownloadUri is null) {

--- a/src/Services/UpdateService.cs
+++ b/src/Services/UpdateService.cs
@@ -21,6 +21,15 @@ public class UpdateService {
 
     private string _tempFilename = null!;
 
+    // SECURITY (#146): the exact release asset the updater will download and run. Selected by name so a
+    // rogue/extra asset that merely sorts first can't be delivered as `Assets[0]`.
+    internal const string InstallerFileName = "mcec.Setup.exe";
+
+    // The publisher name the installer's Authenticode signer certificate subject must contain. The
+    // release is signed via Azure Trusted Signing under the Kindel LLC publisher identity (see
+    // docs/code-signing.md); a substring keeps this stable across certificate rotations.
+    private const string ExpectedPublisher = "Kindel";
+
     public UpdateService() {
         LatestStableVersion = new Version(0, 0);
 
@@ -82,12 +91,24 @@ public class UpdateService {
             Release[] releases =
                 [.. allReleases.Where(r => !r.Prerelease).OrderByDescending(r => new Version(r.TagName.TrimStart('v')))];
             if (releases.Length > 0) {
-                Logger.Instance.Log4.Debug(
-                    $"The latest release is tagged at {releases[0].TagName} and is named '{releases[0].Name}'. Download Url: {releases[0].Assets[0].BrowserDownloadUrl}");
+                Release latest = releases[0];
+                LatestStableVersion = new Version(latest.TagName.TrimStart('v'));
+                ReleasePageUri = new Uri(latest.HtmlUrl);
 
-                LatestStableVersion = new Version(releases[0].TagName.TrimStart('v'));
-                ReleasePageUri = new Uri(releases[0].HtmlUrl);
-                DownloadUri = new Uri(releases[0].Assets[0].BrowserDownloadUrl);
+                // SECURITY (#146): pick the pinned installer asset by name — never a blind Assets[0],
+                // which could be an attacker-added asset that sorts first (and throws on an empty list).
+                string? assetUrl = SelectInstallerAssetUrl(
+                    latest.Assets.Select(a => (a.Name, a.BrowserDownloadUrl)), InstallerFileName);
+                if (assetUrl is null) {
+                    ErrorMessage = $"Release {latest.TagName} has no '{InstallerFileName}' asset";
+                    Logger.Instance.Log4.Warn($"{GetType().Name}: {ErrorMessage}");
+                    DownloadUri = null!;
+                }
+                else {
+                    Logger.Instance.Log4.Debug(
+                        $"The latest release is tagged at {latest.TagName} and is named '{latest.Name}'. Download Url: {assetUrl}");
+                    DownloadUri = new Uri(assetUrl);
+                }
             }
             else {
                 ErrorMessage = "No release found";
@@ -109,8 +130,55 @@ public class UpdateService {
         return CurrentVersion.CompareTo(LatestStableVersion);
     }
 
+    /// <summary>
+    /// Returns the download URL of the asset whose name exactly matches <paramref name="installerFileName"/>
+    /// (case-insensitive), or null if no such asset exists. Pins the asset by name instead of trusting
+    /// position (#146).
+    /// </summary>
+    internal static string? SelectInstallerAssetUrl(IEnumerable<(string Name, string Url)> assets, string installerFileName) {
+        foreach ((string name, string url) in assets) {
+            if (string.Equals(name, installerFileName, StringComparison.OrdinalIgnoreCase)) {
+                return url;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// True only for an absolute <c>https</c> URL whose host is <c>github.com</c> or a
+    /// <c>*.githubusercontent.com</c> asset host. Pins scheme + host so the updater never downloads over
+    /// plain HTTP or from an attacker-influenced host (#146).
+    /// </summary>
+    internal static bool IsTrustedDownloadUri(Uri? uri) {
+        if (uri is null || !uri.IsAbsoluteUri) {
+            return false;
+        }
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+        string host = uri.Host;
+        return string.Equals(host, "github.com", StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith(".githubusercontent.com", StringComparison.OrdinalIgnoreCase);
+    }
+
     internal async void StartUpgrade() {
-        _tempFilename = Path.GetTempFileName() + ".exe";
+        if (DownloadUri is null) {
+            Logger.Instance.Log4.Error($"{GetType().Name}: no installer download URL available — aborting upgrade.");
+            return;
+        }
+        // SECURITY (#146): only ever download over https from a GitHub host.
+        if (!IsTrustedDownloadUri(DownloadUri)) {
+            Logger.Instance.Log4.Error(
+                $"{GetType().Name}: refusing to download from untrusted URL '{DownloadUri.AbsoluteUri}' " +
+                "(must be https from github.com / githubusercontent.com).");
+            return;
+        }
+
+        // Download into a fresh, app-private directory (not a predictable %TEMP%\tmpXXXX.tmp.exe that a
+        // local attacker could pre-create or swap). Verify, then launch; clean up on any failure.
+        string dir = Path.Combine(Path.GetTempPath(), "mcec-update-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        _tempFilename = Path.Combine(dir, InstallerFileName);
         Logger.Instance.Log4.Info($"{GetType().Name}: Downloading {DownloadUri.AbsoluteUri} to {_tempFilename}...");
 
         try {
@@ -118,23 +186,46 @@ public class UpdateService {
                 HttpResponseMessage response = await httpClient.GetAsync(DownloadUri);
                 response.EnsureSuccessStatusCode();
                 byte[] data = await response.Content.ReadAsByteArrayAsync();
-                File.WriteAllBytes(_tempFilename, data);
+                await File.WriteAllBytesAsync(_tempFilename, data);
+            }
+            Logger.Instance.Log4.Info($"{GetType().Name}: Download complete");
+
+            // SECURITY (#146): verify the file carries a valid Authenticode signature from the expected
+            // publisher BEFORE launching it. A compromised/wrong asset or any tampering fails here.
+            if (!AuthenticodeVerifier.Verify(_tempFilename, ExpectedPublisher, out string reason)) {
+                Logger.Instance.Log4.Error(
+                    $"{GetType().Name}: signature verification FAILED ({reason}); refusing to run {_tempFilename}.");
+                TryDeleteDirectory(dir);
+                return;
             }
 
-            Logger.Instance.Log4.Info($"{GetType().Name}: Download complete");
-            Logger.Instance.Log4.Info($"{GetType().Name}: Exiting and running installer ({_tempFilename})...");
+            Logger.Instance.Log4.Info($"{GetType().Name}: signature verified; exiting and running installer ({_tempFilename})...");
             Process p = new Process { StartInfo = { FileName = _tempFilename, UseShellExecute = true } };
             try {
                 p.Start();
             }
             catch (Win32Exception we) {
                 Logger.Instance.Log4.Error($"{GetType().Name}: {_tempFilename} failed to run with error: {we.Message}");
+                TryDeleteDirectory(dir);
+                return;
             }
 
             MainWindow.Instance.BeginInvoke((Action)(() => { MainWindow.Instance.ShutDown(); }));
         }
         catch (Exception ex) {
             Logger.Instance.Log4.Error($"{GetType().Name}: Download failed: {ex.Message}");
+            TryDeleteDirectory(dir);
+        }
+    }
+
+    private static void TryDeleteDirectory(string dir) {
+        try {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Warn($"UpdateService: could not clean up '{dir}': {e.Message}");
         }
     }
 }

--- a/src/Services/WinTrustData.cs
+++ b/src/Services/WinTrustData.cs
@@ -1,0 +1,29 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace MCEControl;
+
+/// <summary>
+/// Native <c>WINTRUST_DATA</c> passed to <c>WinVerifyTrust</c> by <see cref="AuthenticodeVerifier"/>
+/// (issue #146). Only the file-choice union member is used, so the union is modeled as a single
+/// pointer to a <see cref="WinTrustFileInfo"/>. The newer <c>pSignatureSettings</c> tail field is
+/// intentionally omitted; <c>cbStruct</c> is set to this (older) size, which Windows accepts.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct WinTrustData {
+    public uint cbStruct;
+    public IntPtr pPolicyCallbackData;
+    public IntPtr pSIPClientData;
+    public uint dwUIChoice;
+    public uint fdwRevocationChecks;
+    public uint dwUnionChoice;
+    public IntPtr pFile; // union: WINTRUST_FILE_INFO* (we only use WTD_CHOICE_FILE)
+    public uint dwStateAction;
+    public IntPtr hWVTStateData;
+    public IntPtr pwszURLReference;
+    public uint dwProvFlags;
+    public uint dwUIContext;
+}

--- a/src/Services/WinTrustFileInfo.cs
+++ b/src/Services/WinTrustFileInfo.cs
@@ -1,0 +1,19 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace MCEControl;
+
+/// <summary>
+/// Native <c>WINTRUST_FILE_INFO</c> — identifies the file whose Authenticode signature
+/// <see cref="AuthenticodeVerifier"/> asks <c>WinVerifyTrust</c> to validate (issue #146).
+/// </summary>
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+internal struct WinTrustFileInfo {
+    public uint cbStruct;
+    [MarshalAs(UnmanagedType.LPWStr)] public string pcwszFilePath;
+    public IntPtr hFile;
+    public IntPtr pgKnownSubject;
+}

--- a/tests/MCEControl.xUnit/Services/UpdateServiceVerificationTests.cs
+++ b/tests/MCEControl.xUnit/Services/UpdateServiceVerificationTests.cs
@@ -62,6 +62,8 @@ public class UpdateServiceVerificationTests {
     [InlineData("https://github.com.evil.com/x")]                                     // suffix trick
     [InlineData("https://notgithub.com/x")]
     [InlineData("ftp://github.com/x")]
+    [InlineData("https://raw.githubusercontent.com/tig/mcec/main/evil.exe")]          // arbitrary user content
+    [InlineData("https://github.com@evil.com/x")]                                     // userinfo trick
     public void IsTrustedDownloadUri_RejectsUntrusted(string uri) {
         Assert.False(UpdateService.IsTrustedDownloadUri(new Uri(uri)));
     }

--- a/tests/MCEControl.xUnit/Services/UpdateServiceVerificationTests.cs
+++ b/tests/MCEControl.xUnit/Services/UpdateServiceVerificationTests.cs
@@ -1,0 +1,91 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Security regression tests for issue #146: the auto-updater must (1) pick the pinned installer asset
+/// rather than a blind <c>Assets[0]</c>, (2) only download from https + a GitHub host, and (3) verify the
+/// downloaded file's Authenticode signature/publisher before launching it.
+/// </summary>
+public class UpdateServiceVerificationTests {
+    // ---- (1) asset pinning ----
+
+    private static readonly (string Name, string Url)[] Assets = [
+        ("SHA256SUMS", "https://github.com/tig/mcec/releases/download/v3.0/SHA256SUMS"),
+        ("mcec.Setup.exe", "https://github.com/tig/mcec/releases/download/v3.0/mcec.Setup.exe"),
+        ("source.zip", "https://github.com/tig/mcec/releases/download/v3.0/source.zip"),
+    ];
+
+    [Fact]
+    public void SelectInstallerAssetUrl_PicksPinnedName_NotFirstAsset() {
+        string? url = UpdateService.SelectInstallerAssetUrl(Assets, "mcec.Setup.exe");
+        Assert.Equal("https://github.com/tig/mcec/releases/download/v3.0/mcec.Setup.exe", url);
+    }
+
+    [Fact]
+    public void SelectInstallerAssetUrl_IsCaseInsensitiveOnName() {
+        string? url = UpdateService.SelectInstallerAssetUrl(Assets, "MCEC.SETUP.EXE");
+        Assert.NotNull(url);
+    }
+
+    [Fact]
+    public void SelectInstallerAssetUrl_ReturnsNull_WhenNoMatchingAsset() {
+        var assets = new[] { ("readme.txt", "https://github.com/x/y/releases/download/v1/readme.txt") };
+        Assert.Null(UpdateService.SelectInstallerAssetUrl(assets, "mcec.Setup.exe"));
+    }
+
+    [Fact]
+    public void SelectInstallerAssetUrl_ReturnsNull_WhenNoAssets() {
+        Assert.Null(UpdateService.SelectInstallerAssetUrl(Array.Empty<(string, string)>(), "mcec.Setup.exe"));
+    }
+
+    // ---- (2) download-URL pinning ----
+
+    [Theory]
+    [InlineData("https://github.com/tig/mcec/releases/download/v3.0/mcec.Setup.exe")]
+    [InlineData("https://objects.githubusercontent.com/github-production-release-asset/1/2")]
+    [InlineData("https://release-assets.githubusercontent.com/x/y")]
+    public void IsTrustedDownloadUri_AllowsHttpsGitHubHosts(string uri) {
+        Assert.True(UpdateService.IsTrustedDownloadUri(new Uri(uri)));
+    }
+
+    [Theory]
+    [InlineData("http://github.com/tig/mcec/releases/download/v3.0/mcec.Setup.exe")] // not https
+    [InlineData("https://evil.com/mcec.Setup.exe")]                                   // wrong host
+    [InlineData("https://github.com.evil.com/x")]                                     // suffix trick
+    [InlineData("https://notgithub.com/x")]
+    [InlineData("ftp://github.com/x")]
+    public void IsTrustedDownloadUri_RejectsUntrusted(string uri) {
+        Assert.False(UpdateService.IsTrustedDownloadUri(new Uri(uri)));
+    }
+
+    [Fact]
+    public void IsTrustedDownloadUri_RejectsNull() {
+        Assert.False(UpdateService.IsTrustedDownloadUri(null));
+    }
+
+    // ---- (3) Authenticode verification (negative paths — no signed fixture available) ----
+
+    [Fact]
+    public void Verify_ReturnsFalse_ForMissingFile() {
+        bool ok = AuthenticodeVerifier.Verify(@"C:\does\not\exist\mcec.Setup.exe", "Kindel", out string reason);
+        Assert.False(ok);
+        Assert.Contains("file not found", reason);
+    }
+
+    [Fact]
+    public void Verify_ReturnsFalse_ForUnsignedFile() {
+        // The test assembly itself is not Authenticode-signed, so verification must fail closed.
+        string unsigned = Assembly.GetExecutingAssembly().Location;
+        bool ok = AuthenticodeVerifier.Verify(unsigned, "Kindel", out string reason);
+        Assert.False(ok);
+        Assert.Contains("signature", reason, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
Closes #146

## Problem (P1 — code execution as the current user)

`UpdateService.StartUpgrade` downloaded a release asset and **ran it with no integrity verification of any kind** — no Authenticode/signature check, no publisher pinning, no hash/manifest, no asset-name pinning, no scheme/host pinning:

```csharp
_tempFilename = Path.GetTempFileName() + ".exe";
... GetAsync(DownloadUri); File.WriteAllBytes(_tempFilename, data);
Process.Start(_tempFilename);   // runs whatever bytes arrived
```

The URL was chosen blindly as `releases[0].Assets[0].BrowserDownloadUrl`. A compromised/leaked token, a maintainer-account takeover, or an attacker who can add an asset that sorts first → every install auto-fetches and launches the payload. The predictable `%TEMP%\tmpXXXX.tmp.exe` was also swappable by a local attacker and leaked an orphan `.tmp`. Chained with #160 (a botched signing run that ships an unsigned installer), this is directly reachable.

## Fix — verify **before** launch

1. **Pin the asset by name.** `SelectInstallerAssetUrl(...)` picks the asset named exactly `mcec.Setup.exe` (the release's installer); a release with no matching asset is rejected (no more `Assets[0]` index-throw / wrong-asset delivery).
2. **Pin the URL.** `IsTrustedDownloadUri(...)` requires `https` and host `github.com` / `*.githubusercontent.com`; http downgrades, foreign hosts, and `github.com.evil.com` suffix tricks are rejected.
3. **Private temp dir.** Download into a fresh `%TEMP%\mcec-update-<guid>\mcec.Setup.exe`, replacing the predictable/leaky `GetTempFileName` pattern; the directory is cleaned up on any failure.
4. **Authenticode + publisher.** `AuthenticodeVerifier.Verify(...)` runs `WinVerifyTrust` (validates the signature, the PE hash, and a trusted chain — so a tampered file fails even if it embeds a copied signature blob) **and** requires the signer certificate subject to contain the `Kindel` publisher. Launch is refused (and the download deleted) on any failure.

New interop lives in its own files per the one-type-per-file analyzer: `WinTrustFileInfo`, `WinTrustData`, `AuthenticodeVerifier`.

## Tests (written first, red → green)

`tests/MCEControl.xUnit/Services/UpdateServiceVerificationTests.cs` — 15 cases:

- **Asset pinning:** picks `mcec.Setup.exe` (not `Assets[0]`), case-insensitive; null on no-match / empty list.
- **URL pinning:** https + `github.com`/`objects.githubusercontent.com`/`release-assets.githubusercontent.com` allowed; `http://`, `evil.com`, `github.com.evil.com`, `notgithub.com`, `ftp://`, and null rejected.
- **Signature (fails closed):** missing file → false ("file not found"); the unsigned test assembly → false (reason mentions the signature). (No signed fixture is available in CI, so positive verification is covered by the release/#160 pipeline and manual verification.)

Full suite: **350 passed, 22 skipped, 0 failed** locally.

## Note

`WinVerifyTrust` uses `WTD_REVOKE_NONE` (validates signature + chain to a trusted root without a network revocation round-trip) to avoid false-negatives breaking updates on flaky networks; combined with the TLS+host pin and publisher-subject check this is a large step up from zero verification. A signed SHA-256 manifest could be layered on later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)