### PR TITLE
fix(agent): gate send_command over HTTP behind AgentCommandsEnabled (#153)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -58,10 +58,22 @@ and returns a JSON failure (for commands) — it never silently proceeds.
 `record`/`drag`/`click` — are gated by **both** `AgentCommandsEnabled` **and** the per-command `Enabled`
 flag, over **both** MCP transports (`mcec.exe --mcp` stdio and the HTTP floor): a `tools/call` for a
 command whose `Enabled=false` is refused (`error.code: command-disabled`) even when
-`AgentCommandsEnabled=true`. **`send_command` is the exception** — it is a raw pass-through to the existing
-command engine and does **not** require `AgentCommandsEnabled`; the raw command it runs is still subject to
-that command's own `Enabled` flag in `mcec.commands` (the normal MCEC gate). `McpServerEnabled` gates only
-the HTTP floor; it has no bearing on stdio or on which individual tools may run.
+`AgentCommandsEnabled=true`.
+
+**`send_command` is transport-sensitive (#153).** It is a raw pass-through to the existing command engine,
+so it is a command-injection surface. Over the **local stdio** transport (`mcec.exe --mcp`, launched by its
+client — no network/CSRF surface) it keeps the documented pass-through and does **not** require
+`AgentCommandsEnabled`. Over the **network-facing HTTP floor** it honors the **same `AgentCommandsEnabled`
+gate as every other tool**: with `McpServerEnabled=true` but `AgentCommandsEnabled=false`, a `send_command`
+`tools/call` is refused (`error.code: agent-commands-disabled`) and never executed. This is deliberate
+secure-by-default hardening — enabling the HTTP floor alone must not expose a raw-command surface with no
+agent opt-in, which chained with the missing origin/auth checks ([#143]) is reachable by browser CSRF /
+DNS-rebinding. In **both** cases the raw command it runs is still subject to that command's own `Enabled`
+flag in `mcec.commands` (the normal MCEC gate). `McpServerEnabled` gates only the HTTP floor; it has no
+bearing on stdio or on which individual tools may run.
+
+[#143]: https://github.com/tig/mcec/issues/143
+[#153]: https://github.com/tig/mcec/issues/153
 
 **The command queue is bounded.** Commands (from any client — network, serial, or an agent's
 `send_command`) are queued and executed paced (`CommandPacing` delay between items). To prevent a remote
@@ -450,6 +462,10 @@ Content-Type: application/json
 The address and port come from `McpBindAddress` (default `127.0.0.1`) and `McpHttpPort`
 (default `5151`). This is a deliberately minimal floor for local scripts and agents; it
 is not a general-purpose web API and is not exposed off-box by default.
+
+Over this HTTP transport, `send_command` requires `AgentCommandsEnabled=true` (see *Which gate applies
+where*, above): enabling the floor alone does **not** expose the raw-command pass-through. To drive
+`send_command` without opting into the agent surface, use the local stdio transport (`mcec.exe --mcp`).
 
 The floor is hardened against resource exhaustion ([#151]): a request body larger than
 **1 MB** is refused with `413` (the cap is enforced by a bounded read, so chunked bodies

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -104,5 +104,9 @@ immediately, tell the user, and do NOT retry; nothing will actuate until they re
 
 SECURITY: the agent tools (capture/query/displays/find/invoke/record/launch/drag/click) only work when the operator has set
 AgentCommandsEnabled=true; otherwise they return an error — surface that to the user rather than retrying.
+`send_command` is also gated by AgentCommandsEnabled when you are connected over the HTTP transport (it is
+refused with `error.code:agent-commands-disabled` if the agent surface is not opted in); over the local
+stdio transport (`mcec.exe --mcp`) `send_command` remains available without that opt-in. Either way the raw
+command it runs still needs its own command Enabled in mcec.commands.
 `provision-session` additionally requires AllowSessionProvisioning, and any tool is refused with
 `emergency-stopped` while the operator's emergency stop is engaged. Every action is audit-logged on the host.

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -79,9 +79,11 @@ public static class AgentServer {
 
     /// <summary>
     /// Dispatches a single JSON-RPC request object and returns the response object, or null when the
-    /// request is a notification (no <c>id</c>) and therefore takes no response.
+    /// request is a notification (no <c>id</c>) and therefore takes no response. <paramref name="transport"/>
+    /// defaults to <see cref="AgentTransport.Stdio"/> — the local, opt-in-preserving path; the HTTP floor
+    /// passes <see cref="AgentTransport.Http"/> so <c>send_command</c> honors the network gate (#153).
     /// </summary>
-    public static JsonObject? Dispatch(JsonObject request) {
+    public static JsonObject? Dispatch(JsonObject request, AgentTransport transport = AgentTransport.Stdio) {
         if (request is null) {
             throw new ArgumentNullException(nameof(request));
         }
@@ -108,7 +110,7 @@ public static class AgentServer {
                 return Result(idNode, new JsonObject { ["tools"] = BuildToolsList() });
 
             case "tools/call":
-                JsonObject callResult = CallTool(prms);
+                JsonObject callResult = CallTool(prms, transport);
                 return Result(idNode, callResult);
 
             default:
@@ -328,7 +330,7 @@ public static class AgentServer {
     // tools/call
     // -------------------------------------------------------------------------------------------
 
-    private static JsonObject CallTool(JsonObject? prms) {
+    private static JsonObject CallTool(JsonObject? prms, AgentTransport transport) {
         string name = AsString(prms?["name"]);
         JsonObject args = prms?["arguments"] as JsonObject ?? [];
 
@@ -344,6 +346,18 @@ public static class AgentServer {
         }
 
         if (name == "send_command") {
+            // #153: send_command is a raw command-injection surface. Over the network-facing HTTP floor it
+            // must NOT be reachable unless the operator opted into the agent surface — otherwise enabling
+            // McpServerEnabled alone (with AgentCommandsEnabled=false) leaves a CSRF/DNS-rebinding-reachable
+            // (#143) raw pass-through. So over HTTP it honors the SAME AgentCommandsEnabled gate as every
+            // other tool. Over local stdio (the operator launched mcec.exe --mcp — no CSRF surface) the
+            // documented raw pass-through stays available; the per-command Enabled table still applies below.
+            if (transport == AgentTransport.Http && !AgentRuntime.AgentCommandsEnabled) {
+                AgentRuntime.Audit("send_command", "BLOCKED — agent commands disabled; send_command over HTTP requires AgentCommandsEnabled");
+                return ToolError(
+                    "send_command over HTTP requires AgentCommandsEnabled=true. Enable the agent surface to opt in, or drive send_command over the local stdio transport (mcec.exe --mcp).",
+                    "agent-commands-disabled");
+            }
             return RunSendCommand(args);
         }
 
@@ -764,7 +778,7 @@ public static class AgentServer {
         using StreamReader reader = new(input, new UTF8Encoding(false));
         using StreamWriter writer = new(output, new UTF8Encoding(false)) { AutoFlush = true };
         Logger.Instance.Log4.Info("AgentServer: MCP stdio transport started.");
-        RunStdioLoop(reader, writer, Dispatch);
+        RunStdioLoop(reader, writer, req => Dispatch(req, AgentTransport.Stdio));
         Logger.Instance.Log4.Info("AgentServer: MCP stdio transport ended (EOF).");
     }
 
@@ -897,6 +911,14 @@ public static class AgentServer {
         }
     }
 
+    /// <summary>
+    /// Dispatches an HTTP request through the test override when one is set, otherwise through
+    /// <see cref="Dispatch"/> tagged <see cref="AgentTransport.Http"/> so the transport-sensitive
+    /// <c>send_command</c> gate (#153) sees the network transport.
+    /// </summary>
+    private static JsonObject? DispatchHttp(JsonObject req) =>
+        HttpDispatchOverride is { } over ? over(req) : Dispatch(req, AgentTransport.Http);
+
     private static void HandleHttp(HttpListenerContext context) {
         try {
             if (!string.Equals(context.Request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase)) {
@@ -919,7 +941,7 @@ public static class AgentServer {
             try {
                 JsonNode? node = JsonNode.Parse(body);
                 response = node is JsonObject req
-                    ? (HttpDispatchOverride ?? Dispatch)(req) ?? new JsonObject { ["jsonrpc"] = "2.0" }
+                    ? DispatchHttp(req) ?? new JsonObject { ["jsonrpc"] = "2.0" }
                     : Error(null, -32600, "Invalid Request")!;
             }
             catch (JsonException e) {

--- a/src/Services/AgentTransport.cs
+++ b/src/Services/AgentTransport.cs
@@ -1,0 +1,18 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// Which transport a JSON-RPC request arrived over. It matters for one security decision: the raw
+/// <c>send_command</c> pass-through is reachable without the agent-surface opt-in only over the LOCAL
+/// stdio transport (the operator launched <c>mcec.exe --mcp</c>), never over the network-facing HTTP
+/// floor (#153). Every other tool is gated identically on both transports.
+/// </summary>
+public enum AgentTransport {
+    /// <summary>Local stdio (<c>mcec.exe --mcp</c>) — the process was launched by its client; no CSRF surface.</summary>
+    Stdio,
+
+    /// <summary>The localhost HTTP floor (<c>POST /mcp</c>) — network-reachable, so CSRF/DNS-rebinding applies.</summary>
+    Http,
+}

--- a/tests/MCEControl.xUnit/Services/AgentServerHttpTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerHttpTests.cs
@@ -44,6 +44,83 @@ public class AgentServerHttpTests {
     private static void StopServer() {
         AgentServer.StopHttp();
         AgentRuntime.Settings = null;
+        AgentRuntime.Invoker = null;
+    }
+
+    /// <summary>Posts a JSON-RPC tools/call for <paramref name="tool"/> and returns the HTTP response.</summary>
+    private static async Task<HttpResponseMessage> PostToolCallAsync(string url, string tool, JsonObject args) {
+        using HttpClient client = new() { Timeout = TimeSpan.FromSeconds(30) };
+        JsonObject request = new() {
+            ["jsonrpc"] = "2.0",
+            ["id"] = 1,
+            ["method"] = "tools/call",
+            ["params"] = new JsonObject { ["name"] = tool, ["arguments"] = args },
+        };
+        StringContent content = new(request.ToJsonString(), Encoding.UTF8, "application/json");
+        return await client.PostAsync(url, content);
+    }
+
+    /// <summary>Unwraps the #101 envelope out of a tools/call HTTP response body.</summary>
+    private static JsonObject EnvelopeOf(JsonObject body) {
+        JsonObject result = body["result"]!.AsObject();
+        foreach (JsonNode? block in result["content"]!.AsArray()) {
+            if (block?["type"]?.GetValue<string>() == "text") {
+                return JsonNode.Parse(block["text"]!.GetValue<string>())!.AsObject();
+            }
+        }
+        Assert.Fail("no text content block in tool result");
+        return [];
+    }
+
+    [Fact]
+    public async Task Http_SendCommand_AgentSurfaceNotOptedIn_IsRefused_AndNotExecuted() {
+        // #153: over the network-facing HTTP floor, send_command must NOT be reachable when the operator
+        // enabled McpServerEnabled but left AgentCommandsEnabled=false — otherwise it is a CSRF/DNS-
+        // rebinding-reachable (#143) raw command-injection surface. A NON-empty command with a live invoker
+        // present proves the refusal happens at the gate, BEFORE execution: without the gate this would run
+        // the pass-through and return ok=true; with it we get ok=false / agent-commands-disabled.
+        string url = StartServer();
+        AgentRuntime.Settings!.AgentCommandsEnabled = false;
+        AgentRuntime.Invoker = [];
+        try {
+            using HttpResponseMessage resp = await PostToolCallAsync(url, "send_command",
+                new JsonObject { ["command"] = "chars:pwnd" });
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            JsonObject body = JsonNode.Parse(await resp.Content.ReadAsStringAsync())!.AsObject();
+            Assert.True(body["result"]!.AsObject()["isError"]!.GetValue<bool>());
+
+            JsonObject env = EnvelopeOf(body);
+            Assert.False(env["ok"]!.GetValue<bool>());
+            Assert.Equal("agent-commands-disabled", env["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            StopServer();
+        }
+    }
+
+    [Fact]
+    public async Task Http_SendCommand_WhenAgentSurfaceOptedIn_IsAllowed() {
+        // #153: with the agent surface opted in (AgentCommandsEnabled=true) send_command over HTTP works —
+        // it reaches the pass-through and returns ok=true (empty capture → the "ok" payload).
+        AgentTestSupport.EnsureTelemetry();
+        string url = StartServer();
+        AgentRuntime.Settings!.AgentCommandsEnabled = true;
+        AgentRuntime.Invoker = [];
+        try {
+            using HttpResponseMessage resp = await PostToolCallAsync(url, "send_command",
+                new JsonObject { ["command"] = "chars:hello" });
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            JsonObject body = JsonNode.Parse(await resp.Content.ReadAsStringAsync())!.AsObject();
+            Assert.False(body["result"]!.AsObject()["isError"]!.GetValue<bool>());
+
+            JsonObject env = EnvelopeOf(body);
+            Assert.True(env["ok"]!.GetValue<bool>());
+        }
+        finally {
+            StopServer();
+        }
     }
 
     [Fact]

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -437,14 +437,14 @@ public class AgentServerTests {
     }
 
     [Fact]
-    public void Dispatch_ToolsCall_SendCommand_IsNotGatedByAgentCommandsEnabled() {
+    public void Dispatch_ToolsCall_SendCommand_OverStdio_IsNotGatedByAgentCommandsEnabled() {
         AgentTestSupport.EnsureTelemetry();
         AgentRuntime.Settings = null; // AgentCommandsEnabled = false
         try {
-            // send_command is a raw pass-through routed to RunSendCommand BEFORE the AgentCommandsEnabled
-            // check (unlike the agent tools). An empty command therefore returns bad-arguments — proving it
-            // reached RunSendCommand — not agent-commands-disabled. (The raw command it runs is still gated
-            // by that command's own Enabled flag in the table; this only asserts the agent gate is skipped.)
+            // #153: over the LOCAL stdio transport (the default), send_command keeps its documented raw
+            // pass-through — it is not gated by AgentCommandsEnabled. An empty command therefore returns
+            // bad-arguments — proving it reached RunSendCommand — not agent-commands-disabled. (The raw
+            // command it runs is still gated by that command's own Enabled flag in the table.)
             JsonObject resp = AgentServer.Dispatch(Request(22, "tools/call",
                 new JsonObject { ["name"] = "send_command", ["arguments"] = new JsonObject { ["command"] = "" } }))!;
 
@@ -452,6 +452,48 @@ public class AgentServerTests {
         }
         finally {
             AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Dispatch_ToolsCall_SendCommand_OverHttp_WhenAgentDisabled_IsRefused() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = null; // AgentCommandsEnabled = false
+        AgentRuntime.Invoker = [];
+        try {
+            // #153: over the network-facing HTTP transport, send_command honors the AgentCommandsEnabled
+            // gate. A NON-empty command with a live invoker present would execute (and pass the empty-arg
+            // check) if the gate were absent; instead the gate refuses it up front with agent-commands-disabled.
+            JsonObject resp = AgentServer.Dispatch(Request(23, "tools/call",
+                new JsonObject { ["name"] = "send_command", ["arguments"] = new JsonObject { ["command"] = "chars:pwnd" } }),
+                AgentTransport.Http)!;
+
+            Assert.Equal("agent-commands-disabled", ToolErrorCode(resp));
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.Invoker = null;
+        }
+    }
+
+    [Fact]
+    public void Dispatch_ToolsCall_SendCommand_OverHttp_WhenAgentEnabled_ReachesPassThrough() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.Invoker = [];
+        try {
+            // #153: with the agent surface opted in, send_command over HTTP gets past the gate and runs the
+            // pass-through. An empty command now surfaces bad-arguments (from RunSendCommand) — NOT the gate
+            // refusal — proving the request reached execution.
+            JsonObject resp = AgentServer.Dispatch(Request(24, "tools/call",
+                new JsonObject { ["name"] = "send_command", ["arguments"] = new JsonObject { ["command"] = "" } }),
+                AgentTransport.Http)!;
+
+            Assert.Equal("bad-arguments", ToolErrorCode(resp));
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.Invoker = null;
         }
     }
 


### PR DESCRIPTION
## The exposure

`CallTool` routed `send_command` to `RunSendCommand` **before** the `AgentCommandsEnabled` check that guards every other tool, and `RunSendCommand` had no gate of its own. So an operator who enabled `McpServerEnabled` but deliberately left `AgentCommandsEnabled=false` still exposed a **raw command-injection surface over HTTP**, protected only by the per-command `Enabled` table. Before #143's front-door validation landed, a browser CSRF / DNS-rebinding request could reach `send_command` with **no agent opt-in**. With #143's `Host`/`Origin`/token gate now in place **and** this `AgentCommandsEnabled` gate, that surface is closed (defense-in-depth).

This was previously intentional/documented ("send_command skips the agent gate", PR #74 / commit f54f5c7). Now that the HTTP transport ships, #153 asks to reconsider — this PR does.

## Design chosen (secure-by-default) + rationale

**Require `AgentCommandsEnabled` for `send_command` over the HTTP transport; keep the local stdio pass-through unchanged.** No new setting — the existing off-by-default `AgentCommandsEnabled` opt-in is reused.

Each JSON-RPC request is now tagged with its transport (`AgentTransport.Stdio | Http`): the stdio loop tags `Stdio`, the HTTP floor tags `Http`. In `CallTool`, `send_command` over `Http` honors the **same** `AgentCommandsEnabled` gate as every other tool — refused with `error.code: agent-commands-disabled` and never executed.

Composes cleanly with #143 (now merged into develop): `GateHttpRequest` validates the front door (method/path/`Host`/`Origin`/optional token) **first**, then `DispatchHttp` tags the request `Http` so `send_command` additionally honors the agent opt-in. Two independent layers.

Why this over a dedicated new flag:
- **Secure-by-default.** `AgentCommandsEnabled` is off by default, so `McpServerEnabled=true` alone no longer exposes a raw-command surface — it must be an explicit opt-in.
- **Consistent & minimal.** Over HTTP, `send_command` now shares the exact gate/error code of the other tools; no new config/telemetry/UI/settings surface to wire (mirrors the existing `AgentCommandsEnabled` pattern by reusing it).
- **Safe for the documented local use case.** Over **stdio** (`mcec.exe --mcp`, launched by its client) there is no network/CSRF surface — the launching process already has full local control — so the documented raw pass-through stays available with no added friction and no security loss.
- The per-command `Enabled` table gate still applies underneath in **both** cases.

## Corrected documentation

- `docs/agent-server.md`: replaced the outdated "`send_command` is the exception … does not require `AgentCommandsEnabled`" with the precise transport-sensitive rule (stdio: pass-through; HTTP: gated), plus a note in the *HTTP floor* section (kept alongside #143's front-door-validation section). Exposure described in past tense now that #143 landed.
- `src/Agent/AgentInstructions.md`: agent-facing gating updated — `send_command` is gated by `AgentCommandsEnabled` over HTTP (refused `error.code:agent-commands-disabled`), available over stdio.

## Tests

Failing-first confirmed (temporarily disabled the gate → the two refusal tests go red), then green with the fix.

- `AgentServerHttpTests` (real `HttpListener`):
  - `Http_SendCommand_AgentSurfaceNotOptedIn_IsRefused_AndNotExecuted` — a *non-empty* command with a live invoker present is refused at the gate (`agent-commands-disabled`, `isError`), proving it never reached execution (without the gate it would run and return `ok=true`).
  - `Http_SendCommand_WhenAgentSurfaceOptedIn_IsAllowed` — with `AgentCommandsEnabled=true` it passes the gate and returns `ok=true`.
- `AgentServerTests` (dispatch-level matrix):
  - `Dispatch_ToolsCall_SendCommand_OverStdio_IsNotGatedByAgentCommandsEnabled` (renamed from the old test) — stdio pass-through preserved.
  - `Dispatch_ToolsCall_SendCommand_OverHttp_WhenAgentDisabled_IsRefused`.
  - `Dispatch_ToolsCall_SendCommand_OverHttp_WhenAgentEnabled_ReachesPassThrough`.

`dotnet build MCEControl.slnx` clean (analyzers MCEC0001/MCEC0002 included); full suite `dotnet test` green after merging develop: **516 passed, 22 skipped, 0 failed**.

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHUv7FptJgKjyqXEvAxgnU
