### PR TITLE
Arch: make the agent security gate structural — AgentCommand base class with a sealed Execute template

### DIFF
--- a/docs/agent-server-architecture.md
+++ b/docs/agent-server-architecture.md
@@ -72,27 +72,32 @@ the server runs a command against a `CapturingReply : Reply` and reads back
 
 ## How the new commands plug into the existing pattern
 
-Each new command (`capture`, `query`, `find`, `wait-for`, `invoke`) is an ordinary
-`Command` subclass and follows the house pattern exactly:
+Each agent command (`capture`, `query`, `find`/`wait-for`, `invoke`, `click`, `drag`,
+`record`, `displays`, `launch`) derives from `AgentCommand : Command` (#208) and follows
+the house pattern:
 
-- `Clone(Reply)` via `base.Clone(reply, new XxxCommand { ... })`.
-- `Execute()` whose **first** line is `if (!base.Execute()) { return false; }`
-  (preserving the per-command `Enabled` gate + telemetry).
+- `Clone(Reply)` via `base.Clone(reply, new XxxCommand { ... })` (base layers copy the
+  shared properties they host).
 - `BuiltInCommands` returning the command with `Enabled=false` by default.
-- `[XmlAttribute]` on serializable props.
+- `[XmlAttribute]` on serializable props (all-lowercase names — see `XmlNameCasingTests`, #200).
 
-Immediately after `base.Execute()`, every agent command runs the gating block:
+`AgentCommand` owns a **sealed** `Execute()` template method: the base
+`Command.Execute()` (per-command `Enabled` gate + telemetry), then the
+`AgentRuntime.AgentCommandsEnabled` gating block (Warn log + structured
+`CommandResult.Fail` reply, fail-closed), then the `AGENT-AUDIT:` line, then dispatch to
+the command's `ExecuteCore()`. The gate is **structural**: a subclass cannot override
+`Execute()`, so a new agent command cannot forget the opt-in check. This matters because
+agent commands are ordinary `Command`s reachable over the legacy TCP/serial pipeline,
+which has **no** server-side agent gate — in-command enforcement is the only gate on
+those transports (`AgentServer` re-checks it only on the MCP/HTTP path).
+`AgentCommandStructuralGateTests` asserts every agent tool maps to an `AgentCommand`.
 
-```csharp
-if (!AgentRuntime.AgentCommandsEnabled) {
-    Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. " +
-        "Set AgentCommandsEnabled=true to opt in.");
-    Reply?.WriteLine(CommandResult.Fail(Cmd,
-        "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-    return false;
-}
-AgentRuntime.Audit(Cmd, "<target/action>");
-```
+Window-targeting commands additionally derive from
+`WindowTargetingAgentCommand : AgentCommand`, which hosts the five shared selector
+properties (`window`/`handle`/`process`/`classname`/`foreground`) once, performs the
+single `WindowResolver.Resolve` call, and hands `ExecuteCore(WindowInfo? target)` the
+resolved window (commands with window-less modes — pixel `click`/`drag`, region
+`capture`, `record` — override `RequiresWindowTarget`).
 
 Because they are normal commands, they are dispatched by the existing
 `CommandInvoker` and are reachable through every existing transport as well as the new

--- a/src/Commands/AgentCommand.cs
+++ b/src/Commands/AgentCommand.cs
@@ -1,0 +1,62 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// Base class for every MCEC 3.0 agent command (<c>capture</c>, <c>query</c>, <c>find</c>/<c>wait-for</c>,
+/// <c>invoke</c>, <c>click</c>, <c>drag</c>, <c>record</c>, <c>displays</c>, <c>launch</c>). Its sealed
+/// <see cref="Execute"/> template method makes the <see cref="AgentRuntime.AgentCommandsEnabled"/>
+/// security gate STRUCTURAL: a subclass implements <see cref="ExecuteCore"/> and can only ever run
+/// after the gate has passed — forgetting the gate is impossible by construction (issue #208).
+///
+/// SECURITY — why the gate must live here and not (only) in the server: the MCP path checks
+/// <c>AgentCommandsEnabled</c> in <c>AgentServer</c> before dispatch, but agent commands are ordinary
+/// <see cref="Command"/>s reachable over the legacy TCP/serial pipeline too, and that pipeline has NO
+/// server-side agent gate. For those transports this in-command check is the ONLY thing standing
+/// between a flipped per-command <c>Enabled</c> flag and full agent observation/actuation. Under the
+/// old copy-paste pattern, a new agent command whose author forgot the paste was silently exposed
+/// over TCP — nothing caught it. <c>AgentCommandStructuralGateTests</c> asserts every agent tool maps
+/// to a subclass of this type.
+/// </summary>
+public abstract class AgentCommand : Command {
+    /// <summary>
+    /// Sealed gate + audit + dispatch template. Order (identical to the pre-#208 hand-written
+    /// bodies): the <see cref="Command.Execute"/> per-command <c>Enabled</c> check and telemetry,
+    /// then the <see cref="AgentRuntime.AgentCommandsEnabled"/> opt-in gate (fail-closed with the
+    /// same structured <see cref="CommandResult"/> the commands have always emitted), then the
+    /// <see cref="AgentRuntime.Audit"/> line (when <see cref="AuditDetails"/> supplies one), then
+    /// <see cref="ExecuteCore"/>.
+    /// </summary>
+    public sealed override bool Execute() {
+        if (!base.Execute()) {
+            return false;
+        }
+
+        if (!AgentRuntime.AgentCommandsEnabled) {
+            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
+            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
+            return false;
+        }
+
+        string? auditDetails = AuditDetails();
+        if (auditDetails is not null) {
+            AgentRuntime.Audit(Cmd, auditDetails);
+        }
+
+        return ExecuteCore();
+    }
+
+    /// <summary>
+    /// The <c>AGENT-AUDIT:</c> detail logged immediately after the gate passes, or <c>null</c> when
+    /// the command audits later itself (e.g. <c>capture</c>/<c>record</c>/<c>launch</c> audit after
+    /// branch-specific validation, with branch-specific detail).
+    /// </summary>
+    protected virtual string? AuditDetails() => null;
+
+    /// <summary>
+    /// The command body. Runs only when the per-command <c>Enabled</c> flag AND the
+    /// <see cref="AgentRuntime.AgentCommandsEnabled"/> opt-in are both set.
+    /// </summary>
+    protected abstract bool ExecuteCore();
+}

--- a/src/Commands/CaptureCommand.cs
+++ b/src/Commands/CaptureCommand.cs
@@ -15,24 +15,10 @@ namespace MCEControl;
 /// <see cref="CommandResult"/> carrying base64 image bytes (and optionally writes the PNG to a file).
 ///
 /// SECURITY: gated behind <see cref="AgentRuntime.AgentCommandsEnabled"/> (a separate opt-in from the
-/// actuation enable) and every capture is audited via <see cref="AgentRuntime.Audit"/>.
+/// actuation enable — enforced structurally by <see cref="AgentCommand"/>) and every capture is
+/// audited via <see cref="AgentRuntime.Audit"/>.
 /// </summary>
-public class CaptureCommand : Command {
-    [XmlAttribute("window")]
-    public string Window { get; set; } = null!;
-
-    [XmlAttribute("handle")]
-    public long Handle { get; set; }
-
-    [XmlAttribute("process")]
-    public string Process { get; set; } = null!;
-
-    [XmlAttribute("classname")]
-    public string ClassName { get; set; } = null!;
-
-    [XmlAttribute("foreground")]
-    public bool Foreground { get; set; }
-
+public class CaptureCommand : WindowTargetingAgentCommand {
     [XmlAttribute("x")]
     public int X { get; set; }
 
@@ -55,11 +41,6 @@ public class CaptureCommand : Command {
     public CaptureCommand() { }
 
     public override ICommand Clone(Reply reply) => base.Clone(reply, new CaptureCommand {
-        Window = Window,
-        Handle = Handle,
-        Process = Process,
-        ClassName = ClassName,
-        Foreground = Foreground,
         X = X,
         Y = Y,
         Width = Width,
@@ -67,112 +48,104 @@ public class CaptureCommand : Command {
         File = File,
     });
 
-    // ICommand:Execute
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
+    /// <summary>True when this is an explicit-region capture (region given, no window selector).</summary>
+    private bool IsRegionCapture => Width > 0 && Height > 0 && !HasWindowTarget;
 
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
+    // A region capture never resolves a window; everything else (including no selectors at all,
+    // which fails as window-not-found) does.
+    protected override bool RequiresWindowTarget => !IsRegionCapture;
 
-        bool hasWindowTarget = !string.IsNullOrEmpty(Window)
-            || Handle > 0
-            || !string.IsNullOrEmpty(Process)
-            || !string.IsNullOrEmpty(ClassName)
-            || Foreground;
+    protected override bool OnWindowNotFound() {
+        AgentRuntime.Audit(Cmd, "no matching window");
+        Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
+        return false;
+    }
 
+    protected override bool ExecuteCore(WindowInfo? target) {
         try {
-            JsonObject data;
-
-            if (Width > 0 && Height > 0 && !hasWindowTarget) {
-                // SECURITY (#158): region dimensions are agent-controlled — reject oversized
-                // requests BEFORE any bitmap/PNG/base64 allocation, with a diagnosable envelope.
-                string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
-                if (sizeError is not null) {
-                    AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED — {sizeError}");
-                    Reply?.WriteLine(CommandResult.Fail(Cmd, sizeError, "region-too-large", "no-target").ToJson());
-                    return false;
-                }
-
-                AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height}");
-
-                CaptureResult regionCap = ScreenCapture.CaptureRegion(X, Y, Width, Height);
-                data = new JsonObject {
-                    ["encoding"] = "png",
-                    ["width"] = regionCap.Width,
-                    ["height"] = regionCap.Height,
-                    ["bytes"] = regionCap.Png.Length,
-                    ["base64"] = Convert.ToBase64String(regionCap.Png),
-                    ["blankCheck"] = BlankCheckJson(regionCap.Stats),
-                };
-                WriteFileIfRequested(regionCap.Png, data);
-
-                // A user-specified region can legitimately be empty, so a blank region is a non-fatal
-                // warning (not a capture-blank error) — the agent still gets the image and the signal.
-                CommandResult regionRes = CommandResult.Ok(Cmd, data);
-                if (regionCap.Stats.IsBlank) {
-                    regionRes.Warn("capture-blank", "Captured region is blank (a flat fill); it may be off-screen or genuinely empty.");
-                }
-                Reply?.WriteLine(regionRes.ToJson());
-                return true;
-            }
-
-            WindowInfo? win = WindowResolver.Resolve(
-                Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
-            if (win is null) {
-                AgentRuntime.Audit(Cmd, "no matching window");
-                Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
-                return false;
-            }
-
-            AgentRuntime.Audit(Cmd, $"window 0x{win.Handle:X} \"{win.Title}\" ({win.ProcessName})");
-
-            CaptureResult cap = ScreenCapture.CaptureWindow(new IntPtr(win.Handle));
-            data = new JsonObject {
-                ["handle"] = win.Handle,
-                ["width"] = cap.Width,
-                ["height"] = cap.Height,
-                ["encoding"] = "png",
-                ["bytes"] = cap.Png.Length,
-                ["base64"] = Convert.ToBase64String(cap.Png),
-                ["window"] = win.ToJsonObject(),
-                ["blankCheck"] = BlankCheckJson(cap.Stats),
-            };
-            WriteFileIfRequested(cap.Png, data);
-
-            // A blank window frame is a hard observation failure: don't return a silent bad image.
-            // The PNG stays in `data` (so the agent still sees what was grabbed and it can serve as the
-            // contract's lastObservation), but the result is flagged capture-blank so the agent branches.
-            CommandResult res;
-            bool ok;
-            if (cap.Stats.IsBlank) {
-                string code = cap.Stats.DominantIsDark ? "frame-all-black" : "frame-uniform";
-                string detail = cap.UsedFallback
-                    ? "Captured frame is blank — PrintWindow was refused and the on-screen-blit fallback returned a flat image (composited/occluded/minimized window or a locked session)."
-                    : "Captured frame is blank (a flat fill); the window may be minimized, cloaked, or rendering off-screen.";
-                AgentRuntime.Audit(Cmd, $"blank frame ({code}, dominant {cap.Stats.DominantFraction:P0}, fallback={cap.UsedFallback})");
-                res = CommandResult.Fail(Cmd, detail, code, "capture-blank", data);
-                ok = false;
-            }
-            else {
-                res = CommandResult.Ok(Cmd, data);
-                ok = true;
-            }
-            if (cap.UsedFallback) {
-                res.Warn("capture-fallback", "PrintWindow was refused; used an on-screen blit, which returns black for composited/occluded surfaces and cannot see windows behind others.");
-            }
-            Reply?.WriteLine(res.ToJson());
-            return ok;
+            return target is null ? CaptureRegion() : CaptureWindow(target);
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"{GetType().Name}: Capture failed: {e.Message}");
             Reply?.WriteLine(CommandResult.Fail(Cmd, $"Capture failed: {e.Message}").ToJson());
             return false;
         }
+    }
+
+    /// <summary>The explicit-region path (no window was required or resolved).</summary>
+    private bool CaptureRegion() {
+        // SECURITY (#158): region dimensions are agent-controlled — reject oversized
+        // requests BEFORE any bitmap/PNG/base64 allocation, with a diagnosable envelope.
+        string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
+        if (sizeError is not null) {
+            AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED — {sizeError}");
+            Reply?.WriteLine(CommandResult.Fail(Cmd, sizeError, "region-too-large", "no-target").ToJson());
+            return false;
+        }
+
+        AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height}");
+
+        CaptureResult regionCap = ScreenCapture.CaptureRegion(X, Y, Width, Height);
+        JsonObject data = new JsonObject {
+            ["encoding"] = "png",
+            ["width"] = regionCap.Width,
+            ["height"] = regionCap.Height,
+            ["bytes"] = regionCap.Png.Length,
+            ["base64"] = Convert.ToBase64String(regionCap.Png),
+            ["blankCheck"] = BlankCheckJson(regionCap.Stats),
+        };
+        WriteFileIfRequested(regionCap.Png, data);
+
+        // A user-specified region can legitimately be empty, so a blank region is a non-fatal
+        // warning (not a capture-blank error) — the agent still gets the image and the signal.
+        CommandResult regionRes = CommandResult.Ok(Cmd, data);
+        if (regionCap.Stats.IsBlank) {
+            regionRes.Warn("capture-blank", "Captured region is blank (a flat fill); it may be off-screen or genuinely empty.");
+        }
+        Reply?.WriteLine(regionRes.ToJson());
+        return true;
+    }
+
+    /// <summary>The resolved-window path.</summary>
+    private bool CaptureWindow(WindowInfo win) {
+        AgentRuntime.Audit(Cmd, $"window 0x{win.Handle:X} \"{win.Title}\" ({win.ProcessName})");
+
+        CaptureResult cap = ScreenCapture.CaptureWindow(new IntPtr(win.Handle));
+        JsonObject data = new JsonObject {
+            ["handle"] = win.Handle,
+            ["width"] = cap.Width,
+            ["height"] = cap.Height,
+            ["encoding"] = "png",
+            ["bytes"] = cap.Png.Length,
+            ["base64"] = Convert.ToBase64String(cap.Png),
+            ["window"] = win.ToJsonObject(),
+            ["blankCheck"] = BlankCheckJson(cap.Stats),
+        };
+        WriteFileIfRequested(cap.Png, data);
+
+        // A blank window frame is a hard observation failure: don't return a silent bad image.
+        // The PNG stays in `data` (so the agent still sees what was grabbed and it can serve as the
+        // contract's lastObservation), but the result is flagged capture-blank so the agent branches.
+        CommandResult res;
+        bool ok;
+        if (cap.Stats.IsBlank) {
+            string code = cap.Stats.DominantIsDark ? "frame-all-black" : "frame-uniform";
+            string detail = cap.UsedFallback
+                ? "Captured frame is blank — PrintWindow was refused and the on-screen-blit fallback returned a flat image (composited/occluded/minimized window or a locked session)."
+                : "Captured frame is blank (a flat fill); the window may be minimized, cloaked, or rendering off-screen.";
+            AgentRuntime.Audit(Cmd, $"blank frame ({code}, dominant {cap.Stats.DominantFraction:P0}, fallback={cap.UsedFallback})");
+            res = CommandResult.Fail(Cmd, detail, code, "capture-blank", data);
+            ok = false;
+        }
+        else {
+            res = CommandResult.Ok(Cmd, data);
+            ok = true;
+        }
+        if (cap.UsedFallback) {
+            res.Warn("capture-fallback", "PrintWindow was refused; used an on-screen blit, which returns black for composited/occluded surfaces and cannot see windows behind others.");
+        }
+        Reply?.WriteLine(res.ToJson());
+        return ok;
     }
 
     /// <summary>Serializes the blank-frame analysis so an agent can see why a capture was flagged.</summary>

--- a/src/Commands/ClickCommand.cs
+++ b/src/Commands/ClickCommand.cs
@@ -15,20 +15,10 @@ namespace MCEControl;
 /// agent can click a control it just observed without converting to normalized coordinates itself. The
 /// move-then-click is dispatched atomically by <see cref="MouseCommand.PerformClick"/> so it cannot
 /// interleave with another command's mouse input (the hazard #113 warns about when a caller hand-rolls
-/// <c>mt</c>/<c>lbc</c>). Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited. Disabled
-/// by default (security).
+/// <c>mt</c>/<c>lbc</c>). Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited
+/// (structurally, via <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
-public class ClickCommand : Command {
-    // NOTE: attribute names MUST be all-lowercase. SerializedCommands.Deserialize runs an XSLT that
-    // lower-cases every element/attribute name before deserializing, so a camelCase name would never
-    // bind on load and the value would be silently lost (see DragCommand). Enforced for every Command
-    // by XmlNameCasingTests (#200).
-    [XmlAttribute("window")] public string Window { get; set; } = null!;
-    [XmlAttribute("handle")] public long Handle { get; set; }
-    [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
-    [XmlAttribute("foreground")] public bool Foreground { get; set; }
-
+public class ClickCommand : WindowTargetingAgentCommand {
     [XmlAttribute("by")] public string By { get; set; } = "name";
     [XmlAttribute("value")] public string Value { get; set; } = null!;
     [XmlAttribute("x")] public int X { get; set; }
@@ -49,11 +39,6 @@ public class ClickCommand : Command {
     }
 
     public override ICommand Clone(Reply reply) => base.Clone(reply, new ClickCommand {
-        Window = this.Window,
-        Handle = this.Handle,
-        Process = this.Process,
-        ClassName = this.ClassName,
-        Foreground = this.Foreground,
         By = this.By,
         Value = this.Value,
         X = this.X,
@@ -62,28 +47,19 @@ public class ClickCommand : Command {
         Count = this.Count,
     });
 
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
+    protected override string? AuditDetails() =>
+        $"click at (by={By} value='{Value}' {X},{Y}) button={Button} count={Count} window handle={Handle} title='{Window}' process='{Process}'";
 
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
-        AgentRuntime.Audit(Cmd, $"click at (by={By} value='{Value}' {X},{Y}) button={Button} count={Count} window handle={Handle} title='{Window}' process='{Process}'");
+    // A window is only needed to resolve an element endpoint; a pure pixel click needs none.
+    protected override bool RequiresWindowTarget => !string.IsNullOrEmpty(Value);
 
-        // A window is only needed to resolve an element endpoint; a pure pixel click needs none.
-        IntPtr hwnd = IntPtr.Zero;
-        if (!string.IsNullOrEmpty(Value)) {
-            WindowInfo? win = WindowResolver.Resolve(Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
-            if (win is null) {
-                Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
-                return false;
-            }
-            hwnd = new IntPtr(win.Handle);
-        }
+    protected override bool OnWindowNotFound() {
+        Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
+        return false;
+    }
+
+    protected override bool ExecuteCore(WindowInfo? target) {
+        IntPtr hwnd = target is null ? IntPtr.Zero : new IntPtr(target.Handle);
 
         if (!TryResolvePoint(hwnd, out (int X, int Y) point, out string? error)) {
             Reply?.WriteLine(CommandResult.Fail(Cmd, error!, "element-not-found", "no-target").ToJson());
@@ -118,7 +94,7 @@ public class ClickCommand : Command {
             point = (X, Y);
             return true;
         }
-        // hwnd is guaranteed non-zero here: Execute resolves the window whenever Value is set.
+        // hwnd is guaranteed non-zero here: the base resolves the window whenever Value is set.
         UiaElementInfo? el = UiaService.Find(hwnd, string.IsNullOrEmpty(By) ? "name" : By, Value, FindTimeoutMs);
         if (el is null) {
             point = default;

--- a/src/Commands/DisplaysCommand.cs
+++ b/src/Commands/DisplaysCommand.cs
@@ -16,27 +16,19 @@ namespace MCEControl;
 /// <c>query</c>/<c>find</c> return into pointer actions: it learns screen size and per-monitor scaling
 /// from MCEC rather than doing the host-side <c>SetProcessDPIAware()</c>/<c>GetSystemMetrics()</c> dance
 /// the hero script used to. Pure observation — no input is generated. Gated by
-/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited. Disabled by default (security).
+/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
+/// <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
-public class DisplaysCommand : Command {
+public class DisplaysCommand : AgentCommand {
     public static new List<Command> BuiltInCommands {
         get => [new DisplaysCommand { Cmd = "displays" }];
     }
 
     public override ICommand Clone(Reply reply) => base.Clone(reply, new DisplaysCommand());
 
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
+    protected override string? AuditDetails() => "displays";
 
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
-        AgentRuntime.Audit(Cmd, "displays");
-
+    protected override bool ExecuteCore() {
         JsonArray displays = [];
         Screen[] screens = Screen.AllScreens;
         for (int i = 0; i < screens.Length; i++) {

--- a/src/Commands/DragCommand.cs
+++ b/src/Commands/DragCommand.cs
@@ -15,18 +15,13 @@ namespace MCEControl;
 /// intermediate waypoints (<see cref="PathSpec"/>). The whole gesture is dispatched atomically by
 /// <see cref="MouseCommand.PerformDrag"/> so it cannot interleave with another command's mouse input
 /// (the hazard #113 warns about when a caller hand-rolls <c>lbd</c>/<c>mt</c>/<c>lbu</c>). Gated by
-/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited. Disabled by default (security).
+/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
+/// <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
-public class DragCommand : Command {
+public class DragCommand : WindowTargetingAgentCommand {
     // NOTE: attribute names MUST be all-lowercase. SerializedCommands.Deserialize runs an XSLT that
     // lower-cases every element/attribute name before deserializing, so a camelCase name (e.g. "fromValue")
     // would never bind on load and the value would be silently lost.
-    [XmlAttribute("window")] public string Window { get; set; } = null!;
-    [XmlAttribute("handle")] public long Handle { get; set; }
-    [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
-    [XmlAttribute("foreground")] public bool Foreground { get; set; }
-
     [XmlAttribute("fromby")] public string FromBy { get; set; } = "name";
     [XmlAttribute("fromvalue")] public string FromValue { get; set; } = null!;
     [XmlAttribute("fromx")] public int FromX { get; set; }
@@ -49,11 +44,6 @@ public class DragCommand : Command {
     }
 
     public override ICommand Clone(Reply reply) => base.Clone(reply, new DragCommand {
-        Window = this.Window,
-        Handle = this.Handle,
-        Process = this.Process,
-        ClassName = this.ClassName,
-        Foreground = this.Foreground,
         FromBy = this.FromBy,
         FromValue = this.FromValue,
         FromX = this.FromX,
@@ -65,29 +55,14 @@ public class DragCommand : Command {
         PathSpec = this.PathSpec,
     });
 
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
+    protected override string? AuditDetails() =>
+        $"drag from (by={FromBy} value='{FromValue}' {FromX},{FromY}) to (by={ToBy} value='{ToValue}' {ToX},{ToY}) window handle={Handle} title='{Window}' process='{Process}'";
 
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
-        AgentRuntime.Audit(Cmd, $"drag from (by={FromBy} value='{FromValue}' {FromX},{FromY}) to (by={ToBy} value='{ToValue}' {ToX},{ToY}) window handle={Handle} title='{Window}' process='{Process}'");
+    // A window is only needed to resolve element endpoints; a pure coordinate drag needs none.
+    protected override bool RequiresWindowTarget => !string.IsNullOrEmpty(FromValue) || !string.IsNullOrEmpty(ToValue);
 
-        // A window is only needed to resolve element endpoints; a pure coordinate drag needs none.
-        bool needsWindow = !string.IsNullOrEmpty(FromValue) || !string.IsNullOrEmpty(ToValue);
-        IntPtr hwnd = IntPtr.Zero;
-        if (needsWindow) {
-            WindowInfo? win = WindowResolver.Resolve(Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
-            if (win is null) {
-                Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window").ToJson());
-                return false;
-            }
-            hwnd = new IntPtr(win.Handle);
-        }
+    protected override bool ExecuteCore(WindowInfo? target) {
+        IntPtr hwnd = target is null ? IntPtr.Zero : new IntPtr(target.Handle);
 
         if (!TryResolvePoint(hwnd, FromBy, FromValue, FromX, FromY, out (int X, int Y) from, out string? fromError)) {
             Reply?.WriteLine(CommandResult.Fail(Cmd, $"Drag start: {fromError}").ToJson());

--- a/src/Commands/FindCommand.cs
+++ b/src/Commands/FindCommand.cs
@@ -10,14 +10,10 @@ namespace MCEControl;
 /// Agent observation command handling both <c>find</c> (one-shot) and <c>wait-for</c> (polls until a
 /// timeout). Resolves a target window, then locates a single UIA element by name/automationid/
 /// classname. Always replies success with a <c>found</c> flag (a miss is not an error). Gated by
-/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited. Disabled by default (security).
+/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
+/// <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
-public class FindCommand : Command {
-    [XmlAttribute("window")] public string Window { get; set; } = null!;
-    [XmlAttribute("handle")] public long Handle { get; set; }
-    [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
-    [XmlAttribute("foreground")] public bool Foreground { get; set; }
+public class FindCommand : WindowTargetingAgentCommand {
     [XmlAttribute("by")] public string By { get; set; } = "name";
     [XmlAttribute("value")] public string Value { get; set; } = null!;
     [XmlAttribute("timeout")] public int Timeout { get; set; }
@@ -30,48 +26,28 @@ public class FindCommand : Command {
     }
 
     public override ICommand Clone(Reply reply) => base.Clone(reply, new FindCommand {
-        Window = this.Window,
-        Handle = this.Handle,
-        Process = this.Process,
-        ClassName = this.ClassName,
-        Foreground = this.Foreground,
         By = this.By,
         Value = this.Value,
         Timeout = this.Timeout,
     });
 
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
+    /// <summary>The effective poll timeout: <c>wait-for</c> defaults to 5000ms when none is given.</summary>
+    private int EffectiveTimeout =>
+        string.Equals(Cmd, "wait-for", StringComparison.OrdinalIgnoreCase) && Timeout <= 0 ? 5000 : Timeout;
 
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
+    protected override string? AuditDetails() =>
+        $"find by={By} value='{Value}' timeout={EffectiveTimeout} window handle={Handle} title='{Window}' process='{Process}'";
 
-        int timeout = Timeout;
-        if (string.Equals(Cmd, "wait-for", StringComparison.OrdinalIgnoreCase) && timeout <= 0) {
-            timeout = 5000;
-        }
-        AgentRuntime.Audit(Cmd, $"find by={By} value='{Value}' timeout={timeout} window handle={Handle} title='{Window}' process='{Process}'");
-
-        WindowInfo? win = WindowResolver.Resolve(Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
-        if (win is null) {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window").ToJson());
-            return false;
-        }
-
-        IntPtr h = new IntPtr(win.Handle);
-        UiaElementInfo? info = UiaService.Find(h, By, Value, timeout);
+    protected override bool ExecuteCore(WindowInfo? target) {
+        IntPtr h = new IntPtr(target!.Handle);
+        UiaElementInfo? info = UiaService.Find(h, By, Value, EffectiveTimeout);
         bool found = info is not null;
         JsonObject data = new() {
             ["found"] = found,
             ["element"] = info?.ToJsonObject(),
             // Echo the resolved window so the session can record it as the active target (a find/wait-for
             // that establishes the current control feeds error.lastObservation for a later failing action).
-            ["window"] = win.ToJsonObject(),
+            ["window"] = target.ToJsonObject(),
         };
         Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
         return true;

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -9,14 +9,10 @@ namespace MCEControl;
 /// <summary>
 /// Agent actuation command: resolves a target window, finds a single UIA element, then runs a UIA
 /// pattern action against it (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>/<c>select</c>). Gated by
-/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited. Disabled by default (security).
+/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
+/// <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
-public class InvokeCommand : Command {
-    [XmlAttribute("window")] public string Window { get; set; } = null!;
-    [XmlAttribute("handle")] public long Handle { get; set; }
-    [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
-    [XmlAttribute("foreground")] public bool Foreground { get; set; }
+public class InvokeCommand : WindowTargetingAgentCommand {
     [XmlAttribute("by")] public string By { get; set; } = "name";
     [XmlAttribute("value")] public string Value { get; set; } = null!;
     [XmlAttribute("action")] public string Action { get; set; } = "invoke";
@@ -27,36 +23,17 @@ public class InvokeCommand : Command {
     }
 
     public override ICommand Clone(Reply reply) => base.Clone(reply, new InvokeCommand {
-        Window = this.Window,
-        Handle = this.Handle,
-        Process = this.Process,
-        ClassName = this.ClassName,
-        Foreground = this.Foreground,
         By = this.By,
         Value = this.Value,
         Action = this.Action,
         Text = this.Text,
     });
 
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
+    protected override string? AuditDetails() =>
+        $"invoke action={Action} by={By} value='{Value}' window handle={Handle} title='{Window}' process='{Process}'";
 
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
-        AgentRuntime.Audit(Cmd, $"invoke action={Action} by={By} value='{Value}' window handle={Handle} title='{Window}' process='{Process}'");
-
-        WindowInfo? win = WindowResolver.Resolve(Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
-        if (win is null) {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window").ToJson());
-            return false;
-        }
-
-        IntPtr h = new IntPtr(win.Handle);
+    protected override bool ExecuteCore(WindowInfo? target) {
+        IntPtr h = new IntPtr(target!.Handle);
         bool ok = UiaService.Invoke(h, By, Value, Action, Text);
         if (ok) {
             JsonObject data = new() {

--- a/src/Commands/LaunchCommand.cs
+++ b/src/Commands/LaunchCommand.cs
@@ -15,9 +15,10 @@ namespace MCEControl;
 /// and returns structured info including the primary window handle when one appears.
 /// Replaces fragile Win+R + chars + enter composition for agents.
 ///
-/// SECURITY: gated behind <see cref="AgentRuntime.AgentCommandsEnabled"/> and per-command Enabled.
+/// SECURITY: gated behind <see cref="AgentRuntime.AgentCommandsEnabled"/> (enforced structurally by
+/// <see cref="AgentCommand"/>) and per-command Enabled.
 /// </summary>
-public class LaunchCommand : Command {
+public class LaunchCommand : AgentCommand {
     [XmlAttribute("path")] public string Path { get; set; } = null!;
     [XmlAttribute("arguments")] public string Arguments { get; set; } = null!;
     [XmlAttribute("workingdirectory")] public string WorkingDirectory { get; set; } = null!;
@@ -36,17 +37,8 @@ public class LaunchCommand : Command {
         Timeout = Timeout,
     });
 
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
-
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
-
+    // Audits after path validation (below), with the effective timeout — not via AuditDetails.
+    protected override bool ExecuteCore() {
         if (string.IsNullOrWhiteSpace(Path)) {
             Reply?.WriteLine(CommandResult.Fail(Cmd, "launch requires a non-empty 'path' (executable, shell: protocol, or .lnk).").ToJson());
             return false;

--- a/src/Commands/QueryCommand.cs
+++ b/src/Commands/QueryCommand.cs
@@ -9,14 +9,9 @@ namespace MCEControl;
 /// <summary>
 /// Agent observation command: resolves a target window and returns a depth-bounded UIA tree dump so a
 /// model can see the window's controls. Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and
-/// audited. Disabled by default (security).
+/// audited (structurally, via <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
-public class QueryCommand : Command {
-    [XmlAttribute("window")] public string Window { get; set; } = null!;
-    [XmlAttribute("handle")] public long Handle { get; set; }
-    [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
-    [XmlAttribute("foreground")] public bool Foreground { get; set; }
+public class QueryCommand : WindowTargetingAgentCommand {
     [XmlAttribute("maxdepth")] public int MaxDepth { get; set; } = 6;
 
     /// <summary>Upper bound on UIA nodes returned; keeps the result bounded for huge/virtualized trees.
@@ -28,37 +23,23 @@ public class QueryCommand : Command {
     }
 
     public override ICommand Clone(Reply reply) => base.Clone(reply, new QueryCommand {
-        Window = this.Window,
-        Handle = this.Handle,
-        Process = this.Process,
-        ClassName = this.ClassName,
-        Foreground = this.Foreground,
         MaxDepth = this.MaxDepth,
         MaxNodes = this.MaxNodes,
     });
 
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
+    protected override string? AuditDetails() =>
+        $"query window handle={Handle} title='{Window}' process='{Process}' class='{ClassName}' fg={Foreground} maxDepth={MaxDepth} maxNodes={MaxNodes}";
 
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
-        AgentRuntime.Audit(Cmd, $"query window handle={Handle} title='{Window}' process='{Process}' class='{ClassName}' fg={Foreground} maxDepth={MaxDepth} maxNodes={MaxNodes}");
+    protected override bool OnWindowNotFound() {
+        Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
+        return false;
+    }
 
-        WindowInfo? win = WindowResolver.Resolve(Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
-        if (win is null) {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
-            return false;
-        }
-
-        IntPtr h = new IntPtr(win.Handle);
+    protected override bool ExecuteCore(WindowInfo? target) {
+        IntPtr h = new IntPtr(target!.Handle);
         UiaTreeResult tree = UiaService.DumpTree(h, MaxDepth, MaxNodes);
         JsonObject data = new() {
-            ["window"] = win.ToJsonObject(),
+            ["window"] = target.ToJsonObject(),
             ["nodeCount"] = tree.NodeCount,
             ["truncated"] = tree.Truncated,
             ["tree"] = tree.Root?.ToJsonObject(),

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -18,20 +18,16 @@ namespace MCEControl;
 /// handle/title/process/class/foreground, or an explicit region) and the same security gate.
 ///
 /// SECURITY: gated behind <see cref="AgentRuntime.AgentCommandsEnabled"/> (a separate opt-in from
-/// actuation) and the per-command <c>Enabled</c> flag; every start/stop/write is audited via
-/// <see cref="AgentRuntime.Audit"/>. The capture loop is hard-bounded (fps/duration/frames/width) by
-/// the operator's <see cref="AppSettings"/> limits so an agent cannot create an unbounded file.
+/// actuation — enforced structurally by <see cref="AgentCommand"/>) and the per-command <c>Enabled</c>
+/// flag; every start/stop/write is audited via <see cref="AgentRuntime.Audit"/>. The capture loop is
+/// hard-bounded (fps/duration/frames/width) by the operator's <see cref="AppSettings"/> limits so an
+/// agent cannot create an unbounded file.
 ///
 /// PRIVACY: a recording captures whatever is on screen for its whole duration — louder than a single
 /// still <c>capture</c>. See <c>docs/agent-server.md</c>.
 /// </summary>
-public class RecordCommand : Command {
+public class RecordCommand : WindowTargetingAgentCommand {
     [XmlAttribute("action")] public string Action { get; set; } = null!;
-    [XmlAttribute("window")] public string Window { get; set; } = null!;
-    [XmlAttribute("handle")] public long Handle { get; set; }
-    [XmlAttribute("process")] public string Process { get; set; } = null!;
-    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
-    [XmlAttribute("foreground")] public bool Foreground { get; set; }
     [XmlAttribute("x")] public int X { get; set; }
     [XmlAttribute("y")] public int Y { get; set; }
     [XmlAttribute("width")] public int Width { get; set; }
@@ -56,11 +52,6 @@ public class RecordCommand : Command {
 
     public override ICommand Clone(Reply reply) => base.Clone(reply, new RecordCommand {
         Action = Action,
-        Window = Window,
-        Handle = Handle,
-        Process = Process,
-        ClassName = ClassName,
-        Foreground = Foreground,
         X = X,
         Y = Y,
         Width = Width,
@@ -71,18 +62,11 @@ public class RecordCommand : Command {
         File = File,
     });
 
-    // ICommand:Execute
-    public override bool Execute() {
-        if (!base.Execute()) {
-            return false;
-        }
+    // Window resolution happens per-target inside BuildGrabber (a virtual test seam that also owns
+    // the region-vs-window branch and its distinct error/audit shapes), not in the base template.
+    protected override bool RequiresWindowTarget => false;
 
-        if (!AgentRuntime.AgentCommandsEnabled) {
-            Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
-        }
-
+    protected override bool ExecuteCore(WindowInfo? target) {
         // Default the action: `oneshot` when a duration is given, else `start`.
         string action = string.IsNullOrWhiteSpace(Action)
             ? (DurationMs > 0 ? "oneshot" : "start")
@@ -105,13 +89,6 @@ public class RecordCommand : Command {
 
     /// <summary>True when the command targets an explicit screen region (no window selector given).</summary>
     private bool IsRegionTarget => Width > 0 && Height > 0 && !HasWindowTarget;
-
-    /// <summary>True when any window selector (title/handle/process/class/foreground) is given.</summary>
-    private bool HasWindowTarget => !string.IsNullOrEmpty(Window)
-        || Handle > 0
-        || !string.IsNullOrEmpty(Process)
-        || !string.IsNullOrEmpty(ClassName)
-        || Foreground;
 
     /// <summary>Starts a recording; for a one-shot, also waits the duration and stops/encodes/writes.</summary>
     private bool DoStart(bool oneshot) {
@@ -218,8 +195,7 @@ public class RecordCommand : Command {
             return () => ScreenCapture.CaptureRegionBitmap(rx, ry, rw, rh);
         }
 
-        WindowInfo? win = WindowResolver.Resolve(
-            Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
+        WindowInfo? win = ResolveTargetWindow();
         if (win is null) {
             target = null;
             error = "No matching window";

--- a/src/Commands/WindowTargetingAgentCommand.cs
+++ b/src/Commands/WindowTargetingAgentCommand.cs
@@ -1,0 +1,94 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Xml.Serialization;
+
+namespace MCEControl;
+
+/// <summary>
+/// An <see cref="AgentCommand"/> that targets a window with the shared selector set
+/// (<c>window</c> title substring / <c>handle</c> / <c>process</c> / <c>classname</c> /
+/// <c>foreground</c>). Hosts the five selector properties once (they were copy-pasted — and had
+/// drifted, #200 — across seven commands), performs the single
+/// <see cref="WindowResolver.Resolve(long?, string?, string?, string?, bool)"/> incantation, and
+/// hands <see cref="ExecuteCore(WindowInfo?)"/> the resolved window.
+///
+/// Not every command resolves unconditionally: <c>click</c>/<c>drag</c> only need a window for
+/// element endpoints, <c>capture</c> supports a window-less region grab, and <c>record</c> resolves
+/// inside its (test-overridable) grabber factory — those override <see cref="RequiresWindowTarget"/>
+/// and receive <c>null</c>. When resolution fails, <see cref="OnWindowNotFound"/> emits each
+/// command's historical failure envelope (they differ — result unification is #206).
+/// </summary>
+public abstract class WindowTargetingAgentCommand : AgentCommand {
+    // NOTE: attribute names MUST be all-lowercase. SerializedCommands.Deserialize runs an XSLT that
+    // lower-cases every element/attribute name before deserializing, so a camelCase name would never
+    // bind on load and the value would be silently lost. Enforced for every Command by
+    // XmlNameCasingTests (#200).
+    [XmlAttribute("window")] public string Window { get; set; } = null!;
+    [XmlAttribute("handle")] public long Handle { get; set; }
+    [XmlAttribute("process")] public string Process { get; set; } = null!;
+    [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
+    [XmlAttribute("foreground")] public bool Foreground { get; set; }
+
+    /// <summary>True when any window selector (title/handle/process/class/foreground) is given.</summary>
+    protected bool HasWindowTarget => !string.IsNullOrEmpty(Window)
+        || Handle > 0
+        || !string.IsNullOrEmpty(Process)
+        || !string.IsNullOrEmpty(ClassName)
+        || Foreground;
+
+    /// <summary>
+    /// Whether this invocation needs a resolved window before <see cref="ExecuteCore(WindowInfo?)"/>
+    /// runs. Defaults to true (query/find/invoke always target a window); commands with window-less
+    /// modes (pixel click/drag, region capture, record's grabber-owned resolution) override this.
+    /// </summary>
+    protected virtual bool RequiresWindowTarget => true;
+
+    /// <summary>Resolves the target window from the shared selectors. Null when nothing matches.</summary>
+    protected WindowInfo? ResolveTargetWindow() =>
+        WindowResolver.Resolve(Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
+
+    /// <summary>
+    /// Emits the command's window-not-found failure and returns false. The base emission is the
+    /// historical majority shape; commands that emit a coded envelope (or audit the miss) override.
+    /// </summary>
+    protected virtual bool OnWindowNotFound() {
+        Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window").ToJson());
+        return false;
+    }
+
+    /// <summary>Resolve-once template: resolve (when required), fail via <see cref="OnWindowNotFound"/>, dispatch.</summary>
+    protected sealed override bool ExecuteCore() {
+        if (!RequiresWindowTarget) {
+            return ExecuteCore(null);
+        }
+
+        WindowInfo? win = ResolveTargetWindow();
+        if (win is null) {
+            return OnWindowNotFound();
+        }
+
+        return ExecuteCore(win);
+    }
+
+    /// <summary>
+    /// The command body. <paramref name="target"/> is the resolved window, or <c>null</c> only when
+    /// <see cref="RequiresWindowTarget"/> returned false for this invocation.
+    /// </summary>
+    protected abstract bool ExecuteCore(WindowInfo? target);
+
+    /// <summary>
+    /// Copies the shared window-target selectors onto <paramref name="clone"/> so subclasses' Clone
+    /// implementations don't have to repeat them (nor can they forget them).
+    /// </summary>
+    public override Command Clone(Reply reply, Command clone) {
+        if (clone is WindowTargetingAgentCommand c) {
+            c.Window = Window;
+            c.Handle = Handle;
+            c.Process = Process;
+            c.ClassName = ClassName;
+            c.Foreground = Foreground;
+        }
+        return base.Clone(reply, clone);
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
+++ b/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
@@ -1,0 +1,106 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Structural enforcement for issue #208: the <see cref="AgentRuntime.AgentCommandsEnabled"/> gate
+/// lives in <see cref="AgentCommand"/>'s sealed <c>Execute()</c> template, because over the legacy
+/// TCP/serial pipeline the in-command check is the ONLY gate (the server-side check covers only the
+/// MCP/HTTP path). These tests make "someone adds an agent tool whose command skips the gate" a test
+/// failure instead of a silent security hole.
+/// </summary>
+public class AgentCommandStructuralGateTests {
+    /// <summary>
+    /// Every tool name in AgentServer's tools/call gate whitelist (the
+    /// <c>name is "capture" or "query" or ...</c> pattern the AgentCommandsEnabled check guards).
+    /// Kept as a test-side list because the whitelist is a C# pattern, not reflectable data; if a
+    /// name is added there without being added here, the reviewer checklist is this comment.
+    /// </summary>
+    private static readonly string[] GatedToolNames = [
+        "capture", "query", "displays", "find", "wait-for", "invoke", "record", "launch", "drag", "click",
+    ];
+
+    public static TheoryData<string> GatedToolNameData {
+        get {
+            TheoryData<string> data = [];
+            foreach (string name in GatedToolNames) {
+                data.Add(name);
+            }
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GatedToolNameData))]
+    public void EveryGatedToolName_MapsToAnAgentCommand(string name) {
+        // BuildCommand is AgentServer's own name -> command mapping (#201: exhaustive, null for
+        // unknown). Whatever command a gated tool name produces MUST derive from AgentCommand so the
+        // sealed Execute() gate applies on transports that have no server-side gate (TCP/serial).
+        Command? cmd = AgentServer.BuildCommand(name, []);
+
+        Assert.NotNull(cmd);
+        Assert.IsAssignableFrom<AgentCommand>(cmd);
+    }
+
+    [Fact]
+    public void AgentCommand_Execute_IsSealed_SoSubclassesCannotBypassTheGate() {
+        MethodInfo execute = typeof(AgentCommand).GetMethod(nameof(Command.Execute))!;
+
+        // Declared on AgentCommand (the template) and final — a subclass cannot re-open it and skip
+        // the AgentCommandsEnabled check.
+        Assert.Equal(typeof(AgentCommand), execute.DeclaringType);
+        Assert.True(execute.IsFinal, "AgentCommand.Execute() must stay sealed: it is the structural AgentCommandsEnabled gate.");
+    }
+
+    [Fact]
+    public void EveryConcreteAgentCommandType_IsCoveredByTheGatedToolList() {
+        // The inverse guard: a NEW AgentCommand subclass must be represented in the gated tool list
+        // (i.e. producible by BuildCommand under some gated name), otherwise the enforcement above
+        // can't see it. FindCommand covers both "find" and "wait-for".
+        HashSet<Type> mappedTypes = [];
+        foreach (string name in GatedToolNames) {
+            Command? cmd = AgentServer.BuildCommand(name, []);
+            if (cmd is not null) {
+                mappedTypes.Add(cmd.GetType());
+            }
+        }
+
+        foreach (Type type in typeof(Command).Assembly.GetTypes()) {
+            if (type.IsClass && !type.IsAbstract && typeof(AgentCommand).IsAssignableFrom(type)) {
+                Assert.True(mappedTypes.Contains(type),
+                    $"{type.Name} derives from AgentCommand but no gated tool name maps to it — " +
+                    "add its tool name to AgentServer's gate whitelist, BuildCommand, and GatedToolNames here.");
+            }
+        }
+    }
+
+    [Fact]
+    public void WindowTargetingClone_CopiesTheSharedSelectors() {
+        // The five window selectors moved to WindowTargetingAgentCommand (#208); its Clone layer —
+        // not each subclass — copies them. Pin that so a future clone refactor can't drop them.
+        QueryCommand original = new() {
+            Cmd = "query",
+            Window = "Notepad",
+            Handle = 0x1234,
+            Process = "notepad",
+            ClassName = "Notepad",
+            Foreground = true,
+        };
+
+        QueryCommand clone = (QueryCommand)original.Clone(null!);
+
+        Assert.Equal("Notepad", clone.Window);
+        Assert.Equal(0x1234L, clone.Handle);
+        Assert.Equal("notepad", clone.Process);
+        Assert.Equal("Notepad", clone.ClassName);
+        Assert.True(clone.Foreground);
+    }
+}


### PR DESCRIPTION
Fixes #208

## What

The identical `AgentRuntime.AgentCommandsEnabled` gate block was copy-pasted into nine agent command `Execute()` bodies. The server-side check covers only the MCP/HTTP path — over legacy TCP/serial the in-command check is the **only** gate, so a future agent command whose author forgot the paste would be fully exposed over TCP the moment its per-command `Enabled` flag flipped. This PR makes the gate structural: forgetting it is now impossible by construction, and a reflection test catches any future agent tool that dodges it.

## Design

```
Command
└── AgentCommand                       (sealed Execute(): Enabled/telemetry → AgentCommandsEnabled
    │                                   gate → AGENT-AUDIT (AuditDetails() hook) → ExecuteCore())
    │   ├── DisplaysCommand
    │   └── LaunchCommand              (audits after path validation, inside ExecuteCore)
    └── WindowTargetingAgentCommand    (hosts window/handle/process/classname/foreground once;
        │                               sealed ExecuteCore(): Resolve once → OnWindowNotFound()
        │                               → ExecuteCore(WindowInfo? target); Clone layer copies
        │                               the five selectors)
        ├── QueryCommand   ├── FindCommand (find + wait-for)   ├── InvokeCommand
        ├── ClickCommand   ├── DragCommand                     (override RequiresWindowTarget:
        ├── CaptureCommand (region mode skips resolution)       element-endpoints-only)
        └── RecordCommand  (RequiresWindowTarget=false: resolution stays in the
                            BuildGrabber test seam, which owns region-vs-window branching)
```

- **`AgentCommand.Execute()` is `sealed`** — a subclass implements `ExecuteCore()` and can only run after the gate passed. The gate emits the exact same Warn log and structured `CommandResult.Fail` reply as before.
- **`AuditDetails()` hook**: commands with a uniform up-front audit (query/find/invoke/click/drag/displays) return their audit string; capture/record/launch return null and keep their branch-specific audits in `ExecuteCore` — audit content and ordering are byte-identical.
- **`OnWindowNotFound()` hook** preserves each command's historical window-not-found envelope exactly (query/click/capture emit `window-not-found`/`no-target` codes, find/invoke/drag emit the plain shape, capture also audits the miss). Envelope unification is #206, deliberately not done here.
- **Clone correctness**: `WindowTargetingAgentCommand.Clone(Reply, Command)` copies the five moved selectors, so subclasses can't drop them (a new test pins this). The `MemberwiseClone` rewrite is #207, not done here.
- **XML serialization**: the moved properties keep their exact lowercase `[XmlAttribute]` names (#200); `XmlNameCasingTests` and the existing round-trip tests (which cover inherited props like `QueryCommand.Window`/`ClassName` and `RecordCommand.ClassName`) pass unchanged.

## Enforcement test

`AgentCommandStructuralGateTests`:
- every name in the tools/call gate whitelist, run through `AgentServer.BuildCommand`, produces an `AgentCommand`;
- `AgentCommand.Execute()` stays sealed (reflection pin);
- inverse guard: every concrete `AgentCommand` subclass is reachable from the gated tool list;
- the shared-selector Clone layer copies all five selectors.

## Scope guards honored

- `src/Services/AgentServer.cs`, `src/Commands/CommandInvoker.cs`, `src/MainWindow.cs` untouched (in-flight #195 owns them) — the test only *calls* `AgentServer.BuildCommand`.
- No emitted error strings/codes changed (#206). No `MemberwiseClone` rewrite (#207).

## Testing

- `dotnet build`: green (TreatWarningsAsErrors + house analyzers; only the pre-existing tracked WFDEV004 advisory).
- `dotnet test`: **637 passed, 0 failed** (22 desktop-touching tests skipped as always). All pre-existing per-command tests pass **unchanged**.

Net: −26 lines in the nine commands plus two new base classes; 10 files of boilerplate collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm