### PR TITLE
fix(security): bound receive buffers to prevent memory-exhaustion DoS (#148)

### DIFF
--- a/src/Services/CommandAccumulator.cs
+++ b/src/Services/CommandAccumulator.cs
@@ -1,0 +1,80 @@
+//-------------------------------------------------------------------
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+//-------------------------------------------------------------------
+
+using System;
+using System.Text;
+
+namespace MCEControl;
+
+/// <summary>
+/// Accumulates received characters into commands delimited by CR, LF, or NUL, enforcing
+/// <see cref="MaxCommandLength"/> so a peer that streams bytes without a delimiter cannot
+/// grow the buffer without bound (issue #148 — memory-exhaustion DoS). On overflow the
+/// partial command is dropped and further input is discarded until the next delimiter.
+/// Used by <see cref="SerialServer"/> and <see cref="SocketClient"/>; the socket server
+/// enforces the same cap in <see cref="SocketServer.ParseReceivedData"/> (it additionally
+/// handles telnet negotiation and closes the offending connection).
+/// </summary>
+internal sealed class CommandAccumulator {
+    /// <summary>
+    /// Maximum accumulated length, in characters, of a single command (issue #148).
+    /// MCEControl commands are short (command names plus modest arguments; typically well
+    /// under 100 chars — 4 KB is generous headroom even for long "chars:" payloads) so a
+    /// few KB caps per-connection memory at a harmless size while never truncating
+    /// legitimate traffic.
+    /// </summary>
+    public const int MaxCommandLength = 4096;
+
+    private readonly StringBuilder _sb = new();
+
+    // True after an overflow: input is dropped until the next delimiter so the tail of an
+    // oversized run can never surface as a (garbage) command.
+    private bool _discarding;
+
+    // Test seam (InternalsVisibleTo MCEControl.xUnit).
+    internal int Length => _sb.Length;
+
+    /// <summary>
+    /// Processes one received character. Returns the completed command when
+    /// <paramref name="c"/> is a delimiter (CR/LF/NUL) and a non-empty command has
+    /// accumulated; otherwise returns null.
+    /// </summary>
+    /// <param name="c">The received character.</param>
+    /// <param name="onOverflow">Invoked once when the accumulated length would exceed
+    /// <see cref="MaxCommandLength"/>; the buffer is reset and input is discarded until
+    /// the next delimiter.</param>
+    public string? ProcessChar(char c, Action? onOverflow = null) {
+        switch (c) {
+            case '\r':
+            case '\n':
+            case '\0':
+                if (_discarding) {
+                    // End of an oversized run — recover; the next command parses normally.
+                    _discarding = false;
+                    return null;
+                }
+                if (_sb.Length == 0) {
+                    return null;
+                }
+                string cmd = _sb.ToString();
+                _sb.Clear();
+                return cmd;
+
+            default:
+                if (_discarding) {
+                    return null;
+                }
+                if (_sb.Length >= MaxCommandLength) {
+                    // #148: drop the oversized partial command and notify once.
+                    _sb.Clear();
+                    _discarding = true;
+                    onOverflow?.Invoke();
+                    return null;
+                }
+                _sb.Append(c);
+                return null;
+        }
+    }
+}

--- a/src/Services/SerialServer.cs
+++ b/src/Services/SerialServer.cs
@@ -156,7 +156,10 @@ public sealed class SerialServer : ServiceBase, IDisposable {
     // Update Read method to accept a CancellationToken
     private void Read(CancellationToken cancellationToken) {
         Log4.Debug($"Serial Read thread starting: {GetSettingsDisplayString()}");
-        StringBuilder sb = new StringBuilder();
+        // #148: cap accumulated command length so a peer streaming bytes without a
+        // delimiter cannot grow the buffer until OOM. On overflow the partial command is
+        // dropped, an error is logged, and input is discarded until the next delimiter.
+        CommandAccumulator accumulator = new();
         while (!cancellationToken.IsCancellationRequested) {
             try {
                 if (_serialPort == null) {
@@ -164,18 +167,13 @@ public sealed class SerialServer : ServiceBase, IDisposable {
                     break;
                 }
                 char c = (char)_serialPort.ReadChar();
-                if (c == '\r' || c == '\n' || c == '\0') {
-                    string cmd = sb.ToString();
-                    sb.Length = 0;
-                    if (cmd.Length > 0) {
-                        SendNotification(ServiceNotification.ReceivedData,
-                                        CurrentStatus,
-                                        new SerialReplyContext(_serialPort),
-                                        cmd);
-                    }
-                }
-                else {
-                    sb.Append(c);
+                string? cmd = accumulator.ProcessChar(c,
+                    () => Error($"SerialServer: command exceeded maximum length ({CommandAccumulator.MaxCommandLength} chars); discarding input until next delimiter"));
+                if (cmd != null) {
+                    SendNotification(ServiceNotification.ReceivedData,
+                                    CurrentStatus,
+                                    new SerialReplyContext(_serialPort),
+                                    cmd);
                 }
             }
             catch (TimeoutException) {

--- a/src/Services/SerialServer.cs
+++ b/src/Services/SerialServer.cs
@@ -160,6 +160,7 @@ public sealed class SerialServer : ServiceBase, IDisposable {
         // delimiter cannot grow the buffer until OOM. On overflow the partial command is
         // dropped, an error is logged, and input is discarded until the next delimiter.
         CommandAccumulator accumulator = new();
+        Action onOverflow = () => Error($"SerialServer: command exceeded maximum length ({CommandAccumulator.MaxCommandLength} chars); discarding input until next delimiter");
         while (!cancellationToken.IsCancellationRequested) {
             try {
                 if (_serialPort == null) {
@@ -167,8 +168,7 @@ public sealed class SerialServer : ServiceBase, IDisposable {
                     break;
                 }
                 char c = (char)_serialPort.ReadChar();
-                string? cmd = accumulator.ProcessChar(c,
-                    () => Error($"SerialServer: command exceeded maximum length ({CommandAccumulator.MaxCommandLength} chars); discarding input until next delimiter"));
+                string? cmd = accumulator.ProcessChar(c, onOverflow);
                 if (cmd != null) {
                     SendNotification(ServiceNotification.ReceivedData,
                                     CurrentStatus,

--- a/src/Services/SocketClient.cs
+++ b/src/Services/SocketClient.cs
@@ -68,7 +68,6 @@ public sealed class SocketClient : ServiceBase, IDisposable {
     }
 
     public void Start(bool delay = false) {
-        StringBuilder currentCmd = new StringBuilder();
         _tcpClient = new TcpClient();
         _bw = new BackgroundWorker {
             WorkerReportsProgress = false,
@@ -171,6 +170,7 @@ public sealed class SocketClient : ServiceBase, IDisposable {
                     // command is dropped, an error is logged, and input is discarded until
                     // the next delimiter.
                     CommandAccumulator accumulator = new();
+                    Action onOverflow = () => Error($"SocketClient: command exceeded maximum length ({CommandAccumulator.MaxCommandLength} chars); discarding input until next delimiter");
                     while (_bw != null &&
                         !_bw.CancellationPending &&
                         CurrentStatus == ServiceStatus.Connected &&
@@ -183,8 +183,7 @@ public sealed class SocketClient : ServiceBase, IDisposable {
                             return;
                         }
 
-                        string? cmd = accumulator.ProcessChar((char)input,
-                            () => Error($"SocketClient: command exceeded maximum length ({CommandAccumulator.MaxCommandLength} chars); discarding input until next delimiter"));
+                        string? cmd = accumulator.ProcessChar((char)input, onOverflow);
                         if (cmd != null) {
                             SendNotification(ServiceNotification.ReceivedData, ServiceStatus.Connected, new ClientReplyContext(_tcpClient), cmd);
                             System.Threading.Thread.Sleep(100);

--- a/src/Services/SocketClient.cs
+++ b/src/Services/SocketClient.cs
@@ -166,7 +166,11 @@ public sealed class SocketClient : ServiceBase, IDisposable {
                     _tcpClient.EndConnect(ar);
                     Log4.Debug($"SocketClient: Back from EndConnect: {_host}:{_port}");
                     SetStatus(ServiceStatus.Connected, $"{_host}:{_port}");
-                    StringBuilder sb = new StringBuilder();
+                    // #148: cap accumulated command length so a peer streaming bytes without
+                    // a delimiter cannot grow the buffer until OOM. On overflow the partial
+                    // command is dropped, an error is logged, and input is discarded until
+                    // the next delimiter.
+                    CommandAccumulator accumulator = new();
                     while (_bw != null &&
                         !_bw.CancellationPending &&
                         CurrentStatus == ServiceStatus.Connected &&
@@ -174,24 +178,16 @@ public sealed class SocketClient : ServiceBase, IDisposable {
                         _tcpClient.Connected) {
                         // TODO: Move exception handling around this
                         int input = _tcpClient.GetStream().ReadByte();
-                        switch (input) {
-                            case (byte)'\r':
-                            case (byte)'\n':
-                            case (byte)'\0':
-                                if (sb.Length > 0) {
-                                    SendNotification(ServiceNotification.ReceivedData, ServiceStatus.Connected, new ClientReplyContext(_tcpClient), sb.ToString());
-                                    sb.Clear();
-                                    System.Threading.Thread.Sleep(100);
-                                }
-                                break;
+                        if (input == -1) {
+                            Error("No more data.");
+                            return;
+                        }
 
-                            case -1:
-                                Error("No more data.");
-                                return;
-
-                            default:
-                                sb.Append((char)input);
-                                break;
+                        string? cmd = accumulator.ProcessChar((char)input,
+                            () => Error($"SocketClient: command exceeded maximum length ({CommandAccumulator.MaxCommandLength} chars); discarding input until next delimiter"));
+                        if (cmd != null) {
+                            SendNotification(ServiceNotification.ReceivedData, ServiceStatus.Connected, new ClientReplyContext(_tcpClient), cmd);
+                            System.Threading.Thread.Sleep(100);
                         }
                     }
                 }

--- a/src/Services/SocketServer.cs
+++ b/src/Services/SocketServer.cs
@@ -312,12 +312,14 @@ sealed public class SocketServer : ServiceBase, IDisposable {
                     byte verb = buffer[i];
                     switch (verb) {
                         case (int)TelnetVerbs.IAC:
-                            //literal IAC = 255 escaped, so append char 255 to string
+                            //literal IAC = 255 escaped, so append char 255 to string.
+                            // The (char) cast matters: Append(byte) would format the NUMBER
+                            // as the 3-char string "255" (#148 review follow-up).
                             if (cmdBuilder.Length >= CommandAccumulator.MaxCommandLength) {
                                 cmdBuilder.Clear(); // #148: drop the oversized partial command
                                 return false;
                             }
-                            cmdBuilder.Append(verb);
+                            cmdBuilder.Append((char)verb);
                             break;
                         case (int)TelnetVerbs.DO:
                         case (int)TelnetVerbs.DONT:

--- a/src/Services/SocketServer.cs
+++ b/src/Services/SocketServer.cs
@@ -227,21 +227,9 @@ sealed public class SocketServer : ServiceBase, IDisposable {
                 return;
             }
 
-            // Parse the received chunk. Guard the parse loop so a malformed/crafted packet can
-            // never escape as an unhandled exception on this ThreadPool callback and terminate
-            // the process (issue #144 — unauthenticated remote crash). Any parse failure closes
-            // the offending client instead.
-            try {
-                ParseReceivedData(
-                    clientContext.DataBuffer,
-                    iRx,
-                    clientContext.CmdBuilder,
-                    reply => clientContext.Socket.Send(reply),
-                    command => SendNotification(ServiceNotification.ReceivedData, CurrentStatus, clientContext, command));
-            }
-            catch (Exception ex) {
-                SendNotification(ServiceNotification.Error, CurrentStatus, clientContext, $"OnDataReceived: parse error: {ex.Message}");
-                CloseSocket(clientContext);
+            // Parse the received chunk; if it closed the client (parse failure or
+            // command-length overflow), stop receiving.
+            if (!ProcessReceivedData(clientContext, iRx)) {
                 return;
             }
 
@@ -261,9 +249,44 @@ sealed public class SocketServer : ServiceBase, IDisposable {
     }
 
     /// <summary>
+    /// Parses the chunk currently in <paramref name="clientContext"/>'s DataBuffer. Guards the
+    /// parse loop so a malformed/crafted packet can never escape as an unhandled exception on a
+    /// ThreadPool callback and terminate the process (issue #144 — unauthenticated remote crash):
+    /// any parse failure closes the offending client. Likewise, a client that streams more than
+    /// <see cref="CommandAccumulator.MaxCommandLength"/> chars without a delimiter (issue #148 —
+    /// memory-exhaustion DoS) is hostile or broken, so it is closed rather than buffered further.
+    /// Internal so tests can drive the receive path without a live listener (InternalsVisibleTo).
+    /// </summary>
+    /// <returns>false if the client was closed and receiving must stop.</returns>
+    internal bool ProcessReceivedData(ServerReplyContext clientContext, int count) {
+        try {
+            if (!ParseReceivedData(
+                    clientContext.DataBuffer,
+                    count,
+                    clientContext.CmdBuilder,
+                    reply => clientContext.Socket.Send(reply),
+                    command => SendNotification(ServiceNotification.ReceivedData, CurrentStatus, clientContext, command))) {
+                SendNotification(ServiceNotification.Error, CurrentStatus, clientContext,
+                    $"OnDataReceived: command exceeded maximum length ({CommandAccumulator.MaxCommandLength} chars); closing connection");
+                CloseSocket(clientContext);
+                return false;
+            }
+        }
+        catch (Exception ex) {
+            SendNotification(ServiceNotification.Error, CurrentStatus, clientContext, $"OnDataReceived: parse error: {ex.Message}");
+            CloseSocket(clientContext);
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
     /// Parses a received chunk of bytes: strips inline telnet negotiation (IAC …) and emits a
     /// command via <paramref name="onCommand"/> on each CR/LF/NUL delimiter. Extracted from
     /// <see cref="OnDataReceived"/> so it can be unit tested and hardened against malformed input.
+    /// Returns false when the accumulated command exceeds
+    /// <see cref="CommandAccumulator.MaxCommandLength"/> (issue #148); the builder is cleared and
+    /// parsing stops — the caller is expected to close the connection.
     /// </summary>
     /// <remarks>
     /// Issue #144: the telnet option byte was read <b>before</b> its bounds check, so a crafted
@@ -271,7 +294,7 @@ sealed public class SocketServer : ServiceBase, IDisposable {
     /// out-of-bounds read → unhandled exception → process crash. Every buffer access here is now
     /// bounds-checked first: a truncated IAC/verb/option sequence is silently ignored.
     /// </remarks>
-    internal static void ParseReceivedData(
+    internal static bool ParseReceivedData(
             byte[] buffer,
             int count,
             StringBuilder cmdBuilder,
@@ -290,6 +313,10 @@ sealed public class SocketServer : ServiceBase, IDisposable {
                     switch (verb) {
                         case (int)TelnetVerbs.IAC:
                             //literal IAC = 255 escaped, so append char 255 to string
+                            if (cmdBuilder.Length >= CommandAccumulator.MaxCommandLength) {
+                                cmdBuilder.Clear(); // #148: drop the oversized partial command
+                                return false;
+                            }
                             cmdBuilder.Append(verb);
                             break;
                         case (int)TelnetVerbs.DO:
@@ -331,10 +358,15 @@ sealed public class SocketServer : ServiceBase, IDisposable {
                     break;
 
                 default:
+                    if (cmdBuilder.Length >= CommandAccumulator.MaxCommandLength) {
+                        cmdBuilder.Clear(); // #148: drop the oversized partial command
+                        return false;
+                    }
                     cmdBuilder.Append((char)b);
                     break;
             }
         }
+        return true;
     }
 
     public void SendAwakeCommand(String cmd, String host, int port) {

--- a/tests/MCEControl.xUnit/Services/CommandAccumulatorTests.cs
+++ b/tests/MCEControl.xUnit/Services/CommandAccumulatorTests.cs
@@ -1,0 +1,97 @@
+//-------------------------------------------------------------------
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+//-------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Tests for the bounded command accumulator (issue #148): received bytes accumulated into a
+/// command builder must never grow without bound. A peer that streams bytes without a CR/LF/NUL
+/// delimiter must not be able to drive the process to OutOfMemoryException; on overflow the
+/// partial command is dropped, the caller is notified (so it can log), and input is discarded
+/// until the next delimiter so a subsequent valid command still parses.
+/// </summary>
+public class CommandAccumulatorTests {
+    private static List<string> Feed(CommandAccumulator accumulator, string input, Action? onOverflow = null) {
+        var commands = new List<string>();
+        foreach (char c in input) {
+            string? cmd = accumulator.ProcessChar(c, onOverflow);
+            if (cmd != null) {
+                commands.Add(cmd);
+            }
+        }
+        return commands;
+    }
+
+    [Fact]
+    public void Delimiter_EmitsAccumulatedCommand() {
+        var accumulator = new CommandAccumulator();
+
+        var commands = Feed(accumulator, "vol+\r");
+
+        Assert.Equal(new[] { "vol+" }, commands);
+        Assert.Equal(0, accumulator.Length);
+    }
+
+    [Fact]
+    public void AllThreeDelimiters_EmitCommands_AndEmptyLinesAreIgnored() {
+        var accumulator = new CommandAccumulator();
+
+        var commands = Feed(accumulator, "a\rb\nc\0\r\n\0");
+
+        Assert.Equal(new[] { "a", "b", "c" }, commands);
+    }
+
+    [Fact]
+    public void DelimiterlessFlood_NeverExceedsMaxCommandLength() {
+        var accumulator = new CommandAccumulator();
+
+        for (int i = 0; i < CommandAccumulator.MaxCommandLength * 3; i++) {
+            _ = accumulator.ProcessChar('x');
+            Assert.True(accumulator.Length <= CommandAccumulator.MaxCommandLength,
+                $"accumulator grew to {accumulator.Length} chars after {i + 1} delimiter-less chars");
+        }
+    }
+
+    [Fact]
+    public void Overflow_InvokesCallbackOnce_AndResetsBuffer() {
+        var accumulator = new CommandAccumulator();
+        int overflows = 0;
+
+        // One char past the cap triggers the overflow; the rest of the run must not
+        // re-notify (no log flooding) and nothing may accumulate while discarding.
+        _ = Feed(accumulator, new string('x', CommandAccumulator.MaxCommandLength + 100), () => overflows++);
+
+        Assert.Equal(1, overflows);
+        Assert.Equal(0, accumulator.Length);
+    }
+
+    [Fact]
+    public void Overflow_DropsOversizedCommand_AndNextCommandStillParses() {
+        var accumulator = new CommandAccumulator();
+
+        // An oversized delimiter-less run, then a delimiter, then a valid command: the
+        // oversized run (including its tail after the overflow) must never surface as a
+        // command, and the accumulator must recover to parse the valid command.
+        var commands = Feed(accumulator, new string('x', CommandAccumulator.MaxCommandLength + 100) + "\n" + "ok\n");
+
+        Assert.Equal(new[] { "ok" }, commands);
+    }
+
+    [Fact]
+    public void CommandOfExactlyMaxLength_IsDelivered() {
+        var accumulator = new CommandAccumulator();
+        string max = new('x', CommandAccumulator.MaxCommandLength);
+        int overflows = 0;
+
+        var commands = Feed(accumulator, max + "\n", () => overflows++);
+
+        Assert.Equal(new[] { max }, commands);
+        Assert.Equal(0, overflows);
+    }
+}

--- a/tests/MCEControl.xUnit/Services/SocketServerReceiveCapTests.cs
+++ b/tests/MCEControl.xUnit/Services/SocketServerReceiveCapTests.cs
@@ -64,8 +64,25 @@ public class SocketServerReceiveCapTests : IDisposable {
     }
 
     [Fact]
+    public void ParseReceivedData_EscapedIacAppendSite_NeverExceedsCap() {
+        // The escaped-IAC path (IAC IAC -> literal 0xFF) is an append site too and must
+        // honor the same cap: fill to one char under the cap, then send IAC IAC. A
+        // multi-char append there (e.g. the decimal string "255") would blow past the cap.
+        var builder = new StringBuilder();
+        var data = new byte[CommandAccumulator.MaxCommandLength + 1];
+        Array.Fill(data, (byte)'a');
+        data[^2] = 255; // IAC
+        data[^1] = 255; // IAC — escaped literal 0xFF
+
+        _ = SocketServer.ParseReceivedData(data, data.Length, builder, _ => { }, _ => { });
+
+        Assert.True(builder.Length <= CommandAccumulator.MaxCommandLength,
+            $"CmdBuilder grew to {builder.Length} chars via the escaped-IAC append site");
+    }
+
+    [Fact]
     public void ProcessReceivedData_DelimiterlessFlood_ClosesOffendingClient_AndLogsError() {
-        Socket socket = NewSocket();
+        using Socket socket = NewSocket();
         var context = _server.RegisterClient(socket);
         var errors = new List<string>();
         _server.Notifications += (notify, status, reply, msg) => {

--- a/tests/MCEControl.xUnit/Services/SocketServerReceiveCapTests.cs
+++ b/tests/MCEControl.xUnit/Services/SocketServerReceiveCapTests.cs
@@ -1,0 +1,111 @@
+//-------------------------------------------------------------------
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+//-------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Text;
+using Xunit;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Regression tests for issue #148 (SocketServer side): the per-command receive buffer must be
+/// bounded. The server binds 0.0.0.0 unauthenticated, so an attacker streaming bytes with no
+/// CR/LF/NUL delimiter must not be able to grow CmdBuilder until OutOfMemoryException (which
+/// surfaces on a ThreadPool callback and kills the process). A client past the cap is hostile
+/// or broken: the buffer is dropped, an error is logged, and the connection is closed.
+/// No live listener is used — tests drive the internal receive seams directly.
+/// </summary>
+public class SocketServerReceiveCapTests : IDisposable {
+    private readonly SocketServer _server = new();
+
+    public void Dispose() {
+        _server.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static Socket NewSocket() =>
+        new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+    [Fact]
+    public void ParseReceivedData_DelimiterlessFlood_NeverExceedsCap_AndDropsBuilder() {
+        var builder = new StringBuilder();
+        var chunk = new byte[1024];
+        Array.Fill(chunk, (byte)'a');
+
+        bool overflowed = false;
+        // 8 KB of delimiter-less data: parsing must refuse to buffer past the cap.
+        for (int i = 0; i < 8 && !overflowed; i++) {
+            overflowed = !SocketServer.ParseReceivedData(chunk, chunk.Length, builder, _ => { }, _ => { });
+            Assert.True(builder.Length <= CommandAccumulator.MaxCommandLength,
+                $"CmdBuilder grew to {builder.Length} chars after chunk {i + 1}");
+        }
+
+        Assert.True(overflowed, "ParseReceivedData never signaled overflow");
+        Assert.Equal(0, builder.Length); // oversized partial command is dropped, not kept
+    }
+
+    [Fact]
+    public void ParseReceivedData_CommandOfExactlyMaxLength_StillParses() {
+        var builder = new StringBuilder();
+        var commands = new List<string>();
+        var data = new byte[CommandAccumulator.MaxCommandLength + 1];
+        Array.Fill(data, (byte)'a');
+        data[^1] = (byte)'\n';
+
+        bool ok = SocketServer.ParseReceivedData(data, data.Length, builder, _ => { }, commands.Add);
+
+        Assert.True(ok);
+        Assert.Single(commands);
+        Assert.Equal(CommandAccumulator.MaxCommandLength, commands[0].Length);
+    }
+
+    [Fact]
+    public void ProcessReceivedData_DelimiterlessFlood_ClosesOffendingClient_AndLogsError() {
+        Socket socket = NewSocket();
+        var context = _server.RegisterClient(socket);
+        var errors = new List<string>();
+        _server.Notifications += (notify, status, reply, msg) => {
+            if (notify == ServiceNotification.Error) {
+                errors.Add(msg);
+            }
+        };
+        Array.Fill(context.DataBuffer, (byte)'a');
+
+        bool closed = false;
+        for (int i = 0; i < 8 && !closed; i++) {
+            closed = !_server.ProcessReceivedData(context, context.DataBuffer.Length);
+            Assert.True(context.CmdBuilder.Length <= CommandAccumulator.MaxCommandLength,
+                $"CmdBuilder grew to {context.CmdBuilder.Length} chars after chunk {i + 1}");
+        }
+
+        Assert.True(closed, "flooding client was never closed");
+        Assert.DoesNotContain(socket, _server.TrackedClients.Values);
+        Assert.Equal(0, _server.ConnectedClientCount);
+        Assert.True(socket.SafeHandle.IsClosed, "offending client's socket was not closed");
+        Assert.Contains(errors, msg => msg.Contains("maximum length", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ProcessReceivedData_ValidCommand_EmitsCommand_AndKeepsClientConnected() {
+        using Socket socket = NewSocket();
+        var context = _server.RegisterClient(socket);
+        var commands = new List<string>();
+        _server.Notifications += (notify, status, reply, msg) => {
+            if (notify == ServiceNotification.ReceivedData) {
+                commands.Add(msg);
+            }
+        };
+        byte[] data = Encoding.ASCII.GetBytes("mute\n");
+        Array.Copy(data, context.DataBuffer, data.Length);
+
+        bool keepReceiving = _server.ProcessReceivedData(context, data.Length);
+
+        Assert.True(keepReceiving);
+        Assert.Equal(new[] { "mute" }, commands);
+        Assert.Contains(socket, _server.TrackedClients.Values);
+    }
+}

--- a/tests/MCEControl.xUnit/Services/SocketServerTelnetParseTests.cs
+++ b/tests/MCEControl.xUnit/Services/SocketServerTelnetParseTests.cs
@@ -110,6 +110,19 @@ public class SocketServerTelnetParseTests {
     }
 
     [Fact]
+    public void LiteralIacEscape_AppendsSingleChar255ToCommand() {
+        // IAC IAC is the telnet escape for a literal 0xFF data byte: exactly one (char)255
+        // must land in the accumulated command — not the decimal string "255"
+        // (StringBuilder.Append(byte) formats the number; #148 review follow-up).
+        var buffer = new byte[] { (byte)'a', IAC, IAC, (byte)'b', (byte)'\n' };
+
+        Parse(buffer, buffer.Length, out var commands);
+
+        Assert.Single(commands);
+        Assert.Equal("aÿb", commands[0]);
+    }
+
+    [Fact]
     public void PlainText_TerminatedByNewline_YieldsOneCommand() {
         var buffer = Encoding.ASCII.GetBytes("hello\r");
 


### PR DESCRIPTION
## Vulnerability

Received bytes were accumulated into a per-command `StringBuilder` flushed only on a `\r`/`\n`/`\0` delimiter, with **no maximum length**. A client streaming bytes without a delimiter grows the buffer until `OutOfMemoryException`. On `SocketServer` the OOM surfaces on a ThreadPool callback (`OnDataReceived`) and can **kill the process** — and the server binds `0.0.0.0` **unauthenticated**, so this is a remote, unauthenticated DoS. The same unbounded pattern existed in `SerialServer.Read` and `SocketClient.Connect`.

## Fix

One shared cap, `CommandAccumulator.MaxCommandLength = 4096` chars, enforced at all three accumulation sites. Rationale: MCEControl commands are short (command names plus modest arguments, typically well under 100 chars), so 4 KB is generous headroom that never truncates legitimate traffic — including long `chars:` payloads — while bounding per-connection memory at a harmless size, in line with the "a few KB" guidance in #148.

Per-server overflow behavior:

| Server | On overflow |
|---|---|
| `SocketServer` | Drop the builder, emit an error notification, **close the offending connection** (`ParseReceivedData` returns `false`; new internal `ProcessReceivedData` seam closes via `CloseSocket`). A client past the cap is hostile or broken. |
| `SerialServer` | Drop the builder, log an error **once**, discard input until the next delimiter, then resume — the tail of an oversized run never surfaces as a garbage command and the next valid command parses normally. |
| `SocketClient` | Same reset-and-discard behavior as `SerialServer`. |

`SerialServer` and `SocketClient` now share the new internal `CommandAccumulator` (own file per MCEC0001); `SocketServer` keeps its telnet-aware `ParseReceivedData` and enforces the same const at both of its append sites (including the escaped-IAC path).

## Tests (test-first; red confirmed before cap was implemented)

No live listeners / no non-loopback binds — tests drive internal seams (`InternalsVisibleTo`), same style as the #147 tests.

- `tests/MCEControl.xUnit/Services/CommandAccumulatorTests.cs` (6 tests): delimiter parsing preserved (CR/LF/NUL, empty lines ignored); delimiter-less flood never exceeds the cap; overflow notifies exactly once and resets the buffer; oversized run (and its tail) is dropped and the next valid command still parses; exact-cap command is delivered untruncated.
- `tests/MCEControl.xUnit/Services/SocketServerReceiveCapTests.cs` (4 tests): `ParseReceivedData` never lets `CmdBuilder` exceed the cap and drops it on overflow; exact-cap command still parses; a delimiter-less flood through `ProcessReceivedData` logs an error and **closes the offending client** (asserted via the `TrackedClients`/`ConnectedClientCount` seams and `SafeHandle.IsClosed`); valid commands are emitted and keep the client connected.

Full suite: **362 passed, 0 failed** (`dotnet build MCEControl.slnx` + `dotnet test tests/MCEControl.xUnit`), only pre-existing WFDEV004 warning.

## Review follow-up (commit b70ea61)

Independent review approved with findings; all resolved test-first:

- **MINOR-1** — the escaped-IAC path in `ParseReceivedData` used `Append(verb)`, hitting the `StringBuilder.Append(byte)` overload which appends the decimal **string** `"255"` (3 chars) instead of a single literal `(char)255` — contradicting its own comment, and letting a 3-char append after the `>= cap` check reach cap+2. **Behavior fix**: `Append((char)verb)` — an escaped `IAC IAC` now yields one `(char)0xFF` in the command instead of the text `255`. Two tests added first and confirmed red: `LiteralIacEscape_AppendsSingleChar255ToCommand` and `ParseReceivedData_EscapedIacAppendSite_NeverExceedsCap`.
- **NIT-3** — hoisted the `onOverflow` `Action` out of the per-character read loops in `SerialServer.Read` and `SocketClient.Connect` (no more per-char lambda allocation).
- **NIT-4** — removed the pre-existing unused `StringBuilder currentCmd` in `SocketClient.Start`.
- **NIT-5** — the flood-test socket in `SocketServerReceiveCapTests` is now in a `using` so an assertion failure cannot leak it.

Full suite after follow-up: **364 passed, 0 failed**.

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU
