### PR TITLE
fix(capture): cap agent-controlled region dimensions to stop OOM DoS (#158)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -175,6 +175,16 @@ comes back blank the result is a failure with `errorCategory: "capture-blank"` �
 stays in `data` so it is never a *silent* bad image. A blank **region** capture is reported as
 a `capture-blank` warning instead, since a user-specified region can legitimately be empty.
 
+**Region size limits.** Region `width`/`height` are agent-controlled, so they are capped — an
+unbounded region (e.g. `40000x40000` ≈ 6.4 GB of raw ARGB, before PNG encoding and base64) could
+otherwise exhaust the host's memory. A region may be at most **16384 px per side** and
+**64,000,000 px total** (64 MP ≈ 256 MB raw — roughly eight 4K frames). An oversized region is
+**rejected before anything is allocated or captured** — the call fails with
+`errorCode: "region-too-large"` (`errorCategory: "no-target"`) and a detail stating the limit,
+and the rejection is `AGENT-AUDIT:`-logged. The same caps apply to `record` regions (window
+targets need no cap: they are bounded by the window's own size). These limits are fixed, not
+settings: they are an anti-DoS bound sized well beyond real desktop geometry, not a tuning knob.
+
 (Over MCP, `capture` additionally returns the PNG as an `image` content block so the
 model can view it directly, in addition to the JSON text above — including for a blank-frame
 failure, so the agent can see what was grabbed.)
@@ -219,6 +229,11 @@ not failed) keep an agent from producing an unbounded file:
 | `AgentRecordMaxDurationMs` | 60000    | Max recording length (60 s). |
 | `AgentRecordMaxFrames`     | 600      | Hard cap on captured frames. |
 | `AgentRecordMaxWidth`      | 1280     | Frames are downscaled so width fits this. |
+
+A `record` **region** target is additionally subject to the fixed capture region size limits
+(max 16384 px per side, 64,000,000 px total — see
+[Region size limits](#capture-result-example)): an oversized region fails fast with
+`errorCode: "region-too-large"` before any recording starts, rather than being clamped.
 
 A finished `record` (one-shot or `stop`) returns the output path and metadata:
 

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -13,7 +13,10 @@ so you can pick a control instead of guessing pixels; `capture` returns a PNG of
 composited WinUI/WPF surfaces). Use `capture` for a single state check; use `record` ONLY to show CHANGE
 over time — a bounded one-shot (`durationMs`) or `action:start` then `action:stop`; keep recordings short
 (fps/duration are capped and frames downscaled), and remember it captures whatever is on screen for the
-whole duration. An open `start` auto-stops at the operator's limits (default 60 s / 600 frames); `stop`
+whole duration. Region targets (`x`/`y`/`width`/`height`) for `capture` and `record` are size-capped: max
+16384 px per side and 64000000 px total — an oversized region fails fast with `error.code:region-too-large`
+(the detail states the limit); request a smaller region or a window target (windows are bounded by their
+own size). An open `start` auto-stops at the operator's limits (default 60 s / 600 frames); `stop`
 still returns that buffered GIF — exactly once — and after an auto-stop a new recording (`start` or a
 one-shot) is allowed: it discards the unfetched GIF, carrying an `unfetched-recording-discarded` warning
 on its result, so `stop` promptly to collect your output. Check results for trouble: a `capture` with errorCategory `capture-blank` is a black/empty

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -14,7 +14,7 @@ composited WinUI/WPF surfaces). Use `capture` for a single state check; use `rec
 over time — a bounded one-shot (`durationMs`) or `action:start` then `action:stop`; keep recordings short
 (fps/duration are capped and frames downscaled), and remember it captures whatever is on screen for the
 whole duration. Region targets (`x`/`y`/`width`/`height`) for `capture` and `record` are size-capped: max
-16384 px per side and 64000000 px total — an oversized region fails fast with `error.code:region-too-large`
+16384 px per side and 64000000 px total — an oversized region fails fast with `errorCode:region-too-large`
 (the detail states the limit); request a smaller region or a window target (windows are bounded by their
 own size). An open `start` auto-stops at the operator's limits (default 60 s / 600 frames); `stop`
 still returns that buffered GIF — exactly once — and after an auto-stop a new recording (`start` or a

--- a/src/Agent/ScreenCapture.cs
+++ b/src/Agent/ScreenCapture.cs
@@ -26,6 +26,45 @@ public static class ScreenCapture {
     /// <summary>Upper bound on samples per axis; keeps blank analysis O(1) regardless of image size.</summary>
     private const int MaxSamplesPerAxis = 64;
 
+    // SECURITY (#158): region width/height come straight from agent-controlled command attributes
+    // (capture/record), so without a ceiling a single request (e.g. 40000x40000 = ~6.4 GB of ARGB,
+    // then PNG + base64) can OOM the process. Window captures are naturally bounded by window size;
+    // these caps bound the region path. They are fixed (not operator settings) on purpose: they are
+    // an anti-DoS bound sized to plausible desktop geometry, not a quality knob — a raisable setting
+    // would reintroduce the failure mode. Oversized requests FAIL FAST with a clear error (code
+    // `region-too-large`) rather than being silently clamped, so agents get a diagnosable result.
+
+    /// <summary>Max region width or height in pixels — comfortably above any single monitor and
+    /// typical multi-monitor spans (e.g. four 4K displays side by side are 15360 px wide).</summary>
+    public const int MaxRegionDimension = 16384;
+
+    /// <summary>Max region area in pixels (64 MP ≈ 256 MB of ARGB — roughly eight 4K frames, twice
+    /// an 8K frame), bounding the bitmap, the PNG encode, and the base64 reply.</summary>
+    public const int MaxRegionPixels = 64_000_000;
+
+    /// <summary>
+    /// Validates agent-requested region dimensions against the #158 caps. Returns null when the
+    /// region is acceptable, else a human-readable detail (stating the limits) suitable for the
+    /// <c>region-too-large</c> error envelope. The single validation seam used by
+    /// <see cref="CaptureRegionBitmap"/> and the capture/record commands.
+    /// </summary>
+    /// <param name="width">Requested region width in pixels.</param>
+    /// <param name="height">Requested region height in pixels.</param>
+    /// <returns>Null when valid; otherwise the rejection detail.</returns>
+    internal static string? ValidateRegionSize(int width, int height) {
+        if (width <= 0 || height <= 0) {
+            return "Region has no area to capture.";
+        }
+        if (width > MaxRegionDimension || height > MaxRegionDimension) {
+            return $"Region {width}x{height} exceeds the capture limit of {MaxRegionDimension} px per side. Request a smaller region.";
+        }
+        // 64-bit math so a huge product can never wrap around to "valid".
+        if ((long)width * height > MaxRegionPixels) {
+            return $"Region {width}x{height} ({(long)width * height} px) exceeds the capture limit of {MaxRegionPixels} px total. Request a smaller region.";
+        }
+        return null;
+    }
+
     /// <summary>
     /// Captures a top-level window by handle. Uses <c>PrintWindow(PW_RENDERFULLCONTENT)</c>, falling
     /// back to an on-screen blit if that fails, and reports which path ran plus blank-frame stats.
@@ -112,10 +151,13 @@ public static class ScreenCapture {
     /// <param name="width">Region width in pixels.</param>
     /// <param name="height">Region height in pixels.</param>
     /// <returns>A new ARGB bitmap of the region; the caller owns and must dispose it.</returns>
-    /// <exception cref="ArgumentException">Thrown when the region has no area.</exception>
+    /// <exception cref="ArgumentException">Thrown when the region has no area or exceeds
+    /// <see cref="MaxRegionDimension"/>/<see cref="MaxRegionPixels"/> (#158) — thrown BEFORE any
+    /// bitmap is allocated, so an oversized agent request costs nothing.</exception>
     public static Bitmap CaptureRegionBitmap(int x, int y, int width, int height) {
-        if (width <= 0 || height <= 0) {
-            throw new ArgumentException("Region has no area to capture.", nameof(width));
+        string? sizeError = ValidateRegionSize(width, height);
+        if (sizeError is not null) {
+            throw new ArgumentException(sizeError, nameof(width));
         }
 
         Bitmap bmp = new(width, height, PixelFormat.Format32bppArgb);

--- a/src/Commands/CaptureCommand.cs
+++ b/src/Commands/CaptureCommand.cs
@@ -89,6 +89,15 @@ public class CaptureCommand : Command {
             JsonObject data;
 
             if (Width > 0 && Height > 0 && !hasWindowTarget) {
+                // SECURITY (#158): region dimensions are agent-controlled — reject oversized
+                // requests BEFORE any bitmap/PNG/base64 allocation, with a diagnosable envelope.
+                string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
+                if (sizeError is not null) {
+                    AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED — {sizeError}");
+                    Reply?.WriteLine(CommandResult.Fail(Cmd, sizeError, "region-too-large", "no-target").ToJson());
+                    return false;
+                }
+
                 AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height}");
 
                 CaptureResult regionCap = ScreenCapture.CaptureRegion(X, Y, Width, Height);

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -103,10 +103,31 @@ public class RecordCommand : Command {
         }
     }
 
+    /// <summary>True when the command targets an explicit screen region (no window selector given).</summary>
+    private bool IsRegionTarget => Width > 0 && Height > 0 && !HasWindowTarget;
+
+    /// <summary>True when any window selector (title/handle/process/class/foreground) is given.</summary>
+    private bool HasWindowTarget => !string.IsNullOrEmpty(Window)
+        || Handle > 0
+        || !string.IsNullOrEmpty(Process)
+        || !string.IsNullOrEmpty(ClassName)
+        || Foreground;
+
     /// <summary>Starts a recording; for a one-shot, also waits the duration and stops/encodes/writes.</summary>
     private bool DoStart(bool oneshot) {
         if (GifRecorder.IsRecording) {
             return FailWith("A recording is already in progress. Stop it first (action=stop).");
+        }
+
+        // SECURITY (#158): an explicit record region feeds the same CaptureRegionBitmap as
+        // `capture`, so its agent-controlled dimensions get the same fail-fast cap — reject
+        // before any recording starts (window targets are naturally bounded by window size).
+        if (IsRegionTarget) {
+            string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
+            if (sizeError is not null) {
+                AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED — {sizeError}");
+                return FailWith(sizeError, code: "region-too-large", category: "no-target");
+            }
         }
 
         RecordLimits limits = ResolveLimits(oneshot);
@@ -185,13 +206,7 @@ public class RecordCommand : Command {
     /// </summary>
     protected virtual Func<Bitmap>? BuildGrabber(out JsonNode? target, out string? error) {
         error = null;
-        bool hasWindowTarget = !string.IsNullOrEmpty(Window)
-            || Handle > 0
-            || !string.IsNullOrEmpty(Process)
-            || !string.IsNullOrEmpty(ClassName)
-            || Foreground;
-
-        if (Width > 0 && Height > 0 && !hasWindowTarget) {
+        if (IsRegionTarget) {
             int rx = X, ry = Y, rw = Width, rh = Height;
             target = new JsonObject {
                 ["type"] = "region",
@@ -278,10 +293,13 @@ public class RecordCommand : Command {
         return true;
     }
 
-    /// <summary>Writes a failure envelope; the discard warning still rides along when set — warnings
-    /// are valid on failure too, and the discard already happened regardless of this call's outcome.</summary>
-    private bool FailWith(string error, bool warnDiscardedUnfetched = false) {
-        CommandResult result = CommandResult.Fail(Cmd, error);
+    /// <summary>Writes a failure envelope (with the structured code/category taxonomy when given);
+    /// the discard warning still rides along when set — warnings are valid on failure too, and the
+    /// discard already happened regardless of this call's outcome.</summary>
+    private bool FailWith(string error, bool warnDiscardedUnfetched = false, string? code = null, string? category = null) {
+        CommandResult result = code is not null && category is not null
+            ? CommandResult.Fail(Cmd, error, code, category)
+            : CommandResult.Fail(Cmd, error);
         if (warnDiscardedUnfetched) {
             result.Warn(DiscardedWarningCode, DiscardedWarningDetail);
         }

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -194,8 +194,8 @@ public static class AgentServer {
         JsonObject captureProps = WindowTargetProps();
         captureProps["x"] = PropSchema("integer", "Region left (use with width/height instead of a window)");
         captureProps["y"] = PropSchema("integer", "Region top");
-        captureProps["width"] = PropSchema("integer", "Region width");
-        captureProps["height"] = PropSchema("integer", "Region height");
+        captureProps["width"] = PropSchema("integer", "Region width (max 16384/side, 64000000 px total; oversized fails with region-too-large)");
+        captureProps["height"] = PropSchema("integer", "Region height (same limits as width)");
         captureProps["file"] = PropSchema("string", "Optional path to also save the PNG to");
         tools.Add(Tool("capture",
             "Screenshot a window (PrintWindow PW_RENDERFULLCONTENT, captures WinUI/WPF surfaces) or a screen region; returns PNG. Blank/black frames are detected and reported as a capture-blank error (window) or warning (region) rather than a silent bad image.",
@@ -266,8 +266,8 @@ public static class AgentServer {
         JsonObject recordProps = WindowTargetProps();
         recordProps["x"] = PropSchema("integer", "Region left (use with width/height instead of a window)");
         recordProps["y"] = PropSchema("integer", "Region top");
-        recordProps["width"] = PropSchema("integer", "Region width");
-        recordProps["height"] = PropSchema("integer", "Region height");
+        recordProps["width"] = PropSchema("integer", "Region width (max 16384/side, 64000000 px total; oversized fails with region-too-large)");
+        recordProps["height"] = PropSchema("integer", "Region height (same limits as width)");
         recordProps["action"] = PropSchema("string", "start | stop | oneshot (default: oneshot if durationMs given, else start)");
         recordProps["fps"] = PropSchema("integer", "Frames per second (default 5, clamped to the operator limit)");
         recordProps["durationMs"] = PropSchema("integer", "For a one-shot: how long to record (clamped to the operator limit)");

--- a/tests/MCEControl.xUnit/Agent/ScreenCaptureRegionLimitTests.cs
+++ b/tests/MCEControl.xUnit/Agent/ScreenCaptureRegionLimitTests.cs
@@ -1,0 +1,111 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Region size caps (#158 security hardening): agent-controlled region width/height must be bounded
+/// before any Bitmap allocation, or a single capture/record request (e.g. 40000x40000 = ~6.4 GB of
+/// ARGB, plus PNG + base64) can OOM the process. These tests exercise the validation seam
+/// (<see cref="ScreenCapture.ValidateRegionSize"/>) and the throwing guard in
+/// <see cref="ScreenCapture.CaptureRegionBitmap"/> without touching the real desktop.
+/// </summary>
+public class ScreenCaptureRegionLimitTests {
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(1920, 1080)]
+    [InlineData(3840, 2160)] // a full 4K monitor
+    public void ValidateRegionSize_NormalRegions_Accepted(int width, int height) {
+        Assert.Null(ScreenCapture.ValidateRegionSize(width, height));
+    }
+
+    [Fact]
+    public void ValidateRegionSize_MaxDimensionBoundary_Accepted() {
+        // Exactly at the per-side cap (with a tiny other side so the pixel cap is not hit).
+        Assert.Null(ScreenCapture.ValidateRegionSize(ScreenCapture.MaxRegionDimension, 1));
+        Assert.Null(ScreenCapture.ValidateRegionSize(1, ScreenCapture.MaxRegionDimension));
+    }
+
+    [Fact]
+    public void ValidateRegionSize_MaxPixelsBoundary_Accepted() {
+        // Exactly at the total-pixel cap: 8000 * 8000 == MaxRegionPixels.
+        Assert.Equal(64_000_000, ScreenCapture.MaxRegionPixels);
+        Assert.Null(ScreenCapture.ValidateRegionSize(8000, 8000));
+    }
+
+    [Fact]
+    public void ValidateRegionSize_WidthOverMaxDimension_Rejected_DetailStatesLimit() {
+        string? error = ScreenCapture.ValidateRegionSize(ScreenCapture.MaxRegionDimension + 1, 1);
+
+        Assert.NotNull(error);
+        Assert.Contains(ScreenCapture.MaxRegionDimension.ToString(), error);
+    }
+
+    [Fact]
+    public void ValidateRegionSize_HeightOverMaxDimension_Rejected_DetailStatesLimit() {
+        string? error = ScreenCapture.ValidateRegionSize(1, ScreenCapture.MaxRegionDimension + 1);
+
+        Assert.NotNull(error);
+        Assert.Contains(ScreenCapture.MaxRegionDimension.ToString(), error);
+    }
+
+    [Fact]
+    public void ValidateRegionSize_ProductOverMaxPixels_Rejected_DetailStatesLimit() {
+        // Each side is under the per-side cap, but the product (72 MP) exceeds the pixel cap.
+        string? error = ScreenCapture.ValidateRegionSize(9000, 8000);
+
+        Assert.NotNull(error);
+        Assert.Contains(ScreenCapture.MaxRegionPixels.ToString(), error);
+    }
+
+    [Fact]
+    public void ValidateRegionSize_ProductJustOverMaxPixels_Rejected() {
+        // 8001 * 8000 = 64_008_000 — one row over the cap.
+        Assert.NotNull(ScreenCapture.ValidateRegionSize(8001, 8000));
+    }
+
+    [Fact]
+    public void ValidateRegionSize_MaxDimensionSquared_RejectedByPixelCap() {
+        // Both sides at the per-side cap: 16384^2 = 268 MP >> 64 MP. The product check must
+        // use 64-bit math so a large product can never wrap around to "valid".
+        Assert.NotNull(ScreenCapture.ValidateRegionSize(
+            ScreenCapture.MaxRegionDimension, ScreenCapture.MaxRegionDimension));
+    }
+
+    [Theory]
+    [InlineData(0, 100)]
+    [InlineData(100, 0)]
+    [InlineData(-1, 100)]
+    [InlineData(100, -5)]
+    public void ValidateRegionSize_ZeroOrNegative_Rejected(int width, int height) {
+        Assert.NotNull(ScreenCapture.ValidateRegionSize(width, height));
+    }
+
+    [Fact]
+    public void ValidateRegionSize_IntMaxValues_RejectedWithoutOverflow() {
+        Assert.NotNull(ScreenCapture.ValidateRegionSize(int.MaxValue, int.MaxValue));
+    }
+
+    [Fact]
+    public void CaptureRegionBitmap_OversizedRegion_ThrowsBeforeAllocating() {
+        // The issue's attack: 40000x40000 asks GDI+ for ~6.4 GB. The guard must throw the
+        // validation message BEFORE any Bitmap is constructed — the exception message matching
+        // the validation seam's output proves the fast-fail path ran (no allocation, no screen IO).
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => ScreenCapture.CaptureRegionBitmap(0, 0, 40000, 40000));
+
+        Assert.Equal(ScreenCapture.ValidateRegionSize(40000, 40000), ex.Message.Split(" (Parameter")[0]);
+        Assert.Contains(ScreenCapture.MaxRegionDimension.ToString(), ex.Message);
+    }
+
+    [Fact]
+    public void CaptureRegionBitmap_ZeroArea_StillThrows() {
+        // The pre-existing lower-bound behavior must survive the new upper-bound guard.
+        Assert.Throws<ArgumentException>(() => ScreenCapture.CaptureRegionBitmap(0, 0, 0, 100));
+        Assert.Throws<ArgumentException>(() => ScreenCapture.CaptureRegionBitmap(0, 0, 100, -1));
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/CaptureCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CaptureCommandTests.cs
@@ -65,6 +65,60 @@ public class CaptureCommandTests {
     }
 
     [Fact]
+    public void Execute_OversizedRegion_FailsWithRegionTooLarge_BeforeCapturing() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            // The #158 attack: an agent-supplied 40000x40000 region would ask GDI+ for ~6.4 GB.
+            // The command must reject it with a diagnosable envelope (code region-too-large, detail
+            // stating the limits) WITHOUT allocating a bitmap or touching the screen.
+            CapturingReply reply = new();
+            CaptureCommand cmd = new() {
+                Cmd = "capture", Enabled = true, Reply = reply, X = 0, Y = 0, Width = 40000, Height = 40000,
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+            Assert.Equal("region-too-large", json["errorCode"]!.GetValue<string>());
+            Assert.Equal("no-target", json["errorCategory"]!.GetValue<string>());
+            // The detail must tell the agent what the limits are so the failure is recoverable.
+            Assert.Contains(ScreenCapture.MaxRegionDimension.ToString(), json["error"]!.GetValue<string>());
+            // Rejected before capture: no image payload may be present.
+            Assert.Null(json["data"]);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_RegionOverPixelBudget_FailsWithRegionTooLarge() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            // Each side is under the per-side cap; the product (81 MP) exceeds the pixel budget.
+            CapturingReply reply = new();
+            CaptureCommand cmd = new() {
+                Cmd = "capture", Enabled = true, Reply = reply, X = 0, Y = 0, Width = 9000, Height = 9000,
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+            Assert.Equal("region-too-large", json["errorCode"]!.GetValue<string>());
+            Assert.Contains(ScreenCapture.MaxRegionPixels.ToString(), json["error"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
     public void Execute_WhenAgentDisabled_ReturnsFalse_WritesFailureJson() {
         AgentTestSupport.EnsureTelemetry();
         AgentRuntime.Settings = null; // agent commands disabled

--- a/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
@@ -112,6 +112,36 @@ public class RecordCommandTests {
     }
 
     [Fact]
+    public void Execute_StartOversizedRegion_FailsWithRegionTooLarge_WithoutRecording() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            GifRecorder.Stop(); // clear any prior recording
+            // A record region flows into the same CaptureRegionBitmap as capture (#158): an
+            // oversized region must be rejected up front — no recording may start.
+            CapturingReply reply = new();
+            RecordCommand cmd = new() {
+                Cmd = "record", Enabled = true, Reply = reply, Action = "start",
+                X = 0, Y = 0, Width = 40000, Height = 40000,
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            Assert.False(GifRecorder.IsRecording);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+            Assert.Equal("region-too-large", json["errorCode"]!.GetValue<string>());
+            Assert.Equal("no-target", json["errorCategory"]!.GetValue<string>());
+            Assert.Contains(ScreenCapture.MaxRegionDimension.ToString(), json["error"]!.GetValue<string>());
+        }
+        finally {
+            GifRecorder.Stop();
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
     public void Execute_StopWriteFailure_ReturnsError() {
         AgentTestSupport.EnsureTelemetry();
         AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };


### PR DESCRIPTION
## Vulnerability (Security P2, #158)

`ScreenCapture.CaptureRegionBitmap` checked only the lower bound (`width<=0 || height<=0`). The region `width`/`height` attributes of `capture` and `record` are **agent-controlled** and had no ceiling, so a single request like `width=40000 height=40000` asked GDI+ for ~6.4 GB of ARGB; on a large host the bitmap can succeed and the PNG encode + base64 reply (+33%) then produces multi-GB managed allocations → process OOM. Even the throwing path let an agent repeatedly trigger huge transient allocations / GC thrash. Window captures are naturally bounded by window size — this was region-specific.

## Limits chosen + rationale

Fixed caps in `ScreenCapture` (public consts, enforced by a single validation seam `ValidateRegionSize`, used by `CaptureRegionBitmap` and both commands):

| Cap | Value | Rationale |
|---|---|---|
| `MaxRegionDimension` | 16384 px per side | Comfortably above any single monitor and typical multi-monitor spans (four 4K displays side by side = 15360 px). |
| `MaxRegionPixels` | 64,000,000 px total | ~256 MB raw ARGB (≈ eight 4K frames, twice an 8K frame) — bounds the bitmap, the PNG encode, and the base64 reply. Product check uses 64-bit math so it can never wrap to "valid". |

**Consts, not settings — by design.** The issue floated a configurable `AgentCaptureMaxPixels`; I deliberately did not add one. Unlike the `AgentRecordMax*` output-quality knobs, this is an anti-DoS bound sized well beyond real desktop geometry — a setting an operator could raise to 2 GP would reintroduce the exact failure mode. Keeping them consts also gives one enforcement seam that covers both `capture` and `record` (whose region grabber feeds the same `CaptureRegionBitmap`). A knob can be added later if a real rig ever hits the ceiling.

## Error behavior (fail fast, not clamp)

Grossly-over-bounds requests are **rejected before any allocation or screen IO** with a diagnosable envelope, per the shared result contract (#101):

- `errorCode: "region-too-large"`, `errorCategory: "no-target"` (closed taxonomy; recovery = pick a smaller target)
- `error` detail states the actual request and the limit (e.g. `Region 40000x40000 exceeds the capture limit of 16384 px per side. Request a smaller region.`)
- The rejection is `AGENT-AUDIT:`-logged
- `record` rejects at `start`/`oneshot` time — no recording ever starts
- `ScreenCapture.CaptureRegionBitmap` itself throws pre-allocation as defense-in-depth for any other caller

## Doc / guidance updates (standing rule: guidance tracks behavior)

- `src/Agent/AgentInstructions.md` — OBSERVE section now states the region limits and the `region-too-large` code
- `src/Services/AgentServer.cs` — MCP tool schema descriptions for `capture`/`record` `width`/`height` state the limits
- `docs/agent-server.md` — new "Region size limits" section under the `capture` result docs + a note in the `record` safety-limits table (region caps are fail-fast, unlike the clamped record limits)

## Tests (written first; red → green)

- `tests/MCEControl.xUnit/Agent/ScreenCaptureRegionLimitTests.cs` (new): normal regions accepted; exact boundaries accepted (16384×1, 8000×8000 = exactly 64 MP); width/height/product just-over rejected with the limit in the detail; zero/negative rejected; `int.MaxValue` rejected without overflow; `CaptureRegionBitmap(0,0,40000,40000)` throws the validation message (proving the pre-allocation path, no timing assertions, no desktop IO)
- `CaptureCommandTests`: oversized region and over-pixel-budget region → `success:false`, `errorCode region-too-large`, `errorCategory no-target`, detail states the limit, no `data` payload
- `RecordCommandTests`: `action=start` with an oversized region fails with the same envelope and `GifRecorder.IsRecording` stays false

Full suite: **403 passed, 0 failed** (22 pre-existing skips); `dotnet build MCEControl.slnx` clean (analyzers MCEC0001/MCEC0002 quiet). No test captures the real desktop.

## Review follow-up

Independent review approved. Applied: aligned the AgentInstructions.md field name to the flat `errorCode` the agent actually sees (was `error.code`). The reviewer flagged that `no-target` is the least-bad `errorCategory` in the current *closed* taxonomy for a too-large region (the region is the target; `internal` would be worse); the proper long-term fix — adding an `invalid-argument` category to the #101 contract — is tracked in #191.

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU
