### PR TITLE
fix(security): block forked PRs from the self-hosted interactive runner (#161)

### DIFF
--- a/.github/workflows/real-windows.yml
+++ b/.github/workflows/real-windows.yml
@@ -43,7 +43,14 @@ jobs:
   real-windows:
     name: Build + Test + Smoke (Interactive Desktop)
     needs: preflight
-    if: needs.preflight.outputs.ready == 'true'
+    # SECURITY (#161): this lane runs untrusted checked-out code (build/test + a desktop smoke script)
+    # on a self-hosted, INTERACTIVE desktop runner — the highest-value target in the pipeline. Never let
+    # a FORKED pull request execute here. Run only for push/workflow_dispatch on trusted branches, and
+    # for pull requests that originate from THIS repository (not a fork).
+    if: >-
+      needs.preflight.outputs.ready == 'true' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, Windows, interactive]   # label your self-hosted runner accordingly
     timeout-minutes: 60                             # backstop so a misconfigured runner fails fast, never the 24h await-runner hang
     permissions:
@@ -55,6 +62,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # SECURITY (#161): don't leave the GITHUB_TOKEN in the runner's git config after checkout on a
+          # persistent self-hosted machine, where a later step (or the next job) could reuse it.
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
Closes #161

## Problem (P1 — forked PR code execution on a self-hosted interactive desktop)

`.github/workflows/real-windows.yml` triggers on `pull_request` and, when enabled (`INTERACTIVE_RUNNER_READY=true`), runs `dotnet build`/`test` plus a desktop smoke script on a **self-hosted, interactive (non-session-0) Windows desktop runner**. The `real-windows` job was gated only on `INTERACTIVE_RUNNER_READY` — **not on PR provenance** — so a **forked pull request could execute arbitrary code on the real desktop runner** (the highest-value target in the pipeline: a logged-in interactive desktop, likely with persistent credentials/tokens). `allow_forking` is enabled, so fork PRs are possible.

## Fix

- **Fork guard on the `real-windows` job:**
  ```yaml
  if: >-
    needs.preflight.outputs.ready == 'true' &&
    (github.event_name != 'pull_request' ||
    github.event.pull_request.head.repo.full_name == github.repository)
  ```
  Runs for `push`/`workflow_dispatch` on trusted branches and for **same-repo** PRs only; a fork PR (`head.repo.full_name != github.repository`) is skipped.
- **`persist-credentials: false`** on `actions/checkout`, so the `GITHUB_TOKEN` isn't left in the runner's git config on the persistent self-hosted machine for a later step to reuse.

## Recommended repo-settings follow-ups (can't be set in a workflow file)

- Actions → "Require approval for all outside collaborators / fork PRs".
- Put the lane behind a protected `environment` with required reviewers.

## Verification

Validated with **actionlint**. The only diagnostic is the pre-existing custom self-hosted label `interactive` (expected for a self-hosted runner label; not introduced by this change). Opening this same-repo PR exercises the `preflight` job (hosted) and correctly **skips** `real-windows` (runner not enabled), confirming the guard parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)