### PR TITLE
fix(agent): enforce loopback-only bind for the MCP HTTP transport (#152)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -40,10 +40,15 @@ does **not** turn the others on.
 
 2. **The MCP / HTTP façade is DISABLED by default.**
    The network-facing server (`McpServerEnabled`) is off unless you opt in. Even when
-   enabled, the HTTP floor **binds to localhost only** (`McpBindAddress = 127.0.0.1`),
-   so it is not reachable from other machines. There is no remote binding default and
-   no authentication bypass — if you need off-box access, front it with your own
-   reverse proxy and auth.
+   enabled, the HTTP floor **binds to localhost only** — and this is **enforced**, not
+   just a default ([#152]): `McpBindAddress` must be `localhost` or a literal loopback
+   IP (any `127.x.y.z`, or `::1` / `[::1]`). Anything else — the `HttpListener`
+   wildcards `+` and `*`, the all-interfaces addresses `0.0.0.0` and `::`, non-loopback
+   IPs, or any other hostname (names are never DNS-resolved) — makes MCEC **refuse to
+   start the HTTP listener at all**, logging a loud error instead. So the endpoint is
+   never reachable from other machines. If you need off-box access, front it with your
+   own reverse proxy and auth (native remote exposure, if ever added, is gated on the
+   authentication work in [#143]).
 
 3. **Every agent action is loudly audited.**
    Each agent command logs an `AGENT-AUDIT:` line (action + target) before it runs.
@@ -427,7 +432,10 @@ Content-Type: application/json
 
 The address and port come from `McpBindAddress` (default `127.0.0.1`) and `McpHttpPort`
 (default `5151`). This is a deliberately minimal floor for local scripts and agents; it
-is not a general-purpose web API and is not exposed off-box by default.
+is not a general-purpose web API and is never exposed off-box: the bind address is
+validated at startup ([#152]) and only `localhost` or a literal loopback IP (`127.x.y.z`,
+`::1`, `[::1]`) is accepted — with any other value the listener refuses to start and MCEC
+logs a loud error explaining what to change.
 
 The floor is hardened against resource exhaustion ([#151]): a request body larger than
 **1 MB** is refused with `413` (the cap is enforced by a bounded read, so chunked bodies
@@ -435,6 +443,8 @@ without a `Content-Length` can't bypass it), and at most **16** requests are ser
 concurrently — past that the server answers `503` rather than queueing.
 
 [#151]: https://github.com/tig/mcec/issues/151
+[#152]: https://github.com/tig/mcec/issues/152
+[#143]: https://github.com/tig/mcec/issues/143
 
 ---
 

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -42,10 +42,15 @@ does **not** turn the others on.
    The network-facing server (`McpServerEnabled`) is off unless you opt in. Even when
    enabled, the HTTP floor **binds to localhost only** — and this is **enforced**, not
    just a default ([#152]): `McpBindAddress` must be `localhost` or a literal loopback
-   IP (any `127.x.y.z`, or `::1` / `[::1]`). Anything else — the `HttpListener`
-   wildcards `+` and `*`, the all-interfaces addresses `0.0.0.0` and `::`, non-loopback
-   IPs, or any other hostname (names are never DNS-resolved) — makes MCEC **refuse to
-   start the HTTP listener at all**, logging a loud error instead. So the endpoint is
+   IP (any `127.x.y.z`, or `::1` / `[::1]`). Any accepted address is **canonicalized**
+   before it reaches the listener — so obfuscated loopback spellings the OS parser still
+   reads as loopback (e.g. `127.1`, `0x7f.0.0.1`, `2130706433`, `::ffff:127.0.0.1`) are
+   normalized to a plain loopback literal (`127.0.0.1` / `[::1]`) rather than passed
+   through raw, closing a path where the underlying HTTP stack could treat the raw form
+   as a wildcard binding. Anything else — the `HttpListener` wildcards `+` and `*`, the
+   all-interfaces addresses `0.0.0.0` and `::`, non-loopback IPs, or any other hostname
+   (names are never DNS-resolved) — makes MCEC **refuse to start the HTTP listener at
+   all**, logging a loud error instead. So the endpoint is
    never reachable from other machines. If you need off-box access, front it with your
    own reverse proxy and auth (native remote exposure, if ever added, is gated on the
    authentication work in [#143]).
@@ -434,7 +439,8 @@ The address and port come from `McpBindAddress` (default `127.0.0.1`) and `McpHt
 (default `5151`). This is a deliberately minimal floor for local scripts and agents; it
 is not a general-purpose web API and is never exposed off-box: the bind address is
 validated at startup ([#152]) and only `localhost` or a literal loopback IP (`127.x.y.z`,
-`::1`, `[::1]`) is accepted — with any other value the listener refuses to start and MCEC
+`::1`, `[::1]`) is accepted — accepted addresses are canonicalized to a plain loopback
+literal before binding, and any other value makes the listener refuse to start while MCEC
 logs a loud error explaining what to change.
 
 The floor is hardened against resource exhaustion ([#151]): a request body larger than

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -22,7 +22,10 @@ namespace MCEControl;
 ///
 /// SECURITY: the observation tools (capture/query/find/invoke) only run when
 /// <see cref="AgentRuntime.AgentCommandsEnabled"/> is true; otherwise a tool call is reported as an
-/// error. The HTTP listener binds to <see cref="AppSettings.McpBindAddress"/> (127.0.0.1 by default).
+/// error. The HTTP listener binds to <see cref="AppSettings.McpBindAddress"/> (127.0.0.1 by default),
+/// and loopback-only is ENFORCED (#152): <see cref="StartHttp"/> refuses to start — with a loud error —
+/// unless the address is <c>localhost</c> or a literal loopback IP (see
+/// <see cref="IsLoopbackBindAddress"/>); wildcards and non-loopback values never reach HttpListener.
 /// Every tool call is loudly audit-logged.
 /// </summary>
 public static class AgentServer {
@@ -821,6 +824,31 @@ public static class AgentServer {
     // HTTP transport (localhost floor)
     // -------------------------------------------------------------------------------------------
 
+    /// <summary>
+    /// Whether <paramref name="address"/> is a bind address <see cref="StartHttp"/> will accept (#152):
+    /// the literal hostname <c>localhost</c>, or a literal IP address that
+    /// <see cref="IPAddress.IsLoopback"/> confirms is loopback (any 127.0.0.0/8 address, or <c>::1</c>,
+    /// optionally bracketed as <c>[::1]</c>). Everything else is rejected: the HttpListener wildcards
+    /// <c>+</c> and <c>*</c>, the all-interfaces addresses <c>0.0.0.0</c> and <c>::</c>, any
+    /// non-loopback IP, and any hostname other than <c>localhost</c>. Hostnames are deliberately NOT
+    /// resolved via DNS — a name could resolve to a non-loopback interface, so only the one literal
+    /// name is trusted.
+    /// </summary>
+    internal static bool IsLoopbackBindAddress(string? address) {
+        if (string.IsNullOrWhiteSpace(address)) {
+            return false;
+        }
+        string candidate = address.Trim();
+        if (string.Equals(candidate, "localhost", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+        // An IPv6 literal may be written bracketed ([::1]), as it appears inside a URL/prefix.
+        if (candidate.Length >= 2 && candidate[0] == '[' && candidate[^1] == ']') {
+            candidate = candidate[1..^1];
+        }
+        return IPAddress.TryParse(candidate, out IPAddress? ip) && IPAddress.IsLoopback(ip);
+    }
+
     public static void StartHttp() {
         AppSettings? settings = AgentRuntime.Settings;
         if (settings is null) {
@@ -830,7 +858,27 @@ public static class AgentServer {
             if (_listener is not null) {
                 return;
             }
-            string prefix = $"http://{settings.McpBindAddress}:{settings.McpHttpPort}/";
+            // SECURITY (#152): enforce the documented "localhost only" contract BEFORE the address ever
+            // reaches HttpListener. The MCP endpoint has no authentication (#143), so binding all
+            // interfaces (a config typo like "+", "*", or "0.0.0.0") would hand unauthenticated UI
+            // automation + screen capture to the whole network. Refuse to start rather than bind.
+            if (!IsLoopbackBindAddress(settings.McpBindAddress)) {
+                Logger.Instance.Log4.Error(
+                    $"AgentServer: REFUSING to start the MCP HTTP transport: McpBindAddress '{settings.McpBindAddress}' " +
+                    "is not a loopback address. The agent endpoint has no authentication, so a non-loopback bind would " +
+                    "expose UI automation and screen capture to the network. Set <McpBindAddress> in mcec.settings to " +
+                    "\"localhost\", \"127.0.0.1\", \"::1\", or another literal loopback IP (127.x.y.z). " +
+                    "Wildcards (\"+\", \"*\"), all-interfaces addresses (\"0.0.0.0\", \"::\"), other IPs, and other " +
+                    "hostnames are rejected. Remote exposure, if ever supported, requires the auth work tracked in #143.");
+                return;
+            }
+            // Normalize the validated address for the prefix: trim stray whitespace and bracket a bare
+            // IPv6 literal ("::1" must appear as "[::1]" in an HttpListener prefix).
+            string host = settings.McpBindAddress.Trim();
+            if (host.Contains(':') && !host.StartsWith('[')) {
+                host = $"[{host}]";
+            }
+            string prefix = $"http://{host}:{settings.McpHttpPort}/";
             HttpListener listener = new();
             listener.Prefixes.Add(prefix);
             try {

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -825,29 +826,58 @@ public static class AgentServer {
     // -------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// Whether <paramref name="address"/> is a bind address <see cref="StartHttp"/> will accept (#152):
-    /// the literal hostname <c>localhost</c>, or a literal IP address that
-    /// <see cref="IPAddress.IsLoopback"/> confirms is loopback (any 127.0.0.0/8 address, or <c>::1</c>,
-    /// optionally bracketed as <c>[::1]</c>). Everything else is rejected: the HttpListener wildcards
-    /// <c>+</c> and <c>*</c>, the all-interfaces addresses <c>0.0.0.0</c> and <c>::</c>, any
-    /// non-loopback IP, and any hostname other than <c>localhost</c>. Hostnames are deliberately NOT
-    /// resolved via DNS — a name could resolve to a non-loopback interface, so only the one literal
-    /// name is trusted.
+    /// Validates <paramref name="address"/> as a loopback bind address AND canonicalizes it into the
+    /// exact host string <see cref="StartHttp"/> puts in the <see cref="HttpListener"/> prefix (#152).
+    /// Returns true only for the literal hostname <c>localhost</c> or a literal IP that
+    /// <see cref="IPAddress.IsLoopback"/> confirms is loopback; on success <paramref name="prefixHost"/>
+    /// is the CANONICAL form — <c>localhost</c>, a dotted IPv4 literal (<c>127.0.0.1</c>), or a bracketed
+    /// IPv6 literal (<c>[::1]</c>).
+    /// <para>
+    /// Canonicalizing is load-bearing, not cosmetic. <see cref="IPAddress.TryParse"/> also blesses
+    /// obfuscated loopback spellings — <c>0x7f.0.0.1</c>, <c>127.1</c>, <c>2130706433</c>,
+    /// <c>127.00.00.01</c>, <c>::ffff:127.0.0.1</c> — as loopback, but <c>http.sys</c> parses those RAW
+    /// strings differently: some register as hostname/wildcard bindings that, under an elevated MCEC,
+    /// bind non-loopback, so a LAN attacker with a matching <c>Host</c> header would reach the
+    /// unauthenticated (#143) endpoint. Building the prefix from <c>ip.ToString()</c> instead collapses
+    /// every accepted form to a literal <c>http.sys</c> binds to loopback (an IPv4-mapped IPv6 loopback
+    /// is folded to its IPv4 literal). Everything else is rejected: the HttpListener wildcards <c>+</c>
+    /// and <c>*</c>, the all-interfaces addresses <c>0.0.0.0</c> and <c>::</c>, any non-loopback IP, and
+    /// any hostname other than <c>localhost</c>. Hostnames are deliberately NOT resolved via DNS — a
+    /// name could resolve to a non-loopback interface, so only the one literal name is trusted.
+    /// </para>
     /// </summary>
-    internal static bool IsLoopbackBindAddress(string? address) {
+    internal static bool TryGetLoopbackPrefixHost(string? address, out string prefixHost) {
+        prefixHost = string.Empty;
         if (string.IsNullOrWhiteSpace(address)) {
             return false;
         }
         string candidate = address.Trim();
         if (string.Equals(candidate, "localhost", StringComparison.OrdinalIgnoreCase)) {
+            prefixHost = "localhost";
             return true;
         }
         // An IPv6 literal may be written bracketed ([::1]), as it appears inside a URL/prefix.
         if (candidate.Length >= 2 && candidate[0] == '[' && candidate[^1] == ']') {
             candidate = candidate[1..^1];
         }
-        return IPAddress.TryParse(candidate, out IPAddress? ip) && IPAddress.IsLoopback(ip);
+        if (!IPAddress.TryParse(candidate, out IPAddress? ip) || !IPAddress.IsLoopback(ip)) {
+            return false;
+        }
+        // Fold an IPv4-mapped IPv6 loopback (::ffff:127.0.0.1) to its IPv4 literal so the prefix
+        // http.sys sees is an unambiguous 127.x.y.z, not a form it may treat as a hostname registration.
+        if (ip.IsIPv4MappedToIPv6) {
+            ip = ip.MapToIPv4();
+        }
+        prefixHost = ip.AddressFamily == AddressFamily.InterNetworkV6 ? $"[{ip}]" : ip.ToString();
+        return true;
     }
+
+    /// <summary>
+    /// Whether <paramref name="address"/> is a bind address <see cref="StartHttp"/> will accept (#152):
+    /// the thin predicate over <see cref="TryGetLoopbackPrefixHost"/>. See that method for the accepted
+    /// set and why an accepted address is canonicalized before it ever reaches <see cref="HttpListener"/>.
+    /// </summary>
+    internal static bool IsLoopbackBindAddress(string? address) => TryGetLoopbackPrefixHost(address, out _);
 
     public static void StartHttp() {
         AppSettings? settings = AgentRuntime.Settings;
@@ -859,10 +889,13 @@ public static class AgentServer {
                 return;
             }
             // SECURITY (#152): enforce the documented "localhost only" contract BEFORE the address ever
-            // reaches HttpListener. The MCP endpoint has no authentication (#143), so binding all
-            // interfaces (a config typo like "+", "*", or "0.0.0.0") would hand unauthenticated UI
-            // automation + screen capture to the whole network. Refuse to start rather than bind.
-            if (!IsLoopbackBindAddress(settings.McpBindAddress)) {
+            // reaches HttpListener, and build the prefix from the CANONICALIZED host (not the raw
+            // settings string) so obfuscated loopback spellings http.sys would treat as wildcard
+            // hostname registrations can't slip through. The MCP endpoint has no authentication (#143),
+            // so binding all interfaces (a config typo like "+", "*", or "0.0.0.0") would hand
+            // unauthenticated UI automation + screen capture to the whole network. Refuse to start
+            // rather than bind.
+            if (!TryGetLoopbackPrefixHost(settings.McpBindAddress, out string prefixHost)) {
                 Logger.Instance.Log4.Error(
                     $"AgentServer: REFUSING to start the MCP HTTP transport: McpBindAddress '{settings.McpBindAddress}' " +
                     "is not a loopback address. The agent endpoint has no authentication, so a non-loopback bind would " +
@@ -872,13 +905,7 @@ public static class AgentServer {
                     "hostnames are rejected. Remote exposure, if ever supported, requires the auth work tracked in #143.");
                 return;
             }
-            // Normalize the validated address for the prefix: trim stray whitespace and bracket a bare
-            // IPv6 literal ("::1" must appear as "[::1]" in an HttpListener prefix).
-            string host = settings.McpBindAddress.Trim();
-            if (host.Contains(':') && !host.StartsWith('[')) {
-                host = $"[{host}]";
-            }
-            string prefix = $"http://{host}:{settings.McpHttpPort}/";
+            string prefix = $"http://{prefixHost}:{settings.McpHttpPort}/";
             HttpListener listener = new();
             listener.Prefixes.Add(prefix);
             try {

--- a/tests/MCEControl.xUnit/Services/AgentServerBindAddressTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerBindAddressTests.cs
@@ -1,0 +1,102 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Tests for the loopback-only bind enforcement (#152). <c>McpBindAddress</c> used to be interpolated
+/// straight into the HttpListener prefix, so a config typo like <c>+</c>, <c>*</c>, or <c>0.0.0.0</c>
+/// bound the unauthenticated (#143) MCP endpoint to every interface. These prove the validation seam
+/// (<see cref="AgentServer.IsLoopbackBindAddress"/>) accepts only <c>localhost</c> and literal loopback
+/// IPs, and that <see cref="AgentServer.StartHttp"/> refuses to open a listener at all for anything else.
+/// NOTE: no test here ever actually binds a non-loopback address — the point is that the listener never
+/// starts.
+/// </summary>
+[Collection("AgentSerial")]
+public class AgentServerBindAddressTests {
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("LOCALHOST")] // hostnames are case-insensitive
+    [InlineData("127.0.0.1")]
+    [InlineData("127.0.0.2")] // any 127/8 literal is loopback
+    [InlineData("127.255.255.254")]
+    [InlineData("::1")]
+    [InlineData("[::1]")] // bracketed IPv6 literal, as it appears inside a URL
+    [InlineData(" 127.0.0.1 ")] // stray whitespace from hand-edited XML settings
+    public void IsLoopbackBindAddress_LoopbackValues_Accepted(string address) {
+        Assert.True(AgentServer.IsLoopbackBindAddress(address));
+    }
+
+    [Theory]
+    [InlineData("+")] // HttpListener wildcard: all interfaces
+    [InlineData("*")] // HttpListener weak wildcard: all interfaces
+    [InlineData("0.0.0.0")] // IPv4 any
+    [InlineData("::")] // IPv6 any
+    [InlineData("[::]")]
+    [InlineData("192.168.1.5")] // non-loopback literal IP
+    [InlineData("10.0.0.1")]
+    [InlineData("evil.example.com")] // hostnames other than localhost are never resolved — could point anywhere
+    [InlineData("localhost.attacker.com")]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void IsLoopbackBindAddress_NonLoopbackValues_Rejected(string? address) {
+        Assert.False(AgentServer.IsLoopbackBindAddress(address));
+    }
+
+    /// <summary>Asks the OS for a free loopback TCP port by binding to port 0 and reading the assignment.</summary>
+    private static int FindFreeLoopbackPort() {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        try {
+            listener.Start();
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public void StartHttp_NonLoopbackBindAddress_DoesNotOpenAListener() {
+        // A settings file with McpBindAddress=0.0.0.0 must NOT start the HTTP transport at all —
+        // not on all interfaces, and not "fixed up" to loopback either. Proof: after StartHttp,
+        // nothing accepts a connection on the port, even from loopback.
+        int port = FindFreeLoopbackPort();
+        AgentRuntime.Settings = new AppSettings { McpBindAddress = "0.0.0.0", McpHttpPort = port };
+        try {
+            AgentServer.StartHttp();
+
+            using TcpClient probe = new();
+            SocketException refused = Assert.Throws<SocketException>(() => probe.Connect(IPAddress.Loopback, port));
+            Assert.Equal(SocketError.ConnectionRefused, refused.SocketErrorCode);
+        }
+        finally {
+            AgentServer.StopHttp(); // no-op if (correctly) never started; cleanup if the test fails
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void StartHttp_LoopbackLocalhostName_StillStarts() {
+        // "localhost" is the one hostname the validator accepts; the listener must still come up.
+        int port = FindFreeLoopbackPort();
+        AgentRuntime.Settings = new AppSettings { McpBindAddress = "localhost", McpHttpPort = port };
+        try {
+            AgentServer.StartHttp();
+
+            using TcpClient probe = new();
+            probe.Connect(IPAddress.Loopback, port); // throws if the listener did not start
+            Assert.True(probe.Connected);
+        }
+        finally {
+            AgentServer.StopHttp();
+            AgentRuntime.Settings = null;
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Services/AgentServerBindAddressTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerBindAddressTests.cs
@@ -29,8 +29,48 @@ public class AgentServerBindAddressTests {
     [InlineData("::1")]
     [InlineData("[::1]")] // bracketed IPv6 literal, as it appears inside a URL
     [InlineData(" 127.0.0.1 ")] // stray whitespace from hand-edited XML settings
+    // Obfuscated-but-loopback forms IPAddress.TryParse blesses (see the normalized-host theory for why
+    // they must be canonicalized, not passed raw, before reaching http.sys):
+    [InlineData("0x7f.0.0.1")]
+    [InlineData("127.1")]
+    [InlineData("2130706433")]
+    [InlineData("127.00.00.01")]
+    [InlineData("::ffff:127.0.0.1")] // IPv4-mapped IPv6 loopback
     public void IsLoopbackBindAddress_LoopbackValues_Accepted(string address) {
         Assert.True(AgentServer.IsLoopbackBindAddress(address));
+    }
+
+    [Theory]
+    // The prefix host StartHttp feeds HttpListener must ALWAYS be a canonical loopback literal, never
+    // the raw obfuscated string (#152 review follow-up). http.sys parses forms like 0x7f.0.0.1 and
+    // ::ffff:127.0.0.1 as hostname/wildcard registrations that, under an elevated MCEC, bind
+    // non-loopback — so a LAN attacker with a matching Host header would reach the unauthenticated
+    // endpoint. Canonicalizing via the parsed IPAddress collapses every accepted form to a literal
+    // http.sys binds to loopback.
+    [InlineData("localhost", "localhost")]
+    [InlineData("LOCALHOST", "localhost")]
+    [InlineData(" 127.0.0.1 ", "127.0.0.1")]
+    [InlineData("127.0.0.2", "127.0.0.2")]
+    [InlineData("0x7f.0.0.1", "127.0.0.1")]
+    [InlineData("127.1", "127.0.0.1")]
+    [InlineData("2130706433", "127.0.0.1")]
+    [InlineData("127.00.00.01", "127.0.0.1")]
+    [InlineData("::1", "[::1]")]
+    [InlineData("[::1]", "[::1]")]
+    [InlineData("::ffff:127.0.0.1", "127.0.0.1")] // IPv4-mapped IPv6 collapses to its IPv4 literal
+    public void TryGetLoopbackPrefixHost_AcceptedValue_NormalizesToCanonicalLoopbackLiteral(string address, string expectedHost) {
+        Assert.True(AgentServer.TryGetLoopbackPrefixHost(address, out string host));
+        Assert.Equal(expectedHost, host);
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("192.168.1.5")]
+    [InlineData("evil.example.com")]
+    [InlineData("")]
+    public void TryGetLoopbackPrefixHost_RejectedValue_ReturnsFalseAndEmptyHost(string address) {
+        Assert.False(AgentServer.TryGetLoopbackPrefixHost(address, out string host));
+        Assert.Equal("", host);
     }
 
     [Theory]


### PR DESCRIPTION
## Risk

`McpBindAddress` was an unvalidated free string interpolated straight into the `HttpListener` prefix. Setting it to `+`, `*`, or `0.0.0.0` bound the MCP endpoint to **all interfaces** — and since the endpoint has no authentication (#143), a single config typo turned into unauthenticated remote UI automation and screen capture from anywhere on the network. The doc comment and `docs/agent-server.md` both claimed "binds to localhost only," but nothing enforced it.

## Enforcement rules

`AgentServer.StartHttp` now validates the address via a pure seam, `AgentServer.TryGetLoopbackPrefixHost` (with `IsLoopbackBindAddress` as its bool predicate), **before** the value ever reaches `HttpListener`, and builds the prefix from the **canonicalized** host it returns — never the raw settings string:

| Value | Result |
| --- | --- |
| `localhost` (any case) | accepted → prefix host `localhost` (the one hostname; never DNS-resolved) |
| `127.0.0.1`, `127.0.0.2`, any `127.x.y.z` | accepted (`IPAddress.IsLoopback`) → canonical dotted literal |
| `::1`, `[::1]` | accepted → bracketed IPv6 literal `[::1]` |
| `+`, `*` (HttpListener wildcards) | **rejected** |
| `0.0.0.0`, `::`, `[::]` (all interfaces) | **rejected** |
| `192.168.1.5`, any non-loopback IP | **rejected** |
| `evil.example.com`, any other hostname | **rejected** — hostnames are deliberately not resolved; a name could point at a non-loopback interface |
| empty / whitespace | **rejected** |

## Failure behavior

With a non-loopback value the HTTP listener **refuses to start at all** (it is not "fixed up" to loopback), and MCEC logs a loud `Log4.Error` explaining exactly why and what to set `<McpBindAddress>` to — following the file's existing error-notification convention for listener start failures. stdio transport and the rest of MCEC are unaffected.

## Review follow-up: canonicalization (closed elevation gap)

An independent security review found a **parse-vs-bind gap**. The validator accepted any spelling `IPAddress.TryParse` blesses as loopback — `0x7f.0.0.1`, `127.1`, `2130706433`, `127.00.00.01`, `::ffff:127.0.0.1` — but the original fix built the `HttpListener` prefix from the **raw settings string**, not the parsed IP. `http.sys` parses those obfuscated forms differently: some register as hostname/wildcard bindings that, under an **elevated** MCEC, bind non-loopback, so a LAN attacker sending a matching `Host` header would reach the unauthenticated endpoint.

Fix: the validation seam now **canonicalizes** — it returns the exact prefix host, and `StartHttp` builds the prefix from that. For IPv4 (including the obfuscated decimal/hex/short forms) it emits `ip.ToString()`; an IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1`) is folded to its IPv4 literal via `MapToIPv4()`; a real IPv6 loopback is bracketed; `localhost` stays the literal `localhost`. Every accepted form therefore collapses to a canonical loopback literal `http.sys` binds to loopback — closing the elevation gap — while non-loopback values are still rejected outright.

## Deferral

Native remote exposure (an explicit "I understand this is remote-exposed" opt-in plus mandatory auth), if ever wanted, is **deferred to #143** (P1, Host/Origin validation + bearer token). This PR is strictly the loopback-only enforcement.

## Tests

`tests/MCEControl.xUnit/Services/AgentServerBindAddressTests.cs` (written failing-first):
- `IsLoopbackBindAddress_LoopbackValues_Accepted` / `IsLoopbackBindAddress_NonLoopbackValues_Rejected` — accept/reject matrix over the predicate, including the obfuscated loopback spellings.
- `TryGetLoopbackPrefixHost_AcceptedValue_NormalizesToCanonicalLoopbackLiteral` — asserts each accepted form (incl. `0x7f.0.0.1`, `127.1`, `2130706433`, `127.00.00.01`, `::ffff:127.0.0.1`) yields the **canonical** prefix host (`127.0.0.1` / `[::1]` / `localhost`), i.e. asserts on the normalized output, not just a bool. These fail before the canonicalization fix.
- `TryGetLoopbackPrefixHost_RejectedValue_ReturnsFalseAndEmptyHost` — rejects return false + empty host.
- Behavior: `StartHttp` with `McpBindAddress = "0.0.0.0"` opens **no** listener (a loopback connect to the configured port is refused); `McpBindAddress = "localhost"` still starts the listener.
- No test ever binds a non-loopback address.

Full suite: **417 passed, 0 failed** (22 pre-existing input-simulator skips). `dotnet build MCEControl.slnx` clean.

Docs: `docs/agent-server.md` security section and HTTP-floor section now state loopback-only as *enforced*, with the accepted-values list and the note that accepted addresses are canonicalized before binding; `AgentServer` class doc comment updated. `src/Agent/AgentInstructions.md` does not mention bind address (transport config is operator-side), so it is unchanged.

## Merge reconciliation with #143 (2026-07-02)

After #143 (token-gated off-box binding) landed on develop, `StartHttp` had two security models to reconcile. Composed so neither is lost: a **loopback** bind is canonicalized (#152, no token needed); a **non-loopback** bind is a deliberate off-box exposure allowed **only with `McpAuthToken`** (#143), else the listener refuses to start. This keeps #152's anti-obfuscation canonicalization AND #143's token-gated remote feature. Docs in agent-server.md updated to the composed rule; full suite green (534 passed).

Fixes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU

