### PR TITLE
fix: separate SocketServer Stop() from Dispose(), quiet shutdown, guard per-client Send

### DIFF
--- a/src/Services/SocketServer.cs
+++ b/src/Services/SocketServer.cs
@@ -37,10 +37,30 @@ sealed public class SocketServer : ServiceBase, IDisposable {
     // Test seams (InternalsVisibleTo MCEControl.xUnit)
     internal int ConnectedClientCount => _clientCount;
     internal IReadOnlyDictionary<int, Socket> TrackedClients => _clientList;
+    // The port the listener actually bound (tests Start on port 0 so the OS assigns an
+    // ephemeral port that a loopback client can then connect to); 0 when not listening.
+    internal int ListeningPort => (_mainSocket?.LocalEndPoint as IPEndPoint)?.Port ?? 0;
+
+    // True once Dispose() has run. Dispose is terminal: unlike Stop() (which leaves the
+    // object restartable), a disposed SocketServer can never be Start()ed again (#202).
+    private bool _disposed;
 
     #region IDisposable Members
+    /// <summary>
+    /// Terminal teardown. Guarded and idempotent: the first call closes the listener and every
+    /// tracked client; later calls no-op. After Dispose, <see cref="Start"/> throws
+    /// <see cref="ObjectDisposedException"/>. Contrast with <see cref="Stop"/>, which closes the
+    /// same sockets but leaves the object restartable. Before issue #202 Stop() <i>was</i>
+    /// Dispose(true) and the "disposed" object was routinely resurrected by Start(), so
+    /// "stopped" and "disposed" were the same state and nothing guarded either.
+    /// </summary>
     public void Dispose() {
-        Dispose(true);
+        if (_disposed) {
+            return;
+        }
+        _disposed = true;
+        Log4.Debug("SocketServer disposing...");
+        CloseListenerAndClients();
         GC.SuppressFinalize(this);
     }
     #endregion
@@ -48,12 +68,13 @@ sealed public class SocketServer : ServiceBase, IDisposable {
     // Disposable members
     private Socket? _mainSocket;
 
-    private void Dispose(bool disposing) {
-        Log4.Debug("SocketServer disposing...");
-        if (!disposing) {
-            return;
-        }
-
+    /// <summary>
+    /// Closes the listening socket and force-closes every tracked client, draining the
+    /// connected tally so a later <see cref="Start"/> does not report a stale count. This is
+    /// the shared teardown used by both the resettable <see cref="Stop"/> and the terminal
+    /// <see cref="Dispose"/> — it mutates live state but does NOT mark the object disposed (#202).
+    /// </summary>
+    private void CloseListenerAndClients() {
         foreach (int i in _clientList.Keys) {
             _clientList.TryRemove(i, out Socket? socket);
             if (socket != null) {
@@ -135,6 +156,8 @@ sealed public class SocketServer : ServiceBase, IDisposable {
     }
 
     public void Start(int port, string? bindAddress = null) {
+        // Stop() is resettable; Dispose() is terminal (#202). Never resurrect a disposed server.
+        ObjectDisposedException.ThrowIf(_disposed, this);
         try {
             // Create the listening socket on the address family of the resolved bind address (#149),
             // so an IPv6 bind (e.g. "::1") gets an IPv6 socket rather than throwing on an IPv4 one.
@@ -161,9 +184,15 @@ sealed public class SocketServer : ServiceBase, IDisposable {
         }
     }
 
+    /// <summary>
+    /// Stops the server: closes the listener and force-closes every tracked client. Unlike
+    /// <see cref="Dispose"/> this is resettable — a stopped server may be <see cref="Start"/>ed
+    /// again (the operator toggles the service on/off in Settings). Before issue #202 this
+    /// called Dispose(true), conflating "stopped" with "disposed".
+    /// </summary>
     public void Stop() {
         Log4.Debug("SocketServer Stop");
-        Dispose(true);
+        CloseListenerAndClients();
         SetStatus(ServiceStatus.Stopped);
     }
 
@@ -173,7 +202,11 @@ sealed public class SocketServer : ServiceBase, IDisposable {
     private void OnClientConnect(IAsyncResult async) {
         Log4.Debug("SocketServer OnClientConnect");
 
-        if (_mainSocket == null) {
+        // Capture the listener locally: Stop()/Dispose() null the field from another thread,
+        // and dereferencing the field again below would race a NullReferenceException into
+        // the generic catch (a spurious Error notification on every stop — #202).
+        Socket? listener = _mainSocket;
+        if (listener == null) {
             return;
         }
 
@@ -182,7 +215,7 @@ sealed public class SocketServer : ServiceBase, IDisposable {
             // Here we complete/end the BeginAccept() asynchronous call
             // by calling EndAccept() - which returns the reference to
             // a new Socket object
-            Socket workerSocket = _mainSocket.EndAccept(async);
+            Socket workerSocket = listener.EndAccept(async);
 
             serverReplyContext = RegisterClient(workerSocket);
 
@@ -200,23 +233,47 @@ sealed public class SocketServer : ServiceBase, IDisposable {
             // just connected client
             BeginReceive(serverReplyContext);
         }
+        catch (ObjectDisposedException) {
+            // Expected on Stop()/Dispose(): closing the listener completes the pending
+            // BeginAccept, and EndAccept then throws ObjectDisposedException. This is
+            // normal shutdown — not an error. Before issue #202 the generic catch below
+            // turned every stop into a spurious Error notification (and a CloseSocket
+            // call on a null context). Do not re-arm the accept; the listener is gone.
+            Log4.Debug("SocketServer OnClientConnect: listener closed during shutdown");
+            return;
+        }
+        catch (SocketException se) when (se.SocketErrorCode == SocketError.OperationAborted) {
+            // The accept was aborted because the listener is shutting down — same benign
+            // shutdown shape as the ObjectDisposedException above (#202).
+            Log4.Debug("SocketServer OnClientConnect: accept aborted during shutdown");
+            return;
+        }
         catch (SocketException se) {
             SendNotification(ServiceNotification.Error, CurrentStatus, serverReplyContext, $"OnClientConnect: {se.Message}, {se.HResult:X} ({se.SocketErrorCode})");
             // See http://msdn.microsoft.com/en-us/library/windows/desktop/ms740668(v=vs.85).aspx
             //if (se.SocketErrorCode == SocketError.ConnectionReset) // WSAECONNRESET (10054)
-            {
+            if (serverReplyContext != null) {
                 // Forcibly closed
-                CloseSocket(serverReplyContext!);
+                CloseSocket(serverReplyContext);
             }
         }
         catch (Exception e) {
             SendNotification(ServiceNotification.Error, CurrentStatus, serverReplyContext, $"OnClientConnect: {e.Message}");
-            CloseSocket(serverReplyContext!);
+            if (serverReplyContext != null) {
+                CloseSocket(serverReplyContext);
+            }
         }
 
         // Since the main Socket is now free, it can go back and wait for
         // other clients who are attempting to connect
-        _mainSocket?.BeginAccept(OnClientConnect, null);
+        try {
+            _mainSocket?.BeginAccept(OnClientConnect, null);
+        }
+        catch (ObjectDisposedException) {
+            // Raced with Stop()/Dispose() between the accept completing and the re-arm —
+            // benign shutdown, nothing to re-arm (#202).
+            Log4.Debug("SocketServer OnClientConnect: listener closed before accept re-arm");
+        }
     }
 
     // Tracks a newly connected client. Internal so tests can exercise the
@@ -553,12 +610,41 @@ sealed public class SocketServer : ServiceBase, IDisposable {
             }
         }
         else {
-            if (((ServerReplyContext)replyContext).Socket.Send(Encoding.UTF8.GetBytes(text)) > 0) {
+            SendToClient(text, (ServerReplyContext)replyContext);
+        }
+    }
+
+    /// <summary>
+    /// Sends <paramref name="text"/> to a single tracked client, guarding the raw
+    /// <see cref="Socket.Send(byte[])"/>. A peer can vanish between the broadcast loop's
+    /// tracking lookup and the send; before issue #202 the resulting exception escaped
+    /// <see cref="Send"/> into whatever command handler triggered the write. A failed send is
+    /// terminal for that client: it is closed and removed from tracking (complementing the
+    /// receive-path fix from #150) and a <see cref="ServiceNotification.WriteFailed"/> is
+    /// emitted — never an unhandled throw. Internal so tests can drive it without a live
+    /// listener (InternalsVisibleTo).
+    /// </summary>
+    internal void SendToClient(string text, ServerReplyContext replyContext) {
+        try {
+            if (replyContext.Socket.Send(Encoding.UTF8.GetBytes(text)) > 0) {
                 SendNotification(ServiceNotification.Write, CurrentStatus, replyContext, text.Trim());
             }
             else {
                 SendNotification(ServiceNotification.WriteFailed, CurrentStatus, replyContext, text);
             }
+        }
+        catch (SocketException se) {
+            SendNotification(ServiceNotification.WriteFailed, CurrentStatus, replyContext,
+                $"Send: {se.Message}, {se.HResult:X} ({se.SocketErrorCode})");
+            CloseSocket(replyContext);
+        }
+        catch (ObjectDisposedException) {
+            // The client's socket was closed out from under us (e.g. the receive path
+            // closed it between the tracking lookup and this send) — treat as a failed
+            // write and make sure the client is fully untracked.
+            SendNotification(ServiceNotification.WriteFailed, CurrentStatus, replyContext,
+                "Send: client socket was already closed");
+            CloseSocket(replyContext);
         }
     }
 

--- a/tests/MCEControl.xUnit/Services/SocketServerLifecycleTests.cs
+++ b/tests/MCEControl.xUnit/Services/SocketServerLifecycleTests.cs
@@ -1,0 +1,175 @@
+//-------------------------------------------------------------------
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+//-------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using Xunit;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Regression tests for issue #202: SocketServer conflated Stop() with Dispose().
+///   - Stop() must be resettable: a stopped server can Start() again and accept clients.
+///   - Dispose() must be terminal and guarded: idempotent, and Start() after Dispose() throws.
+///   - Stop() must be quiet: the pending EndAccept's ObjectDisposedException is expected
+///     shutdown, not an Error notification.
+///   - A per-client send to a dead peer must not throw out of Send into the calling command
+///     handler; the dead client is closed and removed from tracking (complements #150).
+/// Listener tests bind loopback on an ephemeral port (0) only, per the house pattern.
+/// </summary>
+public class SocketServerLifecycleTests : IDisposable {
+    private readonly SocketServer _server = new();
+
+    public SocketServerLifecycleTests() {
+        // Reaching ServiceStatus.Connected starts ServiceBase's connected-time stopwatch, and
+        // SetStatus(Stopped) then dereferences TelemetryService.Instance.TelemetryClient! —
+        // null until telemetry is initialized (see AgentTestSupport).
+        AgentTestSupport.EnsureTelemetry();
+    }
+
+    public void Dispose() {
+        _server.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static Socket NewSocket() =>
+        new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+    /// <summary>Polls (like the other loopback suites) instead of sleeping a fixed time, so the
+    /// test is fast when the server is fast and only slow when something is actually wrong.</summary>
+    private static void WaitUntil(Func<bool> condition, string because, int timeoutMs = 10000) {
+        var sw = Stopwatch.StartNew();
+        while (!condition()) {
+            Assert.True(sw.ElapsedMilliseconds < timeoutMs, $"Timed out waiting for {because}");
+            Thread.Sleep(10);
+        }
+    }
+
+    // ---- Stop() is resettable (#202) ----
+
+    [Fact]
+    public void Start_AfterStop_AcceptsNewClient() {
+        _server.Start(0, "loopback");
+        int firstPort = _server.ListeningPort;
+        Assert.NotEqual(0, firstPort);
+
+        using (TcpClient first = new()) {
+            first.Connect(IPAddress.Loopback, firstPort);
+            WaitUntil(() => _server.ConnectedClientCount == 1, "the first client to be tracked");
+        }
+
+        _server.Stop();
+        Assert.Equal(ServiceStatus.Stopped, _server.CurrentStatus);
+        Assert.Empty(_server.TrackedClients);
+        Assert.Equal(0, _server.ConnectedClientCount);
+        Assert.Equal(0, _server.ListeningPort);
+
+        // A stopped server is NOT disposed: it must Start again and accept a client.
+        _server.Start(0, "loopback");
+        int secondPort = _server.ListeningPort;
+        Assert.NotEqual(0, secondPort);
+
+        using TcpClient second = new();
+        second.Connect(IPAddress.Loopback, secondPort);
+        WaitUntil(() => _server.ConnectedClientCount == 1, "a client to be tracked after restart");
+        Assert.Equal(ServiceStatus.Connected, _server.CurrentStatus);
+    }
+
+    // ---- Stop() is quiet (#202) ----
+
+    [Fact]
+    public void Stop_WithPendingAccept_EmitsNoErrorNotification() {
+        var errors = new List<string>();
+        _server.Notifications += (notify, status, reply, msg) => {
+            if (notify == ServiceNotification.Error) {
+                lock (errors) {
+                    errors.Add(msg);
+                }
+            }
+        };
+
+        _server.Start(0, "loopback");
+        Assert.Equal(ServiceStatus.Waiting, _server.CurrentStatus);
+
+        _server.Stop();
+        Assert.Equal(ServiceStatus.Stopped, _server.CurrentStatus);
+
+        // Closing the listener completes the pending BeginAccept on a ThreadPool thread —
+        // the buggy path fired its spurious Error there, asynchronously — so give the
+        // callback time to run before asserting silence.
+        Thread.Sleep(500);
+        lock (errors) {
+            Assert.Empty(errors);
+        }
+    }
+
+    // ---- Dispose() is terminal and guarded (#202) ----
+
+    [Fact]
+    public void Dispose_IsIdempotent() {
+        var server = new SocketServer();
+        server.Start(0, "loopback");
+
+        server.Dispose();
+        var ex = Record.Exception(server.Dispose);
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Start_AfterDispose_ThrowsObjectDisposedException() {
+        var server = new SocketServer();
+        server.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => server.Start(0, "loopback"));
+    }
+
+    // ---- Per-client Send is guarded (#202) ----
+
+    [Fact]
+    public void SendToClient_DeadPeer_DoesNotThrow_AndRemovesClientFromTracking() {
+        // A never-connected socket makes Socket.Send throw a SocketException
+        // deterministically — the same shape as a peer that vanished between the
+        // broadcast loop's TryGetValue and the Send.
+        using Socket dead = NewSocket();
+        var context = _server.RegisterClient(dead);
+        var writeFailures = new List<string>();
+        _server.Notifications += (notify, status, reply, msg) => {
+            if (notify == ServiceNotification.WriteFailed) {
+                lock (writeFailures) {
+                    writeFailures.Add(msg);
+                }
+            }
+        };
+
+        var ex = Record.Exception(() => _server.SendToClient("hello", context));
+
+        Assert.Null(ex);
+        Assert.DoesNotContain(dead, _server.TrackedClients.Values);
+        Assert.Equal(0, _server.ConnectedClientCount);
+        lock (writeFailures) {
+            Assert.NotEmpty(writeFailures);
+        }
+    }
+
+    [Fact]
+    public void SendToClient_SocketClosedUnderneath_DoesNotThrow_AndRemovesClientFromTracking() {
+        // The receive path (#150) can close a client's socket between the broadcast loop's
+        // tracking lookup and the send — Socket.Send then throws ObjectDisposedException.
+        Socket dead = NewSocket();
+        var context = _server.RegisterClient(dead);
+        dead.Close();
+
+        var ex = Record.Exception(() => _server.SendToClient("hello", context));
+
+        Assert.Null(ex);
+        Assert.Empty(_server.TrackedClients);
+        Assert.Equal(0, _server.ConnectedClientCount);
+    }
+}


### PR DESCRIPTION
Fixes #202

## Problem

All in `src/Services/SocketServer.cs`:

1. **Stop was Dispose.** `Stop()` called `Dispose(true)` and the object was then reused by `Start()` — "disposed" and "stopped" were the same state, there was no `_disposed` guard, and `Dispose(bool)` mutated live state (the same shape that produced #147).
2. **Every stop emitted a spurious Error.** Closing the listener completes the pending `BeginAccept`; `EndAccept` then throws `ObjectDisposedException`, which fell into the generic catch → an `Error` notification on every stop plus a `CloseSocket(serverReplyContext!)` call with a null context.
3. **Broadcast `Send()` was unguarded.** The per-client `Socket.Send(...)` had no try/catch, so a peer vanishing between `TryGetValue` and `Send` threw out of `Send()` into whatever command handler called it.

## Fix

- **Resettable `Stop()` vs terminal, guarded `Dispose()`.** Both share `CloseListenerAndClients()` (closes the listener, force-closes every tracked client, drains the connected tally), but `Stop()` leaves the object restartable while `Dispose()` sets `_disposed`, is idempotent, and makes a later `Start()` throw `ObjectDisposedException`.
- **Quiet shutdown.** The expected `ObjectDisposedException` from `EndAccept` (and the `OperationAborted` `SocketException` shape) is swallowed with a Debug log — no Error notification, no null `CloseSocket` call, no accept re-arm. The re-arm itself is also guarded against racing a concurrent `Stop()`/`Dispose()`, and the listener is captured locally so the field null-out can't race an NRE into the generic catch. Genuinely unexpected accept errors still notify `Error` exactly as before.
- **Guarded per-client send.** Per-client writes moved to `SendToClient()`, which wraps the raw `Socket.Send` in try/catch: on `SocketException`/`ObjectDisposedException` the client gets a `WriteFailed` notification and is closed/removed from tracking (complements the #150 receive-path fix). The existing `Write`/`WriteFailed` semantics for successful/zero-byte sends are unchanged.

*Not in scope:* #150's `OnDataReceived` fix — already landed separately; this PR only complements it on the send path.

## Tests

New `tests/MCEControl.xUnit/Services/SocketServerLifecycleTests.cs`, following the house pattern (real loopback sockets on ephemeral port 0 + `InternalsVisibleTo` seams; a new `ListeningPort` seam exposes the OS-assigned port):

- `Start_AfterStop_AcceptsNewClient` — Start/Stop/Start works; a client is accepted and tracked after restart.
- `Stop_WithPendingAccept_EmitsNoErrorNotification` — stopping with a pending accept produces no `Error` notification.
- `Dispose_IsIdempotent` / `Start_AfterDispose_ThrowsObjectDisposedException` — the terminal, guarded Dispose contract.
- `SendToClient_DeadPeer_...` / `SendToClient_SocketClosedUnderneath_...` — a send to a dead client does not throw, emits `WriteFailed`, and removes the client from tracking.

`dotnet build` clean (TreatWarningsAsErrors + MCEC analyzers); full suite: **598 passed, 0 failed, 22 skipped** (desktop/input tests skipped by design). The new lifecycle suite ran 5x consecutively with no flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm