### PR TITLE
fix: enqueue-and-return in LL hook callbacks; drop KeyPress/ToAscii path

### DIFF
--- a/docs/safety-emergency-stop-and-provisioning.md
+++ b/docs/safety-emergency-stop-and-provisioning.md
@@ -45,6 +45,12 @@ Engaging the stop (`EmergencyStop.Trigger`):
 5. **Latches until re-armed.** The operator clicks the **⛔ Re-arm (Emergency Stop)** menu item (visible
    only while stopped); the latch is never cleared automatically.
 
+Step 1 — the latch — is the only work performed inside the low-level hook callback; steps 2–4 run
+immediately after on a background thread (#198). A slow log or serial write can therefore never stall the
+`WH_KEYBOARD_LL` callback past `LowLevelHooksTimeout`, which would make Windows silently evict the hook —
+and the panic hotkey with it. Nothing actuates in the gap: the latch is already set, so every tool call is
+refused before the background steps even run.
+
 ### Why it can't be tripped or defeated by the agent
 
 MCEC's own agent actuation **injects** keystrokes and mouse input. Windows flags injected low-level events

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -422,7 +422,7 @@ InputSimulator (facade)
 - **UI Thread**: MainWindow, all WinForms controls
 - **Worker Threads**: Each SocketServer client connection, SocketClient connection
 - **Command Execution**: Currently on UI thread (via BeginInvoke)
-- **Activity Hooks**: Separate message pump thread (HookManager)
+- **Activity Hooks**: WH_KEYBOARD_LL/WH_MOUSE_LL hooks (HookManager) install on the UI thread — there is no dedicated pump thread. Hook callbacks are enqueue-and-return (#198): only debounce/latch logic runs in the hook proc; heavy work (logging, telemetry, socket/serial sends) is posted off the callback path so the proc can never exceed `LowLevelHooksTimeout` (which would get the hook silently evicted)
 - **Synchronization**: Thread-safe ConcurrentQueue for command execution
 
 **Known Limitation**: Commands execute on UI thread which could block UI during long-running commands. Future enhancement would move CommandInvoker to dedicated thread.

--- a/src/Agent/EmergencyStop.cs
+++ b/src/Agent/EmergencyStop.cs
@@ -2,6 +2,7 @@
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
 using System;
+using System.Threading;
 using Gma.UserActivityMonitor;
 using WindowsInput;
 
@@ -17,7 +18,10 @@ namespace MCEControl;
 /// so no further tool call actuates until the operator explicitly re-arms; (2) aborts in-flight actuation —
 /// stops any recording and signals a cooperative drag cancel; (3) releases held input (all mouse buttons up,
 /// modifiers reset) so a mid-drag or chord can't leave input stuck; and (4) reports loudly to the overlay,
-/// the <c>AGENT-AUDIT:</c> log, and the session record. It stays stopped until <see cref="Rearm"/>.</para>
+/// the <c>AGENT-AUDIT:</c> log, and the session record. It stays stopped until <see cref="Rearm"/>.
+/// Only step (1) — the latch — runs inside the hook callback; steps (2)–(4) are dispatched to the thread
+/// pool so the WH_KEYBOARD_LL callback returns immediately and can never exceed LowLevelHooksTimeout,
+/// which would get the hook (and the hotkey with it) silently evicted (#198).</para>
 ///
 /// <para>Independent of the WinForms message loop's focus — the hook fires regardless of MCEC's window
 /// state (including minimized to tray). It does require a message loop on the installing thread, so it is
@@ -29,7 +33,12 @@ public static class EmergencyStop {
     private static EmergencyStopHotkey _hotkey = EmergencyStopHotkey.Default;
     private static bool _armed;
 
-    /// <summary>Raised (on the hook thread) when the stopped state changes — the overlay/UI subscribe to reflect it.</summary>
+    /// <summary>
+    /// Raised when the stopped state changes — the overlay/UI subscribe to reflect it. Never raised on
+    /// the hook callback path: it fires from the dispatched completion of <see cref="Trigger"/> (a
+    /// thread-pool thread) or from <see cref="Rearm"/>'s caller, so subscribers must marshal to the UI
+    /// thread themselves (MainWindow does).
+    /// </summary>
     public static event Action<bool>? StateChanged;
 
     /// <summary>True while the stop is engaged (mirrors <see cref="AgentRuntime.EmergencyStopped"/>).</summary>
@@ -107,6 +116,20 @@ public static class EmergencyStop {
             StoppedReason = source;
         }
 
+        // The latch above — a lock and a flag — is the ONLY work that runs on the WH_KEYBOARD_LL hook
+        // callback path when the hotkey fires. Everything else (audit log file I/O, stopping a
+        // recording, SendInput, event publishing) is dispatched to the thread pool so the hook proc
+        // returns immediately: Windows silently evicts a low-level hook whose callback exceeds
+        // LowLevelHooksTimeout, and this hook IS the panic hotkey (#198). Nothing actuates in the gap —
+        // the latch is already set, so every tool call is refused before the completion even runs.
+        ThreadPool.QueueUserWorkItem(static state => CompleteTrigger((string)state!), source);
+    }
+
+    /// <summary>
+    /// The post-latch completion of <see cref="Trigger"/>: aborts in-flight actuation, releases held
+    /// input, and reports loudly. Runs on the thread pool, OFF the hook callback path (#198).
+    /// </summary>
+    private static void CompleteTrigger(string source) {
         AgentRuntime.Audit("emergency-stop", $"ENGAGED by operator ({source}) — halting actuation, dropping queue, releasing held input");
 
         // Abort in-flight actuation. Recording stops cleanly here; an in-flight drag observes the latch and

--- a/src/Services/UserActivityMonitorService.cs
+++ b/src/Services/UserActivityMonitorService.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows.Forms;
 using Gma.UserActivityMonitor;
 using Microsoft.Win32;
@@ -44,6 +45,14 @@ public sealed class UserActivityMonitorService : IDisposable {
     private DateTime _lastTime;
     private Timer _presencePresumedTimer = null!;
 
+    // Captured on Start()'s thread (the WinForms UI thread in the GUI host). The heavy per-activity
+    // work — log4net file I/O, a telemetry metric, and SendLine's synchronous socket/serial writes —
+    // is Post()ed here so the low-level hook callback returns immediately (#198). Windows silently
+    // evicts a WH_KEYBOARD_LL/WH_MOUSE_LL hook whose callback exceeds LowLevelHooksTimeout, and the
+    // emergency-stop hotkey (#135) rides the same keyboard hook — a blocked serial write inside the
+    // hook proc could kill the panic hotkey with no error surfaced.
+    private SynchronizationContext? _activitySyncContext;
+
     private UserActivityMonitorService() {
     }
 
@@ -62,6 +71,7 @@ public sealed class UserActivityMonitorService : IDisposable {
     /// </summary>
     public void Start() {
         _lastTime = DateTime.Now;
+        _activitySyncContext = SynchronizationContext.Current;
 
         if (InputDetection) {
             Debug.Assert(!_inputEventsSubscribed);
@@ -289,9 +299,12 @@ public sealed class UserActivityMonitorService : IDisposable {
             return;
         }
 
+        // Deliberately NOT subscribed: HookManager.KeyPress. KeyDown suffices for activity detection,
+        // and with zero KeyPress subscribers HookManager's KeyboardHookProc skips its ToAscii call —
+        // the well-known Gma bug where ToAscii consumes the keyboard's dead-key state and breaks
+        // accented-character composition system-wide while the hook is installed (#198).
         HookManager.MouseMove += HookManager_MouseMove;
         HookManager.MouseClick += HookManager_MouseClick;
-        HookManager.KeyPress += HookManager_KeyPress;
         HookManager.KeyDown += HookManager_KeyDown;
         HookManager.MouseDown += HookManager_MouseDown;
         HookManager.MouseUp += HookManager_MouseUp;
@@ -312,7 +325,6 @@ public sealed class UserActivityMonitorService : IDisposable {
 
         HookManager.MouseMove -= HookManager_MouseMove;
         HookManager.MouseClick -= HookManager_MouseClick;
-        HookManager.KeyPress -= HookManager_KeyPress;
         HookManager.KeyDown -= HookManager_KeyDown;
         HookManager.MouseDown -= HookManager_MouseDown;
         HookManager.MouseUp -= HookManager_MouseUp;
@@ -326,11 +338,18 @@ public sealed class UserActivityMonitorService : IDisposable {
     }
 
     /// <summary>
-    ///     Called anytime user activity is detected.
+    ///     Called anytime user activity is detected — including from INSIDE the WH_KEYBOARD_LL /
+    ///     WH_MOUSE_LL hook callbacks (the HookManager_* handlers below run in the hook proc, before
+    ///     CallNextHookEx). It must stay cheap: Windows silently evicts a low-level hook whose callback
+    ///     exceeds LowLevelHooksTimeout, and the emergency-stop hotkey (#135) rides the same keyboard
+    ///     hook. Only the debounce check runs here; the heavy work (log file I/O, telemetry, SendLine's
+    ///     synchronous socket/serial writes) is dispatched off the hook path by
+    ///     <see cref="DispatchActivityWork" /> (#198).
+    ///     Internal for testing (InternalsVisibleTo MCEControl.xUnit).
     /// </summary>
     /// <param name="source">Indicates the source of the detection; for logging</param>
     /// <param name="moreInfo">More info about the activity.</param>
-    private void Activity(string source, string moreInfo = "") {
+    internal void Activity(string source, string moreInfo = "") {
         if (!_inputEventsSubscribed) {
             return;
         }
@@ -340,20 +359,71 @@ public sealed class UserActivityMonitorService : IDisposable {
             _presencePresumedTimer.Enabled = true;
         }
 
-        if (_lastTime.AddSeconds(DebounceTime) <= DateTime.Now) {
-            // Only log/trigger if outside debounce time
-            Logger.Instance.Log4.Info($@"ActivityMonitor: Activity detected: {source} {moreInfo}");
-
-            // TELEMETRY: 
-            // what: the count of activity detected
-            // why: to understand how frequently activity is detected
-            // how is PII protected: the frequency of activity is not PII
-            TelemetryService.Instance.TrackMetric("activity Sent", 1);
-
-            MainWindow.Instance.SendLine(ActivityMsg);
-
-            _lastTime = DateTime.Now;
+        // Debounce HERE, on the hook callback path, so the dispatch below happens at most once per
+        // DebounceTime — not on every mouse move.
+        if (_lastTime.AddSeconds(DebounceTime) > DateTime.Now) {
+            return;
         }
+        _lastTime = DateTime.Now;
+
+        DispatchActivityWork(source, moreInfo);
+    }
+
+    /// <summary>
+    ///     Test seam (InternalsVisibleTo MCEControl.xUnit): when non-null,
+    ///     <see cref="DispatchActivityWork" /> hands the heavy work here instead of posting it, so tests
+    ///     can assert that the hook-path handler completes without running the work inline.
+    /// </summary>
+    internal Action<Action>? DispatchForTesting { get; set; }
+
+    /// <summary>
+    ///     Test seam (InternalsVisibleTo MCEControl.xUnit): the debounce clock — the time of the last
+    ///     dispatched activity. Settable so tests can step past the debounce window deterministically.
+    /// </summary>
+    internal DateTime LastActivityTimeForTesting {
+        get => _lastTime;
+        set => _lastTime = value;
+    }
+
+    /// <summary>
+    ///     Dispatches the heavy per-activity work so the hook callback returns immediately. Posts to
+    ///     the SynchronizationContext captured at <see cref="Start" /> (the WinForms UI context in the
+    ///     GUI host — the work runs as a normal posted message AFTER the hook proc has returned) and
+    ///     falls back to the thread pool when there is none.
+    /// </summary>
+    private void DispatchActivityWork(string source, string moreInfo) {
+        Action work = () => PerformActivityWork(source, moreInfo);
+
+        Action<Action>? dispatchForTesting = DispatchForTesting;
+        if (dispatchForTesting != null) {
+            dispatchForTesting(work);
+            return;
+        }
+
+        SynchronizationContext? context = _activitySyncContext;
+        if (context != null) {
+            context.Post(static state => ((Action)state!)(), work);
+        }
+        else {
+            ThreadPool.QueueUserWorkItem(static state => ((Action)state!)(), work);
+        }
+    }
+
+    /// <summary>
+    ///     The heavy part of activity handling — log file I/O, a telemetry metric, and SendLine's
+    ///     synchronous socket/serial writes. Runs OFF the hook callback path (see
+    ///     <see cref="Activity" /> / <see cref="DispatchActivityWork" />).
+    /// </summary>
+    private void PerformActivityWork(string source, string moreInfo) {
+        Logger.Instance.Log4.Info($@"ActivityMonitor: Activity detected: {source} {moreInfo}");
+
+        // TELEMETRY:
+        // what: the count of activity detected
+        // why: to understand how frequently activity is detected
+        // how is PII protected: the frequency of activity is not PII
+        TelemetryService.Instance.TrackMetric("activity Sent", 1);
+
+        MainWindow.Instance.SendLine(ActivityMsg);
     }
 
     private void HookManager_KeyDown(object? sender, KeyEventArgs e) {
@@ -364,10 +434,6 @@ public sealed class UserActivityMonitorService : IDisposable {
         Activity("KeyUp", LogActivity ? $"{e.KeyCode}" : "");
     }
 
-
-    private void HookManager_KeyPress(object? sender, KeyPressEventArgs e) {
-        Activity("KeyPress", LogActivity ? $"{e.KeyChar}" : "");
-    }
 
     private void HookManager_MouseMove(object? sender, MouseEventArgs e) {
         Activity("MouseMove", LogActivity ? $"x={e.X:0000}; y={e.Y:0000}" : "");

--- a/tests/MCEControl.xUnit/Services/UserActivityMonitorServiceTests.cs
+++ b/tests/MCEControl.xUnit/Services/UserActivityMonitorServiceTests.cs
@@ -26,7 +26,10 @@ public class UserActivityMonitorServiceTests {
     private static void AssertServiceHandlerDelta(HookSubscriberBaseline baseline, int delta) {
         Assert.Equal(baseline.KeyDown + delta, HookManager.KeyDownSubscriberCount);
         Assert.Equal(baseline.KeyUp + delta, HookManager.KeyUpSubscriberCount);
-        Assert.Equal(baseline.KeyPress + delta, HookManager.KeyPressSubscriberCount);
+        // KeyPress is deliberately NEVER subscribed (#198): with zero KeyPress subscribers the
+        // keyboard hook proc skips its ToAscii call, which would otherwise consume dead-key state
+        // and break accented-character composition system-wide.
+        Assert.Equal(baseline.KeyPress, HookManager.KeyPressSubscriberCount);
         Assert.Equal(baseline.MouseMove + delta, HookManager.MouseMoveSubscriberCount);
         Assert.Equal(baseline.MouseClick + delta, HookManager.MouseClickSubscriberCount);
         Assert.Equal(baseline.MouseDown + delta, HookManager.MouseDownSubscriberCount);
@@ -71,6 +74,108 @@ public class UserActivityMonitorServiceTests {
         finally {
             // Best-effort cleanup if an assertion fired between Start and Stop (Stop is idempotent).
             monitor.Stop();
+        }
+    }
+
+    /// <summary>
+    /// Issue #198 (bonus defect): the monitor must NOT subscribe <see cref="HookManager.KeyPress" />.
+    /// KeyDown suffices for activity detection, and the keyboard hook proc only calls ToAscii when a
+    /// KeyPress subscriber exists — ToAscii consumes the keyboard's dead-key state, breaking
+    /// accented-character composition system-wide while MCEC monitors input.
+    /// </summary>
+    [Fact]
+    public void Start_DoesNotSubscribeKeyPress_SoHookProcSkipsToAscii() {
+        HookManager.SuppressRealHooksForTesting = true;
+        UserActivityMonitorService monitor = UserActivityMonitorService.Instance;
+        monitor.InputDetection = true;
+        monitor.UnlockDetection = false;
+        monitor.PowerBroadcastDetection = false;
+
+        HookSubscriberBaseline baseline = HookSubscriberBaseline.Capture();
+
+        monitor.Start();
+        try {
+            Assert.Equal(baseline.KeyDown + 1, HookManager.KeyDownSubscriberCount);
+            Assert.Equal(baseline.KeyPress, HookManager.KeyPressSubscriberCount);
+        }
+        finally {
+            monitor.Stop();
+        }
+    }
+
+    /// <summary>
+    /// Issue #198: the hook-path handler must do only the cheap debounce check and dispatch the heavy
+    /// work (log I/O, telemetry, SendLine's synchronous socket/serial writes) — never run it inline in
+    /// the hook callback. Windows silently evicts an LL hook whose callback exceeds
+    /// LowLevelHooksTimeout, and the #135 emergency-stop hotkey rides the same WH_KEYBOARD_LL hook.
+    /// The heavy work would throw here if executed (no MainWindow in the test process), so the handler
+    /// completing with the work merely captured proves it was not invoked synchronously.
+    /// </summary>
+    [Fact]
+    public void Activity_DispatchesHeavyWorkOffHookPath_AndDebouncesInHandler() {
+        HookManager.SuppressRealHooksForTesting = true;
+        UserActivityMonitorService monitor = UserActivityMonitorService.Instance;
+        monitor.InputDetection = true;
+        monitor.UnlockDetection = false;
+        monitor.PowerBroadcastDetection = false;
+        monitor.DebounceTime = 60;
+
+        int dispatched = 0;
+        monitor.DispatchForTesting = work => {
+            Assert.NotNull(work);
+            dispatched++; // capture, do NOT run — asserts the handler doesn't need the work executed
+        };
+
+        monitor.Start();
+        try {
+            // Start() primes the debounce clock to "now", so step it back past the window.
+            monitor.LastActivityTimeForTesting = DateTime.Now.AddSeconds(-(monitor.DebounceTime + 1));
+
+            monitor.Activity("KeyDown");
+            Assert.Equal(1, dispatched); // dispatched exactly once, handler returned without running it
+
+            monitor.Activity("MouseMove");
+            monitor.Activity("KeyDown");
+            Assert.Equal(1, dispatched); // inside the debounce window: no further dispatches
+        }
+        finally {
+            monitor.Stop();
+            monitor.DispatchForTesting = null;
+            monitor.DebounceTime = 5;
+        }
+    }
+
+    /// <summary>
+    /// The debounce lives in the handler (not in the dispatched work) so the dispatch mechanism is not
+    /// flooded on every mouse move — after the window elapses, the next activity dispatches again.
+    /// </summary>
+    [Fact]
+    public void Activity_DispatchesAgain_AfterDebounceWindowElapses() {
+        HookManager.SuppressRealHooksForTesting = true;
+        UserActivityMonitorService monitor = UserActivityMonitorService.Instance;
+        monitor.InputDetection = true;
+        monitor.UnlockDetection = false;
+        monitor.PowerBroadcastDetection = false;
+        monitor.DebounceTime = 60;
+
+        int dispatched = 0;
+        monitor.DispatchForTesting = _ => dispatched++;
+
+        monitor.Start();
+        try {
+            monitor.LastActivityTimeForTesting = DateTime.Now.AddSeconds(-(monitor.DebounceTime + 1));
+            monitor.Activity("KeyDown");
+            Assert.Equal(1, dispatched);
+
+            // Simulate the debounce window elapsing.
+            monitor.LastActivityTimeForTesting = DateTime.Now.AddSeconds(-(monitor.DebounceTime + 1));
+            monitor.Activity("MouseMove");
+            Assert.Equal(2, dispatched);
+        }
+        finally {
+            monitor.Stop();
+            monitor.DispatchForTesting = null;
+            monitor.DebounceTime = 5;
         }
     }
 


### PR DESCRIPTION
Fixes #198

## Problem

Low-level hooks install on the UI thread (no pump thread, despite what `ARCHITECTURE.md` claimed). On each debounce expiry the hook callback path (`HookManager.Callbacks.cs` → `UserActivityMonitorService.Activity()`) synchronously did log4net file I/O, a telemetry metric, and `MainWindow.Instance.SendLine(...)` — **synchronous socket and serial-port writes** — all inside the hook proc before `CallNextHookEx`. Windows silently evicts an LL hook whose callback exceeds `LowLevelHooksTimeout`, and the #135 emergency-stop hotkey rides the same `WH_KEYBOARD_LL` hook — a blocked serial write could kill the panic hotkey with no error surfaced.

Bonus defect: the keyboard proc calls `ToAscii` whenever any `KeyPress` subscriber exists (the monitor subscribed one) — the well-known Gma bug that consumes dead-key state and breaks accented-character composition system-wide.

## What changed

- **Enqueue-and-return in `UserActivityMonitorService`** — `Activity()` now does only the cheap debounce check on the hook path (`_lastTime` stays in the handler so mouse moves don't flood the dispatcher) and dispatches the heavy work (logging, telemetry, `SendLine`) off the callback: `Post()`ed to the `SynchronizationContext` captured at `Start()` (the WinForms UI context in the GUI host — the work runs as a normal posted message *after* the hook proc returns, preserving the existing single-threaded `SendLine` assumptions), with a thread-pool fallback when there is none.
- **Dropped the `KeyPress` subscription** — `KeyDown` suffices for activity detection. Verified `HookManager.Callbacks.cs` already gates the `ToAscii` call on `s_KeyPress != null`, so with zero KeyPress subscribers the dead-key-eating path never runs. (No change to `HookManager` was needed.)
- **`EmergencyStop.Trigger()` split latch-first** — the per-keystroke handler (`OnKeyDown`/`OnKeyUp`) was already trivial (lock + detector state machine) and is unchanged. But on *fire*, `Trigger` did audit log file I/O, `GifRecorder.Stop`, `SendInput`, and event publishing inline in the hook proc. Now the latch (`AgentRuntime.SetEmergencyStopped(true)` — a lock and a flag) is the **only** hook-path work; the rest is dispatched to the thread pool. Nothing actuates in the gap — the latch already refuses every tool call before the completion runs. Subscribers of `StateChanged`/`CommandEventHub` already marshal to the UI thread themselves.
- **Docs** — fixed `src/ARCHITECTURE.md`'s incorrect "separate message pump thread" claim; documented the latch-first dispatch in `docs/safety-emergency-stop-and-provisioning.md`. `src/Agent/AgentInstructions.md` needed no change — the agent-facing emergency-stop contract (`error.code: emergency-stopped`, latch-until-rearm) is behaviorally identical.

## Tests

Extended `tests/MCEControl.xUnit/Services/UserActivityMonitorServiceTests.cs` using the #197 `SuppressRealHooksForTesting` seam (no real hooks; CI-safe, no `MCEC_DESKTOP_E2E` tests needed):

- `Start_DoesNotSubscribeKeyPress_SoHookProcSkipsToAscii` — KeyDown +1, KeyPress delta 0.
- `Activity_DispatchesHeavyWorkOffHookPath_AndDebouncesInHandler` — via an internal dispatch seam, asserts the handler completes having *captured* (not executed) the heavy work exactly once per debounce window; the work would throw in the test process (no `MainWindow`) if it ran inline, so completion proves it wasn't invoked synchronously.
- `Activity_DispatchesAgain_AfterDebounceWindowElapses` — debounce lives in the handler, dispatch resumes after the window.

`dotnet build` clean (TreatWarningsAsErrors + house analyzers); `dotnet test`: **615 passed, 0 failed** (22 skipped: pre-existing desktop-gated tests).

## Deferred (follow-ups, per issue "consider")

- **Dedicated hook pump thread** — hooks still install on the UI thread; a long-blocked UI thread can still delay hook delivery (the callbacks themselves now return immediately, which removes the primary eviction trigger). Skipped to keep this change small and behavior-preserving.
- **Hook-eviction detection** — periodic sanity check that re-arms and audit-logs loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm