### PR TITLE
docs: tersify version history; remove issue/PR references from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,12 +61,12 @@ line. An agent that hits "agent commands are disabled" should tell the user, not
 
 Two safety features layer on top (see [`docs/safety-emergency-stop-and-provisioning.md`](docs/safety-emergency-stop-and-provisioning.md)):
 
-- **Emergency stop (#135)** — a global "dead man's switch" hotkey (default `Ctrl+Alt+Shift+S`) the operator
+- **Emergency stop** — a global "dead man's switch" hotkey (default `Ctrl+Alt+Shift+S`) the operator
   can hit from **any** window to instantly halt a session: it latches the actuation gate (every tool call is
   refused with `emergency-stopped` until the operator re-arms), aborts in-flight actuation, and releases held
   input. It reacts to **physical input only** (injected keys are ignored via `LLKHF_INJECTED`), so the agent
   can never trip or defeat it. Do not weaken the injected-key filter or the latch.
-- **Isolated session provisioning (#138)** — agents must **not** enable/disable commands in the installed
+- **Isolated session provisioning** — agents must **not** enable/disable commands in the installed
   instance (a crash leaks enabled gates). Instead, `provision-session` (gated by the operator's
   `AllowSessionProvisioning` opt-in) hands the agent a disposable directory with its own agent-ready config;
   teardown is deleting the directory, and MCEC reaps orphaned session dirs on launch. The installed config is

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -159,7 +159,7 @@ failed call is debuggable without rerunning it):
 > The `AgentServer` translates that into the `{ ok, result, error, … }` envelope at the MCP
 > boundary (`AgentToolResult.FromLegacy`), which is the shape an MCP client actually receives and
 > the one specified by the shared result contract in
-> [`docs/design/agent-tool-result-contract.md`](design/agent-tool-result-contract.md) (#101). A
+> [`docs/design/agent-tool-result-contract.md`](design/agent-tool-result-contract.md). A
 > couple of feature-specific refusals ride in `error.code` while `error.category` stays `internal`:
 > `emergency-stopped` (the operator engaged the [emergency stop](safety-emergency-stop-and-provisioning.md)),
 > `provisioning-not-authorized` (`AllowSessionProvisioning` is off), and `command-disabled` (the
@@ -347,8 +347,7 @@ Known limits:
 
 - **Locked / disconnected sessions:** when the workstation is locked or the session is detached,
   the desktop cannot be rendered and captures are blank. This is detected (blank frame) but cannot
-  be worked around from user space. Live validation of locked-session behavior is tracked
-  separately in [#78].
+  be worked around from user space.
 - **Elevation (UAC):** MCEC running at medium integrity cannot read the UIA tree of, drive, or
   reliably capture a window owned by an elevated (high-integrity) process. Such targets surface as
   empty/failed observations; run MCEC elevated only if you explicitly need to automate elevated
@@ -368,7 +367,6 @@ trees (e.g. a virtualized list with thousands of items):
 Individual stale or unsupported UIA nodes never abort the whole walk — they are skipped and the
 rest of the tree is returned.
 
-[#78]: https://github.com/tig/mcec/issues/78
 
 ---
 
@@ -490,12 +488,11 @@ origin, remote endpoint) so drive-by and rebinding attempts are visible to the o
 > HTTP listener and logs an error. To expose the door off-box, set a bearer token (and prefer a
 > network-level control too).
 
-The floor is hardened against resource exhaustion ([#151]): a request body larger than
+The floor is hardened against resource exhaustion: a request body larger than
 **1 MB** is refused with `413` (the cap is enforced by a bounded read, so chunked bodies
 without a `Content-Length` can't bypass it), and at most **16** requests are served
 concurrently — past that the server answers `503` rather than queueing.
 
-[#151]: https://github.com/tig/mcec/issues/151
 
 ---
 
@@ -515,10 +512,10 @@ concurrently — past that the server answers `503` rather than queueing.
 Two operator-safety features build on the gates above — see
 [`safety-emergency-stop-and-provisioning.md`](safety-emergency-stop-and-provisioning.md):
 
-- **Emergency stop (#135):** a global panic hotkey (default `Ctrl+Alt+Shift+S`, set via
+- **Emergency stop:** a global panic hotkey (default `Ctrl+Alt+Shift+S`, set via
   `EmergencyStopHotkey`) that instantly halts a session from any window — latching the actuation gate
   (`emergency-stopped` refusals until re-armed), aborting in-flight actuation, and releasing held input. It
   reacts to physical input only, so the agent can never trip or defeat it.
-- **Isolated session provisioning (#138):** `provision-session` (gated by `AllowSessionProvisioning`) hands
+- **Isolated session provisioning:** `provision-session` (gated by `AllowSessionProvisioning`) hands
   an agent a disposable, isolated MCEC directory instead of it mutating the installed config; `end-session`
   (or launch-time reaping) tears it down.

--- a/docs/evidence-bundles.md
+++ b/docs/evidence-bundles.md
@@ -1,7 +1,5 @@
 # MCEC evidence bundles
 
-*Issue #87 — trace, replay, and artifact bundles.*
-
 Every MCEC dogfood run (Customer 0 self-dogfood, Customer 1 WinPrint, future benchmarks) produces
 the **same** evidence bundle, so a failed run can be understood without rerunning it and a bundle can
 be attached to an issue as-is. The bundle is produced by [`scripts/McecEvidence.psm1`](../scripts/McecEvidence.psm1)
@@ -78,5 +76,5 @@ Complete-McecSession -Session $s -Passed $true -Environment (Get-McecEnvironment
 `tool-calls.jsonl` is an ordered, replayable transcript: each `request` line is a literal JSON-RPC call
 that can be re-POSTed to a fresh MCEC `/mcp` to reproduce the sequence, and each `response` line is the
 expected result to diff against. A full deterministic replayer (timing, window-handle remapping, screenshot
-diffing) is future work; the format is stable enough to build it on. GIF recording (#80) lands as additional
+diffing) is future work; the format is stable enough to build it on. GIF recordings land as additional
 `*.gif` artifacts in the same bundle.

--- a/docs/hero-gif.md
+++ b/docs/hero-gif.md
@@ -4,9 +4,9 @@
 ([`docs/index.md`](index.md), served at `https://tig.github.io/mcec/hero.gif`). It is MCEC dogfooding
 itself: one MCEC drives a **second MCEC** through a guided tour — launch → **File ▸ Settings** (visit
 every tab) → **mouse-resize** the window ~25% smaller by dragging its sizing border → **drag the title
-bar in small circles** → **Help ▸ About** → pause — while the **on-screen command overlay** (#119)
+bar in small circles** → **Help ▸ About** → pause — while the **on-screen command overlay**
 narrates every command in burnt orange, all recorded by the agent
-[`record`](agent-server.md#record--capturing-change-over-time) tool (#80). No external screen-recorder.
+[`record`](agent-server.md#record--capturing-change-over-time) tool. No external screen-recorder.
 
 The two oranges line up on purpose: the overlay's item background is the **About box's brand orange**,
 so the About dialog and the narration match.
@@ -38,7 +38,7 @@ It is the executable form of these decisions — replicate them if reproducing b
    (else it binds `IPAddress.Any:5150` and triggers the first-run Windows Firewall prompt that steals focus
    and derails the tour), `DisableUpdatePopup=true`, turns its **own overlay off**
    (`CommandOverlayEnabled=false` — only the controller narrates), and **pins** `WindowLocation`/`WindowSize`.
-3. **Launch it the way an agent would — using the direct `launch` tool (not `Start-Process` or Win+R).** Now that #126 is implemented, dogfood the first-class gated launch: the controller calls `launch { "path": "<exe>", "timeout": 10000 }` which starts the process and returns the pid + primary window handle (when it appears). This is more reliable than the Run dialog. (The script falls back to the Win+R composition only if needed for other demos.) The freshly-launched window handle is used to target the subject thereafter (its "MCEC" title is ambiguous with the controller) and the modal dialogs by their unambiguous titles (`Settings`, `About`).
+3. **Launch it the way an agent would — using the direct `launch` tool (not `Start-Process` or Win+R).** The controller dogfoods the first-class gated launch: it calls `launch { "path": "<exe>", "timeout": 10000 }` which starts the process and returns the pid + primary window handle (when it appears). This is more reliable than the Run dialog. (The script falls back to the Win+R composition only if needed for other demos.) The freshly-launched window handle is used to target the subject thereafter (its "MCEC" title is ambiguous with the controller) and the modal dialogs by their unambiguous titles (`Settings`, `About`).
 4. **Overlay docked Left over a wide window → compact capture.** With the overlay on the left of the wide,
    pinned, left-docked subject window, the recorded region is **just the window** — compact, no wallpaper —
    yet still contains the narration. The Settings/About dialogs are `CenterParent`, so they sit to the
@@ -76,31 +76,17 @@ A key aspect of MCEC is that a capable **agent composes the full command set cre
 question isn't "can an agent recreate the hero?" but "how *robustly*?" The honest answer: **an agent can
 already recreate almost all of this today with nothing but `mcec.exe`**, by combining existing primitives.
 The `.ps1` reaches outside MCEC mainly for **determinism and convenience**, not because MCEC can't express
-the step. The tracking issues below are about turning common compositions into first-class, robust actions
-— not about unlocking the impossible.
+the step.
 
-**The one genuine primitive gap — the keystone (#122).** `query` reports control bounds in **pixels**,
-but `mouse:mt` wants **normalized** 0–65535 coordinates, and there is no clean way to read the screen
-geometry to bridge them; the script uses `GetSystemMetrics` for that. Give MCEC a **`displays`/geometry
-query** (or pixel-/element-relative mouse targeting) and every mouse step below becomes composable from
-commands that already exist.
+Most of what the tour needs is now **first-class**: `launch` starts the subject and returns its pid +
+window handle; `displays` reports per-monitor pixel bounds and DPI so `query`'d bounds convert cleanly to
+clicks and drags; the `drag` tool (and raw `mouse:drag`) does atomic press → move-path → release in screen
+pixels; and `invoke` with `action: "select"` switches tabs/list items. What remains composition: wait for a
+window by polling `query`, and record a window by passing its `query`'d bounds as the `record` region.
 
-**One bug, not a missing capability (#128).** Invoking a menu item that opens a **modal** wedges later UIA
-queries of that dialog, so the tour opens Settings with a keystroke (`key_s`) rather than `invoke`. Fixing
-it makes menu navigation fully `invoke`-based. (Meanwhile the keystroke *is* a valid creative composition.)
-
-Everything else is **already composable today** — the issues just make the pattern first-class/robust:
-
-| Step | Already composable today via | Enhancement (issue) |
-|---|---|---|
-| Launch the subject **(the hero now uses this)** | `launch { "path": "...", "timeout": ... }` (direct, returns pid + window handle/info) | direct gated `launch` tool implemented (#126) — robustness; Win+R composition still available via send_command |
-| Drag: resize border / title-bar circles | **one atomic `mouse:drag,x1,y1,…`** — shipped in #123 (pixels in, normalized across the virtual desktop internally); the hand-rolled `mouse:lbd` → path of `mouse:mt` → `mouse:lbu` still works too | ~~first-class `drag`~~ **shipped (#123)** — the agent `drag` tool adds UIA-element endpoints; still open: a window `move`/`resize` with an `animate` mode that still *looks* dragged (#124) |
-| Switch Settings tabs | `query` the tab's bounds → `mouse` click its center | `select` / SelectionItem action (#125) |
-| Record the window | `query` its bounds → `record { x, y, width, height }` | `record { handle }`, optionally following the window (#127) |
-| Wait for a window/dialog | poll `query` until it appears | first-class wait-for-**window** predicate (#112) |
-
-Every mouse row above still depends on the keystone (#122) for pixel→normalized conversion; give MCEC the
-geometry query and the compositions in the middle column work as written.
+One caveat: invoking a menu item that opens a **modal** can wedge later UIA queries of that dialog, so the
+tour opens Settings with a keystroke (`key_s`) rather than `invoke` — the keystroke *is* a valid creative
+composition.
 
 Deliberately **out of scope** for the agent: provisioning the isolated subject (copy + config) and
 enabling the actuation gates (`AgentCommandsEnabled`, per-command `Enabled`, and the overlay settings). An

--- a/docs/home-automation.md
+++ b/docs/home-automation.md
@@ -223,7 +223,7 @@ escapes* for unprintable/Unicode characters — `chars:\\` sends `\`, `chars:☺
 [documented here](https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-escapes-in-regular-expressions).)
 
 How `chars:` interacts with modifier keys (shift/ctrl/alt/win) is app-dependent; for fine-grained control
-use `SendInput` commands instead (see [Issue #14](https://github.com/tig/mcec/issues/14)).
+use `SendInput` commands instead.
 
 Sending a single character without `chars:` (e.g. just `c`) is equivalent to a `SendInput` command — a
 single key press. There is no difference between sending `a` and `A`; use `shiftdown:`/`shiftup:` to hold

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,36 +18,8 @@ Every agent capability is **opt-in, disabled by default, localhost-bound, and lo
 
 ## Version History
 
-* Version 1.0.1 (February 22, 2004) – First publicly released version.
-* Version 1.0.2 (March 24, 2004) - New features: Added support for system shutdown, restart, standby, and hibernate (the Shutdown command type) Renamed a few commands ("mce_start" is now "mcestart" for example) to be more consistent.
-* Version 1.0.3 (March 26, 2004) - Added installer.
-* Version 1.0.4 (February 26, 2005) - Fixed bug that caused MCEC to prevent logoffs and shutdowns.
-* Version 1.0.5 (April, 2005) – Added support for arbitrary # of characters for the “key:” command.
-* Version 1.1.0 (May 11, 2005) – No functional changes. Changed the source license to the BSD license and posted on Sourceforge.
-* Version 1.3.0 (January 3, 2012) – Added support for "chars:". Removed support for "keys:". Added "enter" command. Now builds with VS2010.
-* Version 1.3.1 (January 4, 2012) – Fixed bug parsing -1 in the lParam of SendMessageCommands. Commented MCEController.commands. Minor code cleanup.
-* Version 1.3.2 (January 4, 2012) – Fixed bug in how .commands and .settings are stored (Win7 broke permissions).
-* Version 1.3.3 (January 9, 2012) – Added capability to send individual key presses with shift/ctrl/alt/win modifiers (what keys: originally was supposed to do).
-* Version 1.4.0 (February 11, 2012) - Server now supports any number of client connections. Expanded MCEController.commands to include commands used by iRule (http://iruleathome.com). Updated About Box & Help menu to reflect move to GitHub. Added menu item to open directory containing MCEController.commands.
-* Version 1.5.0 (March 27, 2012) - 'chars:' command now supports escaped characters. This allows the sending of Unicode characters such as € (e.g. 'chars:\u20AC' will cause the € character to be input on the server machine).
-* Version 1.5.1 (April 2, 2012) - Removed readme file from distribution and updated online docs.
-* Version 1.5.2 (October, 4, 2012) - Fixed .settings file bug where it would sometimes read from Program Files and write to AppData. Now always writes to AppData unless started outside of Program Files. Fixed Setting dialog to be more resilient to bad data. Fixed Send Awake so that it does not fault on bad data, but logs errors. General code clean up. Built with VS2012.
-* Version 1.6.0 (October 10, 2012) - Added mouse simulation support.
-* Version 1.6.1 (November 6, 2012) - Fixed bug with some Telnet clients that don't buffer each line before sending.
-* Version 1.7.0 (December 19, 2012) - Added Serial Server support.
-* Version 1.8.0 (December 30, 2012) - Added VK_ command support. Added 'command window'. New icon. Updated documentation.
-* Version 1.8.1 (January 1, 2013) - Updated links for CodePlex. Fixed crashing bug on exit.
-* Version 1.8.4 (March, 2014) - New icon by [http://guillendesign.deviantart.com/](http://guillendesign.deviantart.com/), Minor menu tweaks, MCEControl.commands is now an optional file. The previously defined set of commands from older builds are now built into the program. If a MCEControl.commands file is present it will add to and override these pre-defined commands. Upgrades and un-installs will no longer overwrite or delete the MCEControl.commands file.
-* Version 1.8.6 (May, 2014) – Internal commands can be disabled via a registry key. Fixed bug when client forcibly closed socket. Added logging.
-* Version 1.9.0 (April 15, 2017) - Moved from Codeplex to GitHub.
-* Version 2.0.0 (October 8, 2019) - Version 2. Major update.
-  * Use the PC as an occupancy sensor for a room. The User Activity Monitor feature will send a command to the home automation system when a user is using the PC (moving the mouse or typing).
-  * Re-engineered Client & Server implementation is more robust.
-  * New/enhanced built-in test mode that makes it easy to test commands. The new Commands Window shows all available commands.
-  * Significantly updated UI throughout. Menus and dialog boxes reorganized based on user feedback. Full Windows 10 system font and dpi scaling support.
-  * Command extension has been enhanced. User-defined MCEControl.commands is now automatically generated.
-  * StartProcess commands are now more robust and flexible.
-  * Settings, Command files, and log files are stored in %appdata%.
-  * Improved logging.
-* Version 2.0.4 (October 11, 2019) - Fixed bug where Server was not sending commands back to client.
-* See [Releases](https://github.com/tig/mcec/releases) for more history
+* **3.0 (2026)** — Rebranded to the **Model Context Environment Controller**. Agent automation over MCP: observation (`capture`/`query`/`record`), targeting (`find`/`wait-for`), actuation (`invoke`/`launch`/`drag`/`click`), emergency stop, and isolated session provisioning — all opt-in and off by default.
+* **2.x (2019)** — Major rework: robust client/server, User Activity Monitor (occupancy sensing), Commands Window with built-in test mode, per-monitor DPI support, config in `%APPDATA%`.
+* **1.x (2004–2017)** — Born as "MCE Controller" for Windows Media Center HTPCs. Grew keyboard/mouse/window-message simulation, `chars:` with Unicode escapes, serial support, multi-client TCP, and the `.commands` extension file. Moved from SourceForge to CodePlex to GitHub.
+
+See [Releases](https://github.com/tig/mcec/releases) for the full history and release notes.

--- a/docs/safety-emergency-stop-and-provisioning.md
+++ b/docs/safety-emergency-stop-and-provisioning.md
@@ -3,16 +3,16 @@
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 -->
 
-# Agent safety: Emergency Stop (#135) and Isolated Session Provisioning (#138)
+# Agent safety: Emergency Stop and Isolated Session Provisioning
 
 Two related safety features for MCEC's Agent Mode. When MCEC is agent-driving the desktop, the **target
 app has focus, not MCEC** — so the operator needs (a) a way to instantly intervene when a run goes wrong,
-and (b) assurance that a session can't leave the machine in an unsafe state. This document is the design
-of record for both; they ship together because both are about the operator staying in control.
+and (b) assurance that a session can't leave the machine in an unsafe state. Both features exist so the
+operator stays in control.
 
 ---
 
-## 1. Emergency Stop — a global dead-man's-switch hotkey (#135)
+## 1. Emergency Stop — a global dead-man's-switch hotkey
 
 ### Goal
 
@@ -40,7 +40,7 @@ Engaging the stop (`EmergencyStop.Trigger`):
    neutralizes anything left held.
 3. **Releases held input.** All mouse buttons up; shift/ctrl/alt/win reset (the same reset `MainWindow`
    runs on exit) — no stuck drag or chord.
-4. **Loud feedback.** A persistent red `⛔ STOPPED by operator` banner on the overlay (#119), an
+4. **Loud feedback.** A persistent red `⛔ STOPPED by operator` banner on the overlay, an
    `AGENT-AUDIT:` log line, a status-bar message, and a stamp into the `AgentSession` record.
 5. **Latches until re-armed.** The operator clicks the **⛔ Re-arm (Emergency Stop)** menu item (visible
    only while stopped); the latch is never cleared automatically.
@@ -80,7 +80,7 @@ agent front door could be driving (`McpServerEnabled || AgentCommandsEnabled`).
 
 ---
 
-## 2. Isolated session provisioning (#138)
+## 2. Isolated session provisioning
 
 ### Problem
 
@@ -139,29 +139,8 @@ existing manual practice (`scripts/Run-Customer0Skeleton.ps1`) and is isolated b
 ### Limitations / follow-ups
 
 - **Authorization depth.** `AllowSessionProvisioning` is a single operator opt-in. A richer per-session
-  authorization / token-scoping model ties into epics #92 (safety UX) and #74 (per-command enable) — future work.
+  authorization / token-scoping model is future work.
 - **Auto-launch.** `provision-session` returns a directory + how to launch; it does not spawn the process
   (the caller/host does). An optional MCEC-side launch is a candidate follow-up.
-- **Artifacts** (#87) live under the session directory so teardown collects them.
+- **Artifacts** (evidence bundles) live under the session directory so teardown collects them.
 
----
-
-## Acceptance criteria coverage
-
-**#135**
-
-- [x] Configured combo from any focused app instantly halts the session.
-- [x] In-flight command aborted, queue dropped, no actuation until re-armed (latch + gate + cooperative drag/record abort).
-- [x] No stuck input: mouse buttons + modifiers released.
-- [x] Fires on real physical input only; MCEC's injected keys never trigger it.
-- [x] Feedback on overlay + audit log + session record; tool calls refused with `emergency-stopped` until re-arm.
-- [x] Hotkey configurable; default easy, rare, not agent-synthesized.
-
-**#138**
-
-- [x] Documented tool that provisions an isolated instance and returns its path + connect info.
-- [x] Running a provisioned session never reads/writes the installed `mcec.commands` / settings.
-- [x] Agent commands enabled only within the provisioned instance.
-- [x] Teardown removes the dir; orphaned dirs are reaped; abnormal exit leaves no enabled state in the install.
-- [x] Provisioning gated behind an explicit operator authorization, not self-served.
-- [x] Agent guidance tells agents to provision + tear down rather than touching the installed instance.

--- a/docs/self-hosted-interactive-runner.md
+++ b/docs/self-hosted-interactive-runner.md
@@ -112,7 +112,7 @@ dotnet build MCEControl.slnx -c Release
 
 The lane should report the smoke as skipped with a notice if run on a non-interactive machine.
 
-## Artifact Shape (aligned with #87 bundle ideas)
+## Artifact Shape (aligned with the evidence-bundle layout)
 - test-results-... (trx, coverage)
 - smoke-... (if produced)
 - Any future per-observation screenshots/GIFs from E2E/agent tests can follow the same upload pattern.
@@ -120,4 +120,4 @@ The lane should report the smoke as skipped with a notice if run on a non-intera
 This lane is intentionally independent of the agent "skeleton" and only consumes the built MCEC binary + existing test infrastructure.
 
 ## Next
-Once stable, it can host the full desktop E2E / agent automation tests (#98) that require real input + visible desktop.
+Once stable, it can host the full desktop E2E / agent automation tests that require real input + visible desktop.


### PR DESCRIPTION
Docs are documentation, not specs — issue/PR numbers belong in the tracker, design docs, and commit history, not in user-facing pages.

## Changes
- **docs/index.md** — the 35-line per-release changelog (2004–2019) collapsed into three era summaries (3.0 / 2.x / 1.x) plus a pointer to GitHub Releases.
- **docs/safety-emergency-stop-and-provisioning.md** — issue numbers removed from title/headings/prose; the spec-style "Acceptance criteria coverage" checklist dropped; "design of record" intro reframed as plain documentation.
- **docs/agent-server.md, home-automation.md, evidence-bundles.md, self-hosted-interactive-runner.md, AGENTS.md** — inline issue references stripped.
- **docs/hero-gif.md** — the stale issue-tracked roadmap table replaced with a short description of what is now first-class (`launch`, `displays`, `drag`, `invoke select`) vs. composed; those tools all shipped, so the table was outdated as well as spec-shaped.

`docs/design/` and `docs/proposals/` keep their references — those *are* specs.

Docs-only; net −68 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)