### PR TITLE
fix: gate all telemetry metrics behind the opt-in (TrackMetric)

### DIFF
--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -114,7 +114,7 @@ public abstract class Command : ICommand {
         // what: the number of commands of each type (key) received and executed
         // why: to understand what commands are used and which are not
         // how is PII protected: the name of the command, key, is not user definable
-        TelemetryService.Instance!.TelemetryClient!.GetMetric($"{(UserDefined ? "<userDefined>" : cmd)} Executed").TrackValue(1);
+        TelemetryService.Instance.TrackMetric($"{(UserDefined ? "<userDefined>" : cmd)} Executed", 1);
         return true;
     }
 

--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -221,5 +221,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "<Pending>", Scope = "type", Target = "~T:MCEControl.Commands")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "<Pending>", Scope = "member", Target = "~P:MCEControl.MainWindow.Invoker")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "<Pending>", Scope = "member", Target = "~M:MCEControl.SerializedCommands.LoadBuiltInCommands~MCEControl.SerializedCommands")]
-[assembly: SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "<Pending>", Scope = "member", Target = "~M:MCEControl.TelemetryService.GetTelemetryClient~Microsoft.ApplicationInsights.TelemetryClient")]
 [assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>", Scope = "member", Target = "~M:MCEControl.UserActivityMonitorService.Start")]

--- a/src/Services/ServiceBase.cs
+++ b/src/Services/ServiceBase.cs
@@ -45,7 +45,7 @@ public abstract class ServiceBase {
         // why: to understand what commands are used to control other systems and which are not
         // how is PII protected: we only collect the text if it is a key for a built-in command
         Command? userDefined = MainWindow.Instance.Invoker.Values.Cast<Command>().FirstOrDefault(q => (q.Cmd == text.Trim('\r').Trim('\n') && q.UserDefined == false));
-        TelemetryService.Instance.TelemetryClient!.GetMetric($"{(userDefined == null ? "<userDefined>" : text.Trim('\r').Trim('\n'))} Sent").TrackValue(1);
+        TelemetryService.Instance.TrackMetric($"{(userDefined == null ? "<userDefined>" : text.Trim('\r').Trim('\n'))} Sent", 1);
     }
 
     // Send a status notification
@@ -69,7 +69,7 @@ public abstract class ServiceBase {
                     // what: how long the session was connected for
                     // why: to understand the typical/non-typical connection scenarios
                     // how is PII protected: no PII is involved
-                    TelemetryService.Instance.TelemetryClient!.GetMetric($"{this.GetType().Name} Connected Time").TrackValue(_connectedTime.ElapsedMilliseconds);
+                    TelemetryService.Instance.TrackMetric($"{this.GetType().Name} Connected Time", _connectedTime.ElapsedMilliseconds);
                 }
                 break;
         }

--- a/src/Services/TelemetryService.cs
+++ b/src/Services/TelemetryService.cs
@@ -29,8 +29,12 @@ public partial class TelemetryService {
     public bool TelemetryEnabled { get; set; }
     public Stopwatch? RunTime { get; set; }
 
-    // internal setter so tests can substitute a client backed by a stub channel (#156).
-    public TelemetryClient? TelemetryClient { get; internal set; }
+    // Internal (not public) so no caller outside this class can send telemetry with the raw
+    // client, bypassing the TelemetryEnabled opt-in gate (#199). Production code must go through
+    // TrackEvent/TrackException/TrackMetric, which all gate on the user's registry opt-in.
+    // The property exists solely as a test seam (InternalsVisibleTo MCEControl.xUnit) so tests
+    // can substitute a client backed by a stub channel (#156).
+    internal TelemetryClient? TelemetryClient { get; set; }
 
     public void Start(string appName, IDictionary<string, string>? startProperties = null) {
         RunTime = Stopwatch.StartNew();
@@ -92,18 +96,33 @@ public partial class TelemetryService {
         // why: to understand how long the app stays running
         // how is PII protected: the time the app runs is not PII
         TrackEvent("Application Stopped",
-            metrics: new Dictionary<string, double> { { "runTime", RunTime!.Elapsed.TotalMilliseconds } });
+            metrics: new Dictionary<string, double> { { "runTime", RunTime?.Elapsed.TotalMilliseconds ?? 0 } });
 
-        // before exit, flush the remaining data
-        Flush();
-        // Flush is not blocking so wait a bit
-        Task.Delay(1000).Wait();
+        // Only flush (and pay the shutdown delay) when there can actually be pending data (#199).
+        if (TelemetryEnabled && TelemetryClient != null) {
+            // before exit, flush the remaining data
+            Flush();
+            // Flush is not blocking so wait a bit
+            Task.Delay(1000).Wait();
+        }
     }
 
     public void TrackEvent(string key, IDictionary<string, string>? properties = null,
         IDictionary<string, double>? metrics = null) {
         if (TelemetryEnabled && TelemetryClient != null) {
             TelemetryClient.TrackEvent(key, properties, metrics);
+        }
+    }
+
+    /// <summary>
+    /// Records a value for a metric, subject to the user's telemetry opt-in. This is the only
+    /// supported way to send metrics: it applies the same <c>TelemetryEnabled</c> gate as
+    /// <see cref="TrackEvent"/> and is a safe no-op before <see cref="Start"/> constructs the
+    /// client (#199).
+    /// </summary>
+    public void TrackMetric(string name, double value) {
+        if (TelemetryEnabled && TelemetryClient != null) {
+            TelemetryClient.GetMetric(name).TrackValue(value);
         }
     }
 

--- a/src/Services/UserActivityMonitorService.cs
+++ b/src/Services/UserActivityMonitorService.cs
@@ -311,7 +311,7 @@ public sealed class UserActivityMonitorService : IDisposable {
             // what: the count of activity detected
             // why: to understand how frequently activity is detected
             // how is PII protected: the frequency of activity is not PII
-            TelemetryService.Instance.TelemetryClient!.GetMetric("activity Sent").TrackValue(1);
+            TelemetryService.Instance.TrackMetric("activity Sent", 1);
 
             MainWindow.Instance.SendLine(ActivityMsg);
 

--- a/tests/MCEControl.xUnit/Agent/AgentTestSupport.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentTestSupport.cs
@@ -8,10 +8,12 @@ namespace MCEControl.xUnit;
 /// <summary>
 /// Shared helpers for the agent tests. The agent commands follow the house pattern where
 /// <see cref="Command.Execute"/> first calls <c>base.Execute()</c>, which (for an Enabled command)
-/// records a telemetry metric via <c>TelemetryService.Instance.TelemetryClient</c>. That client is
-/// null until <see cref="TelemetryService.Start"/> is called, so any test that drives an Enabled
-/// command through Execute must initialize telemetry first. <see cref="EnsureTelemetry"/> does that
-/// exactly once for the whole test run; it is safe to call from multiple threads.
+/// records a telemetry metric via <see cref="TelemetryService.TrackMetric"/>. Since #199 that call
+/// is gated on the opt-in and is a safe no-op while the client is null, so initializing telemetry
+/// is no longer required to avoid a crash — but tests that drive Enabled commands still call
+/// <see cref="EnsureTelemetry"/> so Execute runs against an initialized singleton, matching the
+/// real app. It initializes exactly once for the whole test run; it is safe to call from multiple
+/// threads.
 /// </summary>
 internal static class AgentTestSupport {
     private static readonly object _gate = new();

--- a/tests/MCEControl.xUnit/Services/TelemetryServiceTrackMetricTests.cs
+++ b/tests/MCEControl.xUnit/Services/TelemetryServiceTrackMetricTests.cs
@@ -1,0 +1,104 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Linq;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Xunit;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Tests for #199: <see cref="TelemetryService.TrackMetric"/> is the only supported way to send
+/// metrics and must honor the user's telemetry opt-in (<c>TelemetryEnabled</c>) exactly like
+/// <c>TrackEvent</c>/<c>TrackException</c>, and must never throw when the client has not been
+/// constructed yet (i.e., before <c>Start()</c>). Uses a stub channel — no telemetry leaves the
+/// process, and the real registry opt-in is never touched (the tests set
+/// <c>TelemetryEnabled</c> directly).
+/// Joins the "AgentSerial" collection because tests in that collection initialize the
+/// TelemetryService singleton (AgentTestSupport.EnsureTelemetry); these tests temporarily swap
+/// the singleton's client and must not race with them.
+/// </summary>
+[Collection("AgentSerial")]
+public class TelemetryServiceTrackMetricTests {
+    [Fact]
+    public void TrackMetric_WhenEnabled_SendsMetricThroughChannel() {
+        TelemetryService svc = TelemetryService.Instance;
+        TelemetryClient? originalClient = svc.TelemetryClient;
+        bool originalEnabled = svc.TelemetryEnabled;
+
+        using StubTelemetryChannel channel = new();
+        using TelemetryConfiguration config = new() {
+            TelemetryChannel = channel,
+            ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        };
+
+        try {
+            svc.TelemetryClient = new TelemetryClient(config);
+            svc.TelemetryEnabled = true;
+
+            svc.TrackMetric("test Sent", 42);
+            // GetMetric aggregates locally; Flush pushes the aggregate through the channel.
+            svc.Flush();
+
+            MetricTelemetry sent = Assert.Single(channel.SentItems.OfType<MetricTelemetry>());
+            Assert.Equal("test Sent", sent.Name);
+            Assert.Equal(42, sent.Sum);
+        }
+        finally {
+            svc.TelemetryEnabled = originalEnabled;
+            svc.TelemetryClient = originalClient;
+        }
+    }
+
+    [Fact]
+    public void TrackMetric_WhenDisabled_SendsNothing() {
+        TelemetryService svc = TelemetryService.Instance;
+        TelemetryClient? originalClient = svc.TelemetryClient;
+        bool originalEnabled = svc.TelemetryEnabled;
+
+        using StubTelemetryChannel channel = new();
+        using TelemetryConfiguration config = new() {
+            TelemetryChannel = channel,
+            ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        };
+
+        try {
+            svc.TelemetryClient = new TelemetryClient(config);
+            svc.TelemetryEnabled = false;
+
+            svc.TrackMetric("test Sent", 1);
+            svc.Flush();
+
+            Assert.Empty(channel.SentItems);
+        }
+        finally {
+            svc.TelemetryEnabled = originalEnabled;
+            svc.TelemetryClient = originalClient;
+        }
+    }
+
+    [Fact]
+    public void TrackMetric_WhenClientNull_DoesNotThrow() {
+        TelemetryService svc = TelemetryService.Instance;
+        TelemetryClient? originalClient = svc.TelemetryClient;
+        bool originalEnabled = svc.TelemetryEnabled;
+
+        try {
+            svc.TelemetryClient = null;
+            // Enabled on purpose: the null-client guard alone must make this safe (#199 —
+            // previously anything sending a metric before Start() dereferenced null).
+            svc.TelemetryEnabled = true;
+
+            Exception? ex = Record.Exception(() => svc.TrackMetric("test Sent", 1));
+
+            Assert.Null(ex);
+        }
+        finally {
+            svc.TelemetryEnabled = originalEnabled;
+            svc.TelemetryClient = originalClient;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #199

## Problem

`TrackEvent`/`TrackException` check the telemetry registry opt-in, but four call sites sent metrics through the raw `TelemetryClient`, which `Start()` constructs unconditionally:

- `src/Services/ServiceBase.cs` — `"... Sent"` and `"... Connected Time"` metrics
- `src/Services/UserActivityMonitorService.cs` — `"activity Sent"`
- `src/Commands/Command.cs` — `"... Executed"`

Consequences: (a) the moment a real connection string ships, these metrics flow for users who never opted in — today only the empty instrumentation key saves us; (b) the `!` NREs if anything sends before `TelemetryService.Start()`. Also `Stop()` stalled 1 second unconditionally even with telemetry disabled.

## Changes

- **`TelemetryClient` is now `internal`** (was `public` get / `internal` set) and documented as a test-only seam (`InternalsVisibleTo MCEControl.xUnit`). Production code must go through the gated `Track*` methods.
- **New `TelemetryService.TrackMetric(string name, double value)`** with the same `TelemetryEnabled && client != null` guard as `TrackEvent`; safe no-op before `Start()`.
- **Migrated the four call sites** to `TrackMetric`. Metric-name construction is byte-identical, including the `<userDefined>` classification in `ServiceBase.Send` and `Command.Execute` — only the gating changed.
- **`Stop()`** now skips `Flush()` and the 1s `Task.Delay(...).Wait()` when telemetry is disabled or was never started, and reads `RunTime` null-safely.
- Removed a stale `CA1024` suppression targeting the long-gone `TelemetryService.GetTelemetryClient` method.
- Updated the `AgentTestSupport.EnsureTelemetry` doc comment (the "client is null → NRE" rationale no longer holds; kept for realism).

## Tests

New `tests/MCEControl.xUnit/Services/TelemetryServiceTrackMetricTests.cs` (follows the #156 stub-channel pattern, joins the `AgentSerial` collection):

- `TrackMetric_WhenEnabled_SendsMetricThroughChannel` — metric flows to the stub channel with the right name/value
- `TrackMetric_WhenDisabled_SendsNothing`
- `TrackMetric_WhenClientNull_DoesNotThrow`

No test touches the real registry opt-in or installed config: they set `TelemetryEnabled` directly and swap in a client backed by `StubTelemetryChannel`, restoring the singleton state in `finally`.

`dotnet build`: 0 errors (only the pre-existing WFDEV004 warning). `dotnet test`: **595 passed, 0 failed, 22 skipped** (desktop-input tests, expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm