### PR TITLE
fix: quick-win bug bundle - seven small, independently shippable fixes (#203)

### DIFF
--- a/src/Commands/CommandInvoker.cs
+++ b/src/Commands/CommandInvoker.cs
@@ -188,7 +188,10 @@ public class CommandInvoker : Hashtable {
 
         // TODO: Implement ignoreInternalCommands?
 
-        if (cmdString.Length == 1 && ((Command)this["chars:"]!).Enabled) {
+        // #203: `this["chars:"]` is null when built-ins are disabled (DisableInternalCommands)
+        // or a user .commands file omits it — pattern-match instead of casting so a missing
+        // "chars:" falls through to normal unknown-command handling rather than throwing.
+        if (cmdString.Length == 1 && this["chars:"] is Command charsCommand && charsCommand.Enabled) {
             // Sending a single character is equivalent to a single key press of a key on the keyboard. 
             // For example sending a will result in the A key being pressed. 
             // 1 will result in the 1 key being pressed. There is no difference between sending a and A. 

--- a/src/Commands/SendMessageCommand.cs
+++ b/src/Commands/SendMessageCommand.cs
@@ -86,7 +86,8 @@ public class SendMessageCommand : Command {
                     }
                     else {
                         Logger.Instance.Log4.Info($"{this.GetType().Name}: SendMessage(\"{win.MainWindowTitle}\", {Msg}, {WParam}, {LParam}) - {ToString()}");
-                        Win32.SendMessage(win.MainWindowHandle, (DWORD)Msg, (DWORD)WParam, (DWORD)LParam);
+                        // #203: (nint) sign-extends the stored int (lParam=-1 stays -1 on x64).
+                        Win32.SendMessage(win.MainWindowHandle, (DWORD)Msg, (nint)WParam, (nint)LParam);
                     }
                 }
                 else {
@@ -97,7 +98,7 @@ public class SendMessageCommand : Command {
             else {
                 IntPtr h = Win32.GetForegroundWindow();
                 Logger.Instance.Log4.Info($"{this.GetType().Name}: SendMessage(<forground window>, {Msg}, {WParam}, {LParam}) - {ToString()}");
-                Win32.SendMessage(h, (DWORD)Msg, (DWORD)WParam, (DWORD)LParam);
+                Win32.SendMessage(h, (DWORD)Msg, (nint)WParam, (nint)LParam);
             }
         }
         catch (Exception e) {

--- a/src/Commands/SendMessageCommand.cs
+++ b/src/Commands/SendMessageCommand.cs
@@ -82,6 +82,7 @@ public class SendMessageCommand : Command {
                     }
                     if (win == null) {
                         Logger.Instance.Log4.Error($"{this.GetType().Name}: Could not find a window of class '{ClassName}' captioned with '{WindowName}'");
+                        return false;
                     }
                     else {
                         Logger.Instance.Log4.Info($"{this.GetType().Name}: SendMessage(\"{win.MainWindowTitle}\", {Msg}, {WParam}, {LParam}) - {ToString()}");
@@ -90,6 +91,7 @@ public class SendMessageCommand : Command {
                 }
                 else {
                     Logger.Instance.Log4.Error($"{this.GetType().Name}: GetProcessByName for class '{ClassName}' failed");
+                    return false;
                 }
             }
             else {
@@ -100,8 +102,8 @@ public class SendMessageCommand : Command {
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"{this.GetType().Name}: Failed for '{ClassName}' with error: {e.Message}");
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 }

--- a/src/Dialogs/CommandWindow.cs
+++ b/src/Dialogs/CommandWindow.cs
@@ -97,7 +97,10 @@ public partial class CommandWindow : Form {
         listCmds.Columns[2].Width = -1;
 
         listCmds.Focus();
-        listCmds.Items[0].Selected = true;
+        // #203: the list can be empty (DisableInternalCommands + no user commands).
+        if (listCmds.Items.Count > 0) {
+            listCmds.Items[0].Selected = true;
+        }
         saveChangesBtn.Enabled = false;
     }
 

--- a/src/Dialogs/SettingsDialog.cs
+++ b/src/Dialogs/SettingsDialog.cs
@@ -1016,16 +1016,20 @@ public class SettingsDialog : Form {
     }
 
     private void SettingsChanged() {
+        // #203: this used to `return` after validating the first enabled section, so a
+        // valid Server+Wakeup masked an invalid Client (etc.). ALL enabled sections must
+        // validate before OK is enabled.
+        bool valid = true;
+
         if (_checkBoxEnableServer.Checked && _checkBoxEnableWakeup.Checked) {
             if (!int.TryParse(_editWakeupPort.Text, out int port)) {
                 port = 0;
             }
 
-            _buttonOk.Enabled = !(String.IsNullOrEmpty(_editWakeupServer.Text) ||
-                                  String.IsNullOrEmpty(_editWakeupCommand.Text) ||
-                                  String.IsNullOrEmpty(_editClosingCommand.Text) ||
-                                  (port == 0));
-            return;
+            valid = valid && !(String.IsNullOrEmpty(_editWakeupServer.Text) ||
+                               String.IsNullOrEmpty(_editWakeupCommand.Text) ||
+                               String.IsNullOrEmpty(_editClosingCommand.Text) ||
+                               (port == 0));
         }
 
         if (_checkBoxEnableClient.Checked) {
@@ -1033,9 +1037,8 @@ public class SettingsDialog : Form {
                 port = 0;
             }
 
-            _buttonOk.Enabled = !(String.IsNullOrEmpty(_editClientHost.Text) ||
-                                  (port == 0));
-            return;
+            valid = valid && !(String.IsNullOrEmpty(_editClientHost.Text) ||
+                               (port == 0));
         }
 
         if (_checkBoxEnableActivityMonitor.Checked) {
@@ -1043,13 +1046,12 @@ public class SettingsDialog : Form {
                 t = 0;
             }
 
-            _buttonOk.Enabled = !(String.IsNullOrEmpty(_textBoxActivityCommand.Text) ||
-                                String.IsNullOrEmpty(_textBoxDebounceTime.Text) ||
-                                (t == 0));
-            return;
+            valid = valid && !(String.IsNullOrEmpty(_textBoxActivityCommand.Text) ||
+                               String.IsNullOrEmpty(_textBoxDebounceTime.Text) ||
+                               (t == 0));
         }
 
-        _buttonOk.Enabled = true;
+        _buttonOk.Enabled = valid;
     }
 
     /// <summary>
@@ -1147,8 +1149,10 @@ public class SettingsDialog : Form {
     }
 
     private void EditClientDelayTimeTextChanged(object? sender, EventArgs e) {
-        if (_editClientDelayTime.Text.Length > 0) {
-            Settings.ClientDelayTime = Convert.ToInt32(_editClientDelayTime.Text, new NumberFormatInfo());
+        // #203: Convert.ToInt32 fired on every keystroke and threw on non-digits — use
+        // TryParse like the sibling handlers.
+        if (int.TryParse(_editClientDelayTime.Text, out int delay)) {
+            Settings.ClientDelayTime = delay;
         }
 
         SettingsChanged();
@@ -1163,8 +1167,10 @@ public class SettingsDialog : Form {
     }
 
     private void ComboBoxSerialPortSelectedIndexChanged(object? sender, EventArgs e) {
-        if (_comboBoxBaudRate.SelectedItem != null) {
-            Settings.SerialServerPortName = _comboBoxSerialPort.SelectedItem!.ToString()!;
+        // #203: this used to check _comboBoxBaudRate.SelectedItem and then dereference
+        // _comboBoxSerialPort.SelectedItem — guard the control actually being read.
+        if (_comboBoxSerialPort.SelectedItem != null) {
+            Settings.SerialServerPortName = _comboBoxSerialPort.SelectedItem.ToString()!;
             SettingsChanged();
         }
     }
@@ -1250,8 +1256,10 @@ public class SettingsDialog : Form {
     }
 
     private void comboBoxLogThresholds_SelectedIndexChanged(object? sender, EventArgs e) {
+        // #203: do NOT mutate the global Logger.Instance.TextBoxThreshold here — Cancel
+        // could never restore it. The dialog only updates its (cloned) Settings;
+        // MainWindow.ApplySettings applies the threshold on the OK path.
         Settings.TextBoxLogThreshold = _comboBoxLogThresholds.SelectedItem!.ToString()!;
-        Logger.Instance.TextBoxThreshold = LogManager.GetLogger("MCEControl")!.Logger!.Repository!.LevelMap[Settings.TextBoxLogThreshold!]!;
 
         SettingsChanged();
     }

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -154,7 +154,7 @@ public partial class MainWindow : Form {
 
         if (Settings.HideOnStartup) {
             Opacity = 0;
-            Win32.PostMessage(Handle, (UInt32)WM.SYSCOMMAND, (UInt32)SC.CLOSE, 0);
+            Win32.PostMessage(Handle, (UInt32)WM.SYSCOMMAND, (nint)SC.CLOSE, 0);
         }
 
         SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(SystemEvents_UserPreferenceChanged);

--- a/src/Services/ClientReplyContext.cs
+++ b/src/Services/ClientReplyContext.cs
@@ -19,7 +19,7 @@ internal class ClientReplyContext : Reply {
             return;
         }
 
-        byte[] buf = System.Text.Encoding.ASCII.GetBytes(text.Replace("\0xFF", "\0xFF\0xFF"));
+        byte[] buf = System.Text.Encoding.ASCII.GetBytes(TelnetProtocol.EscapeIac(text));
         _tcpClient.GetStream().Write(buf, 0, buf.Length);
     }
 }

--- a/src/Services/SocketClient.cs
+++ b/src/Services/SocketClient.cs
@@ -112,7 +112,7 @@ public sealed class SocketClient : ServiceBase, IDisposable {
         }
 
         try {
-            byte[] buf = System.Text.ASCIIEncoding.ASCII.GetBytes(text.Replace("\0xFF", "\0xFF\0xFF"));
+            byte[] buf = System.Text.ASCIIEncoding.ASCII.GetBytes(TelnetProtocol.EscapeIac(text));
             _tcpClient.GetStream().Write(buf, 0, buf.Length);
         }
         catch (IOException ioe) {

--- a/src/Services/TelnetProtocol.cs
+++ b/src/Services/TelnetProtocol.cs
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+//-------------------------------------------------------------------
+using System;
+
+namespace MCEControl;
+
+/// <summary>
+/// Telnet protocol helpers shared by the outbound socket paths
+/// (<see cref="SocketClient"/> and <see cref="ClientReplyContext"/>).
+/// </summary>
+internal static class TelnetProtocol {
+    /// <summary>
+    /// Escapes the telnet IAC byte (0xFF) in outbound text by doubling it, per RFC 854:
+    /// a literal 0xFF in the data stream must be sent as 0xFF 0xFF so the peer does not
+    /// interpret it as the start of a telnet command.
+    /// (#203: both call sites used <c>Replace("\0xFF", "\0xFF\0xFF")</c> — the four-char
+    /// string NUL+'x'+'F'+'F', not byte 0xFF — so the escaping was dead code.)
+    /// </summary>
+    /// <param name="text">The text to escape. Must not be null.</param>
+    /// <returns>The text with every '\xFF' character doubled.</returns>
+    public static string EscapeIac(string text) {
+        if (text is null) {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        return text.Replace("\xFF", "\xFF\xFF", StringComparison.Ordinal);
+    }
+}

--- a/src/Services/UserActivityMonitorService.cs
+++ b/src/Services/UserActivityMonitorService.cs
@@ -245,7 +245,8 @@ public sealed class UserActivityMonitorService : IDisposable {
         Debug.Assert(_presencePresumedTimer == null);
         _presencePresumedTimer = new Timer();
         _presencePresumedTimer.Tick += ActivityPresumedTimerTick;
-        _presencePresumedTimer.Interval = DebounceTime;
+        // #203: DebounceTime is in seconds everywhere else in this class; Timer.Interval is milliseconds.
+        _presencePresumedTimer.Interval = DebounceTime * 1000;
     }
 
     private void StopPresencePresumedTimer() {

--- a/src/Win32/Win32Interop.cs
+++ b/src/Win32/Win32Interop.cs
@@ -434,11 +434,14 @@ namespace Microsoft.Win32.Security {
         ///
         /// USER32.DLL (NT4+ only) 
         ///
+        // #203: WPARAM/LPARAM are pointer-sized (UINT_PTR/LONG_PTR), not 32-bit DWORDs.
+        // Declaring them as DWORD zero-extended negative values (e.g. monitoron's lParam=-1)
+        // on x64. Declared as nint so call sites can sign-extend stored ints correctly.
         [DllImport(User32, EntryPoint = "SendMessage")]
-        public static extern Int32 SendMessage(HWND hWnd, DWORD Msg, DWORD wParam, DWORD lParam);
+        public static extern IntPtr SendMessage(HWND hWnd, DWORD Msg, nint wParam, nint lParam);
 
         [DllImport(User32, EntryPoint = "PostMessage")]
-        public static extern Int32 PostMessage(HWND hWnd, DWORD Msg, DWORD wParam, DWORD lParam);
+        public static extern BOOL PostMessage(HWND hWnd, DWORD Msg, nint wParam, nint lParam);
 
         [DllImport(User32, EntryPoint = "FindWindow")]
         public static extern HWND FindWindow(string ClassName, string WindowName);

--- a/tests/MCEControl.xUnit/CommandInvokerTests.cs
+++ b/tests/MCEControl.xUnit/CommandInvokerTests.cs
@@ -97,6 +97,22 @@ public class CommandInvokerTests
     }
 
     /// <summary>
+    /// #203: a single-character payload used to NRE when the registry had no "chars:"
+    /// prototype (DisableInternalCommands, or a user .commands file without it). It must
+    /// fall through to normal unknown-command handling instead of throwing.
+    /// </summary>
+    [Fact]
+    public void Enqueue_SingleChar_NoCharsCommand_DoesNotThrow()
+    {
+        CommandInvoker invoker = [];
+        Assert.Null(invoker["chars:"]);
+
+        invoker.Enqueue(new Commands.TestReply(), "a");
+
+        Assert.Equal(0, invoker.QueuedCommandCount);
+    }
+
+    /// <summary>
     /// Test create where there were user-defined changes to builtin commands
     /// </summary>
     [Fact]

--- a/tests/MCEControl.xUnit/Commands/SendMessageCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/SendMessageCommandTests.cs
@@ -66,6 +66,37 @@ public class SendMessageCommandTests
     }
 
     [Fact]
+    public void Execute_WhenEnabled_ProcessNotFound_ReturnsFalse()
+    {
+        // #203: Execute's returns were inverted (success fell through to `return false`,
+        // the catch returned `true`). Failure paths must return false.
+        var cmd = new SendMessageCommand("NoSuchProcess_Issue203_BogusClass", "NoSuchWindow", 0, 0, 0)
+        {
+            Cmd = "test",
+            Enabled = true
+        };
+
+        bool result = cmd.Execute();
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Execute_WhenEnabled_WindowNameNotFound_ReturnsFalse()
+    {
+        // The current test process exists but has no window with this caption:
+        // the `win == null` failure path must return false (not fall through to success).
+        string thisProcess = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+        var cmd = new SendMessageCommand(thisProcess, "NoSuchWindowCaption_Issue203", 0, 0, 0)
+        {
+            Cmd = "test",
+            Enabled = true
+        };
+
+        bool result = cmd.Execute();
+        Assert.False(result);
+    }
+
+    [Fact]
     public void ToString_ReturnsFormattedString()
     {
         var cmd = new SendMessageCommand("TestClass", "TestWindow", 100, 200, 300)

--- a/tests/MCEControl.xUnit/Services/TelnetProtocolTests.cs
+++ b/tests/MCEControl.xUnit/Services/TelnetProtocolTests.cs
@@ -1,0 +1,49 @@
+using System;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Services;
+
+public class TelnetProtocolTests
+{
+    // NOTE: ÿ is used instead of \xFF throughout — C#'s \x escape greedily
+    // consumes up to four hex digits, so "\xFFb" would be the single char U+0FFB.
+
+    [Fact]
+    public void EscapeIac_DoublesIacCharacter()
+    {
+        Assert.Equal("ÿÿ", TelnetProtocol.EscapeIac("ÿ"));
+    }
+
+    [Fact]
+    public void EscapeIac_DoublesEveryIacCharacter()
+    {
+        Assert.Equal("aÿÿbÿÿc", TelnetProtocol.EscapeIac("aÿbÿc"));
+    }
+
+    [Fact]
+    public void EscapeIac_LeavesNormalTextUnchanged()
+    {
+        Assert.Equal("hello world\r\n", TelnetProtocol.EscapeIac("hello world\r\n"));
+    }
+
+    [Fact]
+    public void EscapeIac_EmptyString_ReturnsEmpty()
+    {
+        Assert.Equal("", TelnetProtocol.EscapeIac(""));
+    }
+
+    [Fact]
+    public void EscapeIac_DoesNotMatchTheOldBuggyLiteral()
+    {
+        // The pre-#203 code replaced the four-char string NUL+'x'+'F'+'F' — make sure
+        // that sequence is now left alone and only the real IAC char is escaped.
+        Assert.Equal("\0xFF", TelnetProtocol.EscapeIac("\0xFF"));
+    }
+
+    [Fact]
+    public void EscapeIac_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => TelnetProtocol.EscapeIac(null!));
+    }
+}


### PR DESCRIPTION
Fixes #203

Seven small, one-file(ish), independently verifiable bug fixes, one commit each:

- [x] **1. `SendMessageCommand.Execute` inverted returns** — success now returns `true`; the not-found and exception failure paths return `false`. Added headless unit tests for both failure paths (bogus process class; existing process with no matching window caption).
- [x] **2. Dead telnet IAC escaping** — `Replace("\0xFF", "\0xFF\0xFF")` matched the four-char string NUL+`x`+`F`+`F`, never byte 0xFF, in both `SocketClient.Send` and `ClientReplyContext.Write`. Both now call one shared helper, `TelnetProtocol.EscapeIac` (RFC 854 IAC doubling), with unit tests covering doubling, pass-through, and the old buggy literal.
- [x] **3. Single-char payload NRE when built-ins disabled** — `((Command)this["chars:"]!).Enabled` threw when the registry has no `chars:` (DisableInternalCommands or a user file without it). Now `this["chars:"] is Command chars && chars.Enabled`; an absent `chars:` falls through to normal unknown-command handling. Test: single-char enqueue on an empty `CommandInvoker` does not throw and enqueues nothing.
- [x] **4. Presence timer seconds-vs-milliseconds** — `_presencePresumedTimer.Interval = DebounceTime` fired every ~10 ms; now `DebounceTime * 1000`.
- [x] **5. SettingsDialog handler bugs** — (a) serial-port handler now guards the control it actually dereferences; (b) `ClientDelayTime` uses `int.TryParse` instead of `Convert.ToInt32` per keystroke; (c) `SettingsChanged()` validates ALL enabled sections before enabling OK instead of returning after the first; (d) the log-threshold combo no longer mutates the global `Logger.Instance.TextBoxThreshold` immediately (Cancel could never restore it) — `MainWindow.ApplySettings` already applies it on the OK path.
- [x] **6. CommandWindow crash on empty list** — `listCmds.Items[0].Selected = true` is now guarded for an empty list (DisableInternalCommands + no user commands).
- [x] **7. `SendMessage`/`PostMessage` 32-bit WPARAM/LPARAM** — redeclared as `nint` (SendMessage returns `IntPtr` = LRESULT; PostMessage keeps its BOOL return) and call sites sign-extend the stored ints, so `monitoron` (lParam=-1) no longer zero-extends to `0x00000000FFFFFFFF` on x64. Kept minimal per the issue; broader interop consolidation stays in #210.

## Testing

- `dotnet build src/MCEControl.csproj` — 0 errors (only the pre-existing WFDEV004 designer warning).
- `dotnet test tests/MCEControl.xUnit/MCEControl.xUnit.csproj` — 621 passed, 0 failed, 22 skipped (pre-existing desktop-input/E2E skips).
- New tests: `SendMessageCommandTests` (2), `TelnetProtocolTests` (6), `CommandInvokerTests.Enqueue_SingleChar_NoCharsCommand_DoesNotThrow`.

UI-only fixes (5, 6) have no unit tests — the handlers are private on WinForms controls; behavior verified by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm