### PR TITLE
Arch (P0): AgentRuntime.Settings goes stale after the Settings dialog swaps the object

### DIFF
--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -134,14 +134,8 @@ public partial class MainWindow : Form {
         WindowsInput.Native.NativeMethods.GetClassName(hWnd, sb, 256);
         Logger.Instance.Log4.Info($"Window Class - {sb}");
 #endif
-        // Load AppSettings
-        Settings = AppSettings.Deserialize($@"{Program.ConfigPath}{AppSettings.SettingsFileName}");
-
-        // Expose settings to the UI-agnostic agent engine (capture/query/find/invoke + MCP/HTTP).
-        AgentRuntime.Settings = Settings;
-
-        // Configure logging (some logging already happened).
-        Logger.Instance.TextBoxThreshold = LogManager.GetLogger("MCEControl")!.Logger!.Repository!.LevelMap![Instance.Settings.TextBoxLogThreshold]!;
+        // Load AppSettings (also configures logging; some logging already happened).
+        ApplySettings(AppSettings.Deserialize($@"{Program.ConfigPath}{AppSettings.SettingsFileName}"));
         Logger.Instance.Log4.Info($"Logger: Logging to {Logger.Instance.LogFile}");
 
         // Telemetry
@@ -860,15 +854,39 @@ public partial class MainWindow : Form {
         if (d.ShowDialog(this) == DialogResult.OK) {
             Stop();
 
-            Settings = d.Settings;
+            ApplySettings(d.Settings);
 
             Opacity = (double)Settings.Opacity / 100;
-
-            Logger.Instance.TextBoxThreshold = LogManager.GetLogger("MCEControl")!.Logger!.Repository!.LevelMap![Settings.TextBoxLogThreshold]!;
 
             Start();
         }
         d.Dispose();
+    }
+
+    /// <summary>
+    /// Adopts <paramref name="settings"/> as the active settings object — for the GUI AND the
+    /// UI-agnostic agent engine. This is the single apply path used both at load and when the
+    /// Settings dialog is OK'd (the dialog hands back a deep clone, so the object identity changes
+    /// and <see cref="AgentRuntime.Settings"/> MUST be re-published; see #196: security gates such
+    /// as <c>AllowSessionProvisioning</c> and pacing read that seam, and a stale pre-dialog object
+    /// would keep honoring old gate values until restart).
+    /// </summary>
+    private void ApplySettings(AppSettings settings) {
+        Settings = settings;
+        PublishAgentRuntimeSettings(settings);
+
+        Logger.Instance.TextBoxThreshold = LogManager.GetLogger("MCEControl")!.Logger!.Repository!.LevelMap![settings.TextBoxLogThreshold]!;
+    }
+
+    /// <summary>
+    /// Publishes the settings object to the UI-agnostic agent engine seam
+    /// (capture/query/find/invoke + MCP/HTTP read gating and pacing from
+    /// <see cref="AgentRuntime.Settings"/>). Static and internal so the regression test can
+    /// exercise the republish contract headlessly without constructing a Form
+    /// (InternalsVisibleTo MCEControl.xUnit).
+    /// </summary>
+    internal static void PublishAgentRuntimeSettings(AppSettings settings) {
+        AgentRuntime.Settings = settings;
     }
 
     // ----------------------------------------

--- a/tests/MCEControl.xUnit/Agent/MainWindowApplySettingsTests.cs
+++ b/tests/MCEControl.xUnit/Agent/MainWindowApplySettingsTests.cs
@@ -1,0 +1,69 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Regression tests for #196: the Settings dialog hands MainWindow a deep clone on OK, and the
+/// apply path must re-publish that new object to <see cref="AgentRuntime.Settings"/> — otherwise
+/// the UI-agnostic engine (AgentServer security gates, CommandInvoker pacing, overlay, record)
+/// keeps reading the stale pre-dialog object until restart. MainWindow is a Form and impractical
+/// to construct headlessly, so these tests exercise the extracted republish helper
+/// (<see cref="MainWindow.PublishAgentRuntimeSettings"/>) that both the load and dialog-OK paths
+/// go through, and verify the outcome via <see cref="AgentRuntime"/> state.
+/// </summary>
+[Collection("AgentSerial")]
+public class MainWindowApplySettingsTests {
+    [Fact]
+    public void PublishAgentRuntimeSettings_RepublishesTheExactNewObject() {
+        AppSettings? saved = AgentRuntime.Settings;
+        try {
+            var initial = new AppSettings();
+            MainWindow.PublishAgentRuntimeSettings(initial);
+            Assert.Same(initial, AgentRuntime.Settings);
+
+            // Simulate the Settings dialog OK path: it returns a clone, not the same instance.
+            var clone = (AppSettings)initial.Clone();
+            Assert.NotSame(initial, clone);
+
+            MainWindow.PublishAgentRuntimeSettings(clone);
+
+            // The engine seam must now be the new object — not the stale pre-dialog one.
+            Assert.Same(clone, AgentRuntime.Settings);
+        }
+        finally {
+            AgentRuntime.Settings = saved;
+        }
+    }
+
+    [Fact]
+    public void PublishAgentRuntimeSettings_EngineGatesSeeNewValues() {
+        AppSettings? saved = AgentRuntime.Settings;
+        try {
+            var initial = new AppSettings { AgentCommandsEnabled = false };
+            MainWindow.PublishAgentRuntimeSettings(initial);
+            Assert.False(AgentRuntime.AgentCommandsEnabled);
+
+            // Operator flips a security gate in the Settings dialog; OK produces a clone.
+            var clone = (AppSettings)initial.Clone();
+            clone.AgentCommandsEnabled = true;
+
+            MainWindow.PublishAgentRuntimeSettings(clone);
+
+            // Gate checks that read AgentRuntime.Settings must reflect the post-dialog value.
+            Assert.True(AgentRuntime.AgentCommandsEnabled);
+
+            // And flipping it back off in a later dialog round-trip must also take effect.
+            var second = (AppSettings)clone.Clone();
+            second.AgentCommandsEnabled = false;
+            MainWindow.PublishAgentRuntimeSettings(second);
+            Assert.False(AgentRuntime.AgentCommandsEnabled);
+        }
+        finally {
+            AgentRuntime.Settings = saved;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`AgentRuntime.Settings` — the UI-agnostic seam the agent engine reads for **security gates** (`AgentServer.cs` `AllowSessionProvisioning` et al.), `CommandInvoker` pacing, the command overlay, and `RecordCommand` — was published exactly once at load. `ShowSettings()` replaced `MainWindow.Settings` with the dialog's deep clone on OK but never re-published, so the engine kept honoring stale pre-dialog gate values until restart: a silent split-brain between GUI and engine.

## Change

- **`src/MainWindow.cs`**: new single `ApplySettings(AppSettings)` used by both the load path and the dialog-OK path. It adopts the settings object, re-publishes `AgentRuntime.Settings`, and sets the TextBox log threshold both paths previously duplicated. The republish itself is extracted into `PublishAgentRuntimeSettings` (internal static) so it is testable headlessly — `MainWindow` is a Form and impractical to construct in tests.
- **`tests/MCEControl.xUnit/Agent/MainWindowApplySettingsTests.cs`**: regression tests that simulate the dialog round-trip (publish → `Clone()` with flipped `AgentCommandsEnabled` → publish again) and assert `AgentRuntime.Settings` is reference-equal to the new object and `AgentRuntime.AgentCommandsEnabled` reflects the post-dialog values. Carries `[Collection("AgentSerial")]` and restores `AgentRuntime.Settings` in `finally`.

Notes on scope:
- `AgentRuntime.Invoker` needs no equivalent fix — it is already re-published at its recreation site (`LoadCommands`, `MainWindow.cs`), and `ShowSettings` does not recreate the invoker.
- Dialog persistence / `SettingsDialog` structure untouched (that is #213).

Fixes #196

## Test plan

- `dotnet build` — clean (0 errors; only the pre-existing `WFDEV004` in `MainWindow.Designer.cs`).
- `dotnet test` — 594 passed, 0 failed, 22 skipped (desktop/input-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm