### PR TITLE
fix: refuse unknown tool names in BuildCommand instead of defaulting to InvokeCommand

### DIFF
--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -432,7 +432,18 @@ public static class AgentServer {
         return null;
     }
 
-    private static JsonObject RunAgentCommand(string name, JsonObject args) {
+    // Internal so tests can exercise the unknown-tool refusal for a name that passed the
+    // tools/call gate but has no argument mapping (InternalsVisibleTo). See #201.
+    internal static JsonObject RunAgentCommand(string name, JsonObject args) {
+        // #201: the tools/call gate whitelist and BuildCommand's arg-mapping switch are two
+        // hand-maintained lists. If a name passes the gate but has no mapping, refuse with a
+        // structured error — the old default arm silently mapped unknown names onto InvokeCommand
+        // (an ACTUATION) with garbage selector args.
+        if (BuildCommand(name, args) is not Command cmd) {
+            AgentRuntime.Audit(name, "BLOCKED — tool has no argument mapping; refusing to run it as another command");
+            return ToolError($"Unknown tool: {name}", "unknown-tool");
+        }
+
         // Honor the per-command Enabled flag — the documented second security gate. The MCP tool only
         // runs if the corresponding command in the loaded table is enabled (built-ins ship disabled;
         // the operator opts in per-command via mcec.commands). Fail closed if the table/command is missing.
@@ -441,7 +452,6 @@ public static class AgentServer {
             return ToolError($"The '{name}' command is disabled. Enable it in mcec.commands (set Enabled=\"true\").", "command-disabled");
         }
 
-        Command cmd = BuildCommand(name, args);
         CapturingReply reply = new();
         cmd.Reply = reply;
         cmd.Enabled = true;
@@ -646,8 +656,13 @@ public static class AgentServer {
         return items.Count > 0 ? items : null;
     }
 
-    /// <summary>Builds and populates an agent command instance from MCP tool arguments.</summary>
-    private static Command BuildCommand(string name, JsonObject args) => name switch {
+    /// <summary>
+    /// Builds and populates an agent command instance from MCP tool arguments. Exhaustive over the
+    /// agent tool names: an unknown name returns <c>null</c> (the caller refuses it as
+    /// <c>unknown-tool</c>) rather than falling through to a default command (#201). Internal so
+    /// tests can pin the mapping (InternalsVisibleTo).
+    /// </summary>
+    internal static Command? BuildCommand(string name, JsonObject args) => name switch {
         "capture" => new CaptureCommand {
             Window = Str(args, "window")!,
             Handle = Long(args, "handle"),
@@ -704,7 +719,7 @@ public static class AgentServer {
         "drag" => BuildDragCommand(args),
         "click" => BuildClickCommand(args),
         "displays" => new DisplaysCommand(),
-        _ => new InvokeCommand { // invoke
+        "invoke" => new InvokeCommand {
             Window = Str(args, "window")!,
             Handle = Long(args, "handle"),
             Process = Str(args, "process")!,
@@ -715,6 +730,7 @@ public static class AgentServer {
             Action = Str(args, "action") ?? "invoke",
             Text = Str(args, "text")!,
         },
+        _ => null, // unknown name — the caller reports unknown-tool; never guess a command (#201)
     };
 
     /// <summary>Maps the drag tool's nested <c>from</c>/<c>to</c>/<c>path</c> arguments onto a <see cref="DragCommand"/>.</summary>

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -497,6 +497,60 @@ public class AgentServerTests {
         }
     }
 
+    // --- #201: BuildCommand's arg-mapping switch is exhaustive. A tool name that passed the
+    // tools/call gate but has no mapping must be refused with a structured unknown-tool error —
+    // historically the switch's default arm silently mapped it onto InvokeCommand (an ACTUATION)
+    // with garbage selector args.
+
+    [Fact]
+    public void RunAgentCommand_NameWithNoArgMapping_ReportsUnknownTool_NotInvokeExecution() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        // Even with a matching, ENABLED entry in the command table — i.e. a name that passes every
+        // gate — a name the switch does not map must be refused, never run as another command.
+        AgentRuntime.Invoker = new CommandInvoker { ["hover"] = new CaptureCommand { Cmd = "hover", Enabled = true } };
+        try {
+            JsonObject resp = AgentServer.RunAgentCommand("hover", []);
+
+            Assert.True(resp["isError"]!.GetValue<bool>());
+            JsonObject envelope = JsonNode.Parse(FirstTextBlock(resp))!.AsObject();
+            Assert.False(envelope["ok"]!.GetValue<bool>());
+            JsonObject error = envelope["error"]!.AsObject();
+            Assert.Equal("unknown-tool", error["code"]!.GetValue<string>());
+            Assert.Equal("internal", error["category"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.Invoker = null;
+        }
+    }
+
+    [Fact]
+    public void BuildCommand_UnknownName_ReturnsNull_NeverADefaultCommand() {
+        // The old default arm meant an unmapped name became an InvokeCommand. Now it maps to null,
+        // which RunAgentCommand refuses as unknown-tool.
+        Assert.Null(AgentServer.BuildCommand("hover", new JsonObject { ["window"] = "X", ["value"] = "OK" }));
+    }
+
+    [Fact]
+    public void BuildCommand_Invoke_StillMapsToInvokeCommand() {
+        // "invoke" has its own explicit case (#201) — the mapping must be unchanged.
+        Command? cmd = AgentServer.BuildCommand("invoke", new JsonObject {
+            ["window"] = "Calculator",
+            ["by"] = "automationId",
+            ["value"] = "num7Button",
+            ["action"] = "toggle",
+            ["text"] = "hi",
+        });
+
+        InvokeCommand invoke = Assert.IsType<InvokeCommand>(cmd);
+        Assert.Equal("Calculator", invoke.Window);
+        Assert.Equal("automationId", invoke.By);
+        Assert.Equal("num7Button", invoke.Value);
+        Assert.Equal("toggle", invoke.Action);
+        Assert.Equal("hi", invoke.Text);
+    }
+
     private static string FirstTextBlock(JsonObject toolResult) {
         foreach (JsonNode? block in toolResult["content"]!.AsArray()) {
             if (block?["type"]?.GetValue<string>() == "text") {


### PR DESCRIPTION
Fixes #201

## Problem

`BuildCommand`'s arg-mapping switch fell through to `_ => new InvokeCommand { ... }` (src/Services/AgentServer.cs). This was only safe because the `tools/call` gate whitelist ~330 lines earlier happened to end at `invoke` — two hand-maintained lists that had to agree. Add a new tool name to the whitelist and forget the switch, and the request was silently mapped onto an **actuation** command with garbage selector args instead of erroring.

## Fix (tactical, per the issue — #205 is the strategic single-table fix)

- `BuildCommand` is now exhaustive: `"invoke"` has its own explicit case; the default arm returns `null`.
- `RunAgentCommand` refuses an unmapped name up front with the **existing** `unknown-tool` error code (the same code the gate itself uses for unlisted names), in the #101 envelope (`ok:false`, `error.category: internal`), audit-logged, and returned as a proper MCP tool failure (`isError: true`) — never an exception, never a guessed command.
- `BuildCommand`/`RunAgentCommand` are `internal` (existing `InternalsVisibleTo("MCEControl.xUnit")`) so tests can pin the mapping and the refusal.

## Guidance rule check

`src/Agent/AgentInstructions.md` reviewed: it does not enumerate per-tool names/codes for this path, and the new refusal is unreachable for an agent using the published tool list (the gate rejects unknown names first with the same `unknown-tool` code). No guidance change needed.

## Tests

New in `tests/MCEControl.xUnit/Services/AgentServerTests.cs` (`[Collection("AgentSerial")]`):

- `RunAgentCommand_NameWithNoArgMapping_ReportsUnknownTool_NotInvokeExecution` — a name that hypothetically passed the gate (enabled entry in the command table, `AgentCommandsEnabled=true`) yields the structured `unknown-tool` envelope, not an InvokeCommand execution.
- `BuildCommand_UnknownName_ReturnsNull_NeverADefaultCommand`
- `BuildCommand_Invoke_StillMapsToInvokeCommand` — the invoke mapping is unchanged (window/by/value/action/text pinned).

`dotnet build` clean (TreatWarningsAsErrors + house analyzers); `dotnet test`: **595 passed, 0 failed, 22 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm