### PR TITLE
fix: lower-case XML attribute names so .commands values survive reload

### DIFF
--- a/src/Commands/ClickCommand.cs
+++ b/src/Commands/ClickCommand.cs
@@ -21,7 +21,8 @@ namespace MCEControl;
 public class ClickCommand : Command {
     // NOTE: attribute names MUST be all-lowercase. SerializedCommands.Deserialize runs an XSLT that
     // lower-cases every element/attribute name before deserializing, so a camelCase name would never
-    // bind on load and the value would be silently lost (see DragCommand).
+    // bind on load and the value would be silently lost (see DragCommand). Enforced for every Command
+    // by XmlNameCasingTests (#200).
     [XmlAttribute("window")] public string Window { get; set; } = null!;
     [XmlAttribute("handle")] public long Handle { get; set; }
     [XmlAttribute("process")] public string Process { get; set; } = null!;

--- a/src/Commands/FindCommand.cs
+++ b/src/Commands/FindCommand.cs
@@ -16,7 +16,7 @@ public class FindCommand : Command {
     [XmlAttribute("window")] public string Window { get; set; } = null!;
     [XmlAttribute("handle")] public long Handle { get; set; }
     [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("className")] public string ClassName { get; set; } = null!;
+    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
     [XmlAttribute("foreground")] public bool Foreground { get; set; }
     [XmlAttribute("by")] public string By { get; set; } = "name";
     [XmlAttribute("value")] public string Value { get; set; } = null!;

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -15,7 +15,7 @@ public class InvokeCommand : Command {
     [XmlAttribute("window")] public string Window { get; set; } = null!;
     [XmlAttribute("handle")] public long Handle { get; set; }
     [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("className")] public string ClassName { get; set; } = null!;
+    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
     [XmlAttribute("foreground")] public bool Foreground { get; set; }
     [XmlAttribute("by")] public string By { get; set; } = "name";
     [XmlAttribute("value")] public string Value { get; set; } = null!;

--- a/src/Commands/LaunchCommand.cs
+++ b/src/Commands/LaunchCommand.cs
@@ -20,7 +20,7 @@ namespace MCEControl;
 public class LaunchCommand : Command {
     [XmlAttribute("path")] public string Path { get; set; } = null!;
     [XmlAttribute("arguments")] public string Arguments { get; set; } = null!;
-    [XmlAttribute("workingDirectory")] public string WorkingDirectory { get; set; } = null!;
+    [XmlAttribute("workingdirectory")] public string WorkingDirectory { get; set; } = null!;
     [XmlAttribute("timeout")] public int Timeout { get; set; }
 
     public static new List<Command> BuiltInCommands {

--- a/src/Commands/QueryCommand.cs
+++ b/src/Commands/QueryCommand.cs
@@ -15,13 +15,13 @@ public class QueryCommand : Command {
     [XmlAttribute("window")] public string Window { get; set; } = null!;
     [XmlAttribute("handle")] public long Handle { get; set; }
     [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("className")] public string ClassName { get; set; } = null!;
+    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
     [XmlAttribute("foreground")] public bool Foreground { get; set; }
-    [XmlAttribute("maxDepth")] public int MaxDepth { get; set; } = 6;
+    [XmlAttribute("maxdepth")] public int MaxDepth { get; set; } = 6;
 
     /// <summary>Upper bound on UIA nodes returned; keeps the result bounded for huge/virtualized trees.
     /// A clipped walk is reported via a <c>tree-truncated</c> warning. 0 means unbounded.</summary>
-    [XmlAttribute("maxNodes")] public int MaxNodes { get; set; } = 1000;
+    [XmlAttribute("maxnodes")] public int MaxNodes { get; set; } = 1000;
 
     public static new List<Command> BuiltInCommands {
         get => [new QueryCommand { Cmd = "query" }];

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -30,15 +30,15 @@ public class RecordCommand : Command {
     [XmlAttribute("window")] public string Window { get; set; } = null!;
     [XmlAttribute("handle")] public long Handle { get; set; }
     [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("className")] public string ClassName { get; set; } = null!;
+    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
     [XmlAttribute("foreground")] public bool Foreground { get; set; }
     [XmlAttribute("x")] public int X { get; set; }
     [XmlAttribute("y")] public int Y { get; set; }
     [XmlAttribute("width")] public int Width { get; set; }
     [XmlAttribute("height")] public int Height { get; set; }
     [XmlAttribute("fps")] public int Fps { get; set; }
-    [XmlAttribute("durationMs")] public int DurationMs { get; set; }
-    [XmlAttribute("maxWidth")] public int MaxWidth { get; set; }
+    [XmlAttribute("durationms")] public int DurationMs { get; set; }
+    [XmlAttribute("maxwidth")] public int MaxWidth { get; set; }
     [XmlAttribute("file")] public string File { get; set; } = null!;
 
     private const int DefaultFps = 5;

--- a/tests/MCEControl.xUnit/Commands/SerializedCommandsTests.cs
+++ b/tests/MCEControl.xUnit/Commands/SerializedCommandsTests.cs
@@ -60,11 +60,16 @@ public class SerializedCommandsTests
         string tempFile = Path.GetTempFileName();
         File.Delete(tempFile);
 
+        // Regression (#200): durationMs/maxWidth/classname were serialized camelCase, so the
+        // lower-casing XSLT in LoadCommands silently dropped them on reload.
         var original = new SerializedCommands
         {
             commandArray =
             [
-                new RecordCommand() { Cmd = "record", Action = "oneshot", Fps = 7, DurationMs = 3000, Enabled = true }
+                new RecordCommand() {
+                    Cmd = "record", Action = "oneshot", Fps = 7, DurationMs = 3000,
+                    MaxWidth = 560, ClassName = "Notepad", Enabled = true,
+                }
             ]
         };
 
@@ -77,7 +82,121 @@ public class SerializedCommandsTests
         Assert.Equal("record", rec.Cmd);
         Assert.Equal("oneshot", rec.Action);
         Assert.Equal(7, rec.Fps);
+        Assert.Equal(3000, rec.DurationMs);
+        Assert.Equal(560, rec.MaxWidth);
+        Assert.Equal("Notepad", rec.ClassName);
         Assert.True(rec.Enabled);
+
+        File.Delete(tempFile);
+    }
+
+    [Fact]
+    public void SaveLoad_RoundTrip_QueryCommand_TopLevel()
+    {
+        // Regression (#200): className/maxDepth/maxNodes were serialized camelCase, so the
+        // lower-casing XSLT in LoadCommands silently dropped them on reload — a saved query lost its
+        // targeting and limits.
+        string tempFile = Path.GetTempFileName();
+        File.Delete(tempFile);
+
+        var original = new SerializedCommands
+        {
+            commandArray =
+            [
+                new QueryCommand() {
+                    Cmd = "query", Window = "Calc", Process = "calc", ClassName = "ApplicationFrameWindow",
+                    MaxDepth = 9, MaxNodes = 250, Enabled = true,
+                }
+            ]
+        };
+
+        SerializedCommands.SaveCommands(tempFile, original, "1.0.0.0");
+        var loaded = SerializedCommands.LoadCommands(tempFile, "1.0.0.0");
+
+        Assert.NotNull(loaded);
+        var query = Assert.Single(loaded.commandArray) as QueryCommand;
+        Assert.NotNull(query);
+        Assert.Equal("query", query.Cmd);
+        Assert.Equal("Calc", query.Window);
+        Assert.Equal("calc", query.Process);
+        Assert.Equal("ApplicationFrameWindow", query.ClassName);
+        Assert.Equal(9, query.MaxDepth);
+        Assert.Equal(250, query.MaxNodes);
+        Assert.True(query.Enabled);
+
+        File.Delete(tempFile);
+    }
+
+    [Fact]
+    public void SaveLoad_RoundTrip_LaunchCommand_TopLevel()
+    {
+        // Regression (#200): workingDirectory was serialized camelCase and silently dropped on reload.
+        string tempFile = Path.GetTempFileName();
+        File.Delete(tempFile);
+
+        var original = new SerializedCommands
+        {
+            commandArray =
+            [
+                new LaunchCommand() {
+                    Cmd = "launch", Path = @"C:\Windows\notepad.exe", Arguments = "readme.txt",
+                    WorkingDirectory = @"C:\Temp", Timeout = 5000, Enabled = true,
+                }
+            ]
+        };
+
+        SerializedCommands.SaveCommands(tempFile, original, "1.0.0.0");
+        var loaded = SerializedCommands.LoadCommands(tempFile, "1.0.0.0");
+
+        Assert.NotNull(loaded);
+        var launch = Assert.Single(loaded.commandArray) as LaunchCommand;
+        Assert.NotNull(launch);
+        Assert.Equal("launch", launch.Cmd);
+        Assert.Equal(@"C:\Windows\notepad.exe", launch.Path);
+        Assert.Equal("readme.txt", launch.Arguments);
+        Assert.Equal(@"C:\Temp", launch.WorkingDirectory);
+        Assert.Equal(5000, launch.Timeout);
+        Assert.True(launch.Enabled);
+
+        File.Delete(tempFile);
+    }
+
+    [Fact]
+    public void LoadCommands_LegacyCamelCaseAttributes_StillBind()
+    {
+        // Old files written before #200 contain camelCase attribute names (className=, maxDepth=,
+        // maxNodes=, durationMs=, maxWidth=, workingDirectory=). The lower-casing XSLT normalizes them
+        // on load, so they must bind to the now-lowercase serialization names.
+        string tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile,
+            "<?xml version=\"1.0\"?>\r\n" +
+            "<MCEController Version=\"1.0.0.0\">\r\n" +
+            "  <Commands xmlns=\"http://www.kindel.com/products/mcecontroller\">\r\n" +
+            "    <Query Cmd=\"query\" className=\"Shell_TrayWnd\" maxDepth=\"4\" maxNodes=\"99\" Enabled=\"true\" />\r\n" +
+            "    <Record Cmd=\"record\" durationMs=\"2500\" maxWidth=\"320\" Enabled=\"true\" />\r\n" +
+            "    <Launch Cmd=\"launch\" path=\"x.exe\" workingDirectory=\"C:\\Temp\" Enabled=\"true\" />\r\n" +
+            "  </Commands>\r\n" +
+            "</MCEController>\r\n");
+
+        var loaded = SerializedCommands.LoadCommands(tempFile, "1.0.0.0");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(3, loaded.commandArray.Length);
+
+        var query = loaded.commandArray[0] as QueryCommand;
+        Assert.NotNull(query);
+        Assert.Equal("Shell_TrayWnd", query.ClassName);
+        Assert.Equal(4, query.MaxDepth);
+        Assert.Equal(99, query.MaxNodes);
+
+        var rec = loaded.commandArray[1] as RecordCommand;
+        Assert.NotNull(rec);
+        Assert.Equal(2500, rec.DurationMs);
+        Assert.Equal(320, rec.MaxWidth);
+
+        var launch = loaded.commandArray[2] as LaunchCommand;
+        Assert.NotNull(launch);
+        Assert.Equal(@"C:\Temp", launch.WorkingDirectory);
 
         File.Delete(tempFile);
     }

--- a/tests/MCEControl.xUnit/Commands/XmlNameCasingTests.cs
+++ b/tests/MCEControl.xUnit/Commands/XmlNameCasingTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Serialization;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Regression guard for issue #200. <c>SerializedCommands.Deserialize</c> pipes every .commands file
+/// through an XSLT that lower-cases ALL element and attribute names before XmlSerializer binds. Any
+/// [XmlAttribute]/[XmlElement]/[XmlArray]/[XmlArrayItem] name containing an uppercase character is
+/// written by SaveCommands but can never bind on load — the value is silently lost (this trap claimed
+/// className/maxDepth/maxNodes/durationMs/maxWidth/workingDirectory across five commands). This test
+/// walks every serialized Command type (and every nested serialized type reachable from them) and
+/// asserts every XML name is fully lowercase, closing the bug class permanently.
+/// </summary>
+public class XmlNameCasingTests
+{
+    [Fact]
+    public void AllSerializedXmlNames_AreLowercase()
+    {
+        List<string> offenders = [];
+        foreach (Type type in CollectSerializedTypes()) {
+            foreach (MemberInfo member in type.GetMembers(BindingFlags.Public | BindingFlags.Instance)) {
+                if (member is not PropertyInfo and not FieldInfo) {
+                    continue;
+                }
+                foreach ((string source, string name) in EffectiveXmlNames(member)) {
+                    if (name.Any(char.IsUpper)) {
+                        offenders.Add($"{type.Name}.{member.Name}: [{source}] name \"{name}\" is not all-lowercase — " +
+                            "the .commands lower-casing XSLT means this value will be silently dropped on load");
+                    }
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Serialized XML names must be all-lowercase (see SerializedCommands.Deserialize / ClickCommand note):\n"
+            + string.Join("\n", offenders.Distinct()));
+    }
+
+    /// <summary>
+    /// Every concrete Command subclass, the Command base, SerializedCommands (the document root), and —
+    /// transitively — any type in the product assembly referenced by a serialized member (nested
+    /// serialized types such as EmbeddedCommands' item types).
+    /// </summary>
+    private static HashSet<Type> CollectSerializedTypes()
+    {
+        Assembly assembly = typeof(Command).Assembly;
+        Queue<Type> pending = new();
+        HashSet<Type> visited = [];
+
+        pending.Enqueue(typeof(SerializedCommands));
+        foreach (Type t in assembly.GetTypes().Where(t => t.IsClass && typeof(Command).IsAssignableFrom(t))) {
+            pending.Enqueue(t);
+        }
+
+        while (pending.Count > 0) {
+            Type type = pending.Dequeue();
+            if (!visited.Add(type)) {
+                continue;
+            }
+            foreach (MemberInfo member in type.GetMembers(BindingFlags.Public | BindingFlags.Instance)) {
+                if (member is not PropertyInfo and not FieldInfo) {
+                    continue;
+                }
+                if (member.GetCustomAttribute<XmlIgnoreAttribute>() is not null) {
+                    continue;
+                }
+                // Types named by polymorphic [XmlElement(type)]/[XmlArrayItem(type)] entries.
+                foreach (XmlElementAttribute el in member.GetCustomAttributes<XmlElementAttribute>()) {
+                    Enqueue(el.Type);
+                }
+                foreach (XmlArrayItemAttribute item in member.GetCustomAttributes<XmlArrayItemAttribute>()) {
+                    Enqueue(item.Type);
+                }
+                // The member's own (or element) type when it lives in the product assembly.
+                Type memberType = member is PropertyInfo p ? p.PropertyType : ((FieldInfo)member).FieldType;
+                Enqueue(memberType.IsArray ? memberType.GetElementType() : memberType);
+                if (memberType.IsGenericType) {
+                    foreach (Type arg in memberType.GetGenericArguments()) {
+                        Enqueue(arg);
+                    }
+                }
+            }
+        }
+        return visited;
+
+        void Enqueue(Type? t)
+        {
+            if (t is not null && t.Assembly == assembly && t.IsClass && !visited.Contains(t)) {
+                pending.Enqueue(t);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Yields the XML names XmlSerializer will actually use for a member: explicit names as written, and
+    /// the member-name fallback when an attribute gives no name (a PascalCase member name is then just as
+    /// broken as an explicit camelCase one). Un-named polymorphic entries for abstract types are skipped —
+    /// an abstract type is never instantiated, so no element is ever emitted under that name.
+    /// </summary>
+    private static IEnumerable<(string Source, string Name)> EffectiveXmlNames(MemberInfo member)
+    {
+        if (member.GetCustomAttribute<XmlIgnoreAttribute>() is not null) {
+            yield break;
+        }
+        foreach (XmlAttributeAttribute attr in member.GetCustomAttributes<XmlAttributeAttribute>()) {
+            yield return ("XmlAttribute", string.IsNullOrEmpty(attr.AttributeName) ? member.Name : attr.AttributeName);
+        }
+        foreach (XmlElementAttribute el in member.GetCustomAttributes<XmlElementAttribute>()) {
+            if (string.IsNullOrEmpty(el.ElementName) && el.Type?.IsAbstract == true) {
+                continue; // catch-all like [XmlElement(typeof(Command))] — never serialized directly
+            }
+            yield return ("XmlElement", string.IsNullOrEmpty(el.ElementName) ? member.Name : el.ElementName);
+        }
+        foreach (XmlArrayAttribute arr in member.GetCustomAttributes<XmlArrayAttribute>()) {
+            yield return ("XmlArray", string.IsNullOrEmpty(arr.ElementName) ? member.Name : arr.ElementName);
+        }
+        foreach (XmlArrayItemAttribute item in member.GetCustomAttributes<XmlArrayItemAttribute>()) {
+            if (string.IsNullOrEmpty(item.ElementName) && item.Type?.IsAbstract == true) {
+                continue; // catch-all like [XmlArrayItem(typeof(Command))]
+            }
+            yield return ("XmlArrayItem", string.IsNullOrEmpty(item.ElementName) ? (item.Type?.Name ?? member.Name) : item.ElementName);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #200

## Problem

Every `.commands` load pipes through an XSLT that lower-cases **all** element/attribute names before `XmlSerializer` binds (`SerializedCommands.Deserialize`). Any `[XmlAttribute]` name containing an uppercase character is written by `SaveCommands` but never binds on load — the value is **silently lost**. Five commands violated the documented all-lowercase rule, so save→reload dropped targeting (`className`), limits (`maxDepth`/`maxNodes`/`maxWidth`), durations (`durationMs`), and `workingDirectory`.

## Fix

- **Renamed the XML serialization names to lowercase** in `QueryCommand` (`classname`, `maxdepth`, `maxnodes`), `FindCommand`/`InvokeCommand`/`RecordCommand` (`classname`, plus `durationms`, `maxwidth`), and `LaunchCommand` (`workingdirectory`). Writes are now lowercase; files written before this fix (camelCase) still load because the XSLT normalizes them on the way in — proven by a new legacy-file test.
- **Closed the bug class permanently**: `XmlNameCasingTests` reflects over every serialized `Command` type (and nested serialized types reachable from them, e.g. `EmbeddedCommands` item types and `SerializedCommands` itself) and asserts every `[XmlAttribute]`/`[XmlElement]`/`[XmlArray]`/`[XmlArrayItem]` name is fully lowercase (including member-name fallbacks for unnamed attributes). Verified it fails when a camelCase name is reintroduced.
- **Round-trip regression tests**: `QueryCommand` and `LaunchCommand` round-trips through `SaveCommands` → `LoadCommands` (the real XSLT path) asserting the previously-lost values survive; extended the existing `RecordCommand` round-trip to cover `durationms`/`maxwidth`/`classname`.

## Deliberately unchanged

- The MCP tool JSON argument names (`AgentServer` schemas: `className`, `maxDepth`, `maxNodes`, `durationMs`, `maxWidth`, `workingDirectory`) are a **separate JSON namespace** — untouched, as are the docs/scripts that describe them.
- `Example.mcec.commands` keeps its legacy PascalCase style: it is load-side input the XSLT already normalizes.
- No command-registration refactor (that is #204).

## Testing

- `dotnet build`: 0 errors (TreatWarningsAsErrors + house analyzers).
- `dotnet test`: 596 passed, 0 failed, 22 skipped (desktop-E2E/input-sim, skipped by design).
- Negative check: temporarily reverting one attribute to `className` makes `XmlNameCasingTests` fail with a pointed message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm