### PR TITLE
Arch: MemberwiseClone-based Command.Clone replaces hand-copied field lists

### DIFF
--- a/docs/agent-server-architecture.md
+++ b/docs/agent-server-architecture.md
@@ -76,8 +76,11 @@ Each agent command (`capture`, `query`, `find`/`wait-for`, `invoke`, `click`, `d
 `record`, `displays`, `launch`) derives from `AgentCommand : Command` (#208) and follows
 the house pattern:
 
-- `Clone(Reply)` via `base.Clone(reply, new XxxCommand { ... })` (base layers copy the
-  shared properties they host).
+- No per-command `Clone` code (#207): the MemberwiseClone-based `Command.Clone(Reply)`
+  copies every field by construction (all serializable command state is value/string-typed),
+  installs the fresh `Reply`, and deep-clones `EmbeddedCommands`. A reflection hygiene test
+  (`CommandClonePropertyRoundTripTests`) round-trips every public settable property of every
+  command through Clone.
 - `BuiltInCommands` returning the command with `Enabled=false` by default.
 - `[XmlAttribute]` on serializable props (all-lowercase names — see `XmlNameCasingTests`, #200).
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -156,7 +156,7 @@ All services inherit from `ServiceBase` which provides:
 ```csharp
 public interface ICommand {
     bool Execute();
-    Command Clone(Reply reply, Command clone);
+    ICommand Clone(Reply reply);
 }
 ```
 
@@ -167,6 +167,10 @@ public interface ICommand {
 - Support for nested/embedded commands
 - Telemetry tracking
 - Reply context for bidirectional communication
+- `Clone(Reply)` is MemberwiseClone-based (#207): every field — all serializable state is
+  value/string-typed — is copied by construction, then the fresh `Reply` is set and
+  `EmbeddedCommands` deep-cloned. Subclasses do not (and must not need to) override it to copy
+  fields; a reflection hygiene test round-trips every public settable property of every command.
 
 #### 3.3 Command Types
 

--- a/src/Commands/CaptureCommand.cs
+++ b/src/Commands/CaptureCommand.cs
@@ -40,14 +40,6 @@ public class CaptureCommand : WindowTargetingAgentCommand {
 
     public CaptureCommand() { }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new CaptureCommand {
-        X = X,
-        Y = Y,
-        Width = Width,
-        Height = Height,
-        File = File,
-    });
-
     /// <summary>True when this is an explicit-region capture (region given, no window selector).</summary>
     private bool IsRegionCapture => Width > 0 && Height > 0 && !HasWindowTarget;
 

--- a/src/Commands/CharsCommand.cs
+++ b/src/Commands/CharsCommand.cs
@@ -27,8 +27,6 @@ public class CharsCommand : Command {
 
     public CharsCommand() { }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new CharsCommand());
-
     // ICommand:Execute
     public override bool Execute() {
         if (!base.Execute()) {

--- a/src/Commands/ClickCommand.cs
+++ b/src/Commands/ClickCommand.cs
@@ -38,15 +38,6 @@ public class ClickCommand : WindowTargetingAgentCommand {
         get => [new ClickCommand { Cmd = "click" }];
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new ClickCommand {
-        By = this.By,
-        Value = this.Value,
-        X = this.X,
-        Y = this.Y,
-        Button = this.Button,
-        Count = this.Count,
-    });
-
     protected override string? AuditDetails() =>
         $"click at (by={By} value='{Value}' {X},{Y}) button={Button} count={Count} window handle={Handle} title='{Window}' process='{Process}'";
 

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -80,33 +80,31 @@ public abstract class Command : ICommand {
     /// </summary>
     internal virtual bool SynthesizesInput => true;
 
-    public abstract ICommand Clone(Reply reply);
-
-    public virtual Command Clone(Reply reply, Command clone) {
-        if (clone is null) {
-            throw new ArgumentNullException(nameof(clone));
-        }
-
+    /// <summary>
+    /// Clones this command (a table prototype) for execution with a fresh <paramref name="reply"/>
+    /// context. Built on <see cref="object.MemberwiseClone"/> so EVERY field — including all
+    /// serializable subclass state, which is value/string-typed throughout — is copied by
+    /// construction; a subclass cannot forget a property (#207, the old hand-copied field lists).
+    /// The only reference-typed mutable members are then handled explicitly: <see cref="Reply"/> is
+    /// replaced with the fresh context, and <see cref="EmbeddedCommands"/> is deep-cloned (each
+    /// child cloned recursively, so children keep their own Enabled — the #183 bug is impossible
+    /// here by construction). Virtual only for a subclass that gains genuinely non-mechanical clone
+    /// semantics (e.g. deep-copying a future reference-typed member); field copying never needs an
+    /// override.
+    /// </summary>
+    public virtual Command Clone(Reply reply) {
+        Command clone = (Command)MemberwiseClone();
         clone.Reply = reply;
-
-        clone.Cmd = this.Cmd;
-        clone.Args = this.Args;
         if (this.EmbeddedCommands != null) {
             clone.EmbeddedCommands = [];
             foreach (Command next in this.EmbeddedCommands) {
-                Command eClone = (Command)next.Clone(reply);
-                clone.Enabled = Enabled;
-                clone.EmbeddedCommands.Add(eClone);
+                clone.EmbeddedCommands.Add(next.Clone(reply));
             }
         }
-
-        //TELEMETRY: Prevent info regarding user defined commands from being collected.
-        clone.UserDefined = this.UserDefined;
-
-        clone.Enabled = this.Enabled;
-
         return clone;
     }
+
+    ICommand ICommand.Clone(Reply reply) => Clone(reply);
 
     /// <summary>
     /// Execute command. Derived classes must call base before processing in order to ensure

--- a/src/Commands/CommandDispatchCompletion.cs
+++ b/src/Commands/CommandDispatchCompletion.cs
@@ -43,6 +43,6 @@ internal sealed class CommandDispatchCompletion : ICommand {
     }
 
     /// <summary>Never called — markers are created fresh per enqueue and never live in the command table.</summary>
-    Command ICommand.Clone(Reply reply, Command clone) =>
+    ICommand ICommand.Clone(Reply reply) =>
         throw new NotSupportedException($"{nameof(CommandDispatchCompletion)} is dispatcher bookkeeping and cannot be cloned.");
 }

--- a/src/Commands/CommandInvoker.cs
+++ b/src/Commands/CommandInvoker.cs
@@ -242,7 +242,7 @@ public class CommandInvoker : Hashtable {
         // See if we know about this Command - case insensitive
         if (this[cmd.ToLowerInvariant()] != null) {
             // Always create a clone for enqueing (so Reply context can be independent)
-            Command clone = (Command)((Command)this[cmd.ToLowerInvariant()]!).Clone(reply);
+            Command clone = ((Command)this[cmd.ToLowerInvariant()]!).Clone(reply);
 
             // This supports commands of the form 'chars:args'; these
             // commands do not need to originate in CommandTable

--- a/src/Commands/DisplaysCommand.cs
+++ b/src/Commands/DisplaysCommand.cs
@@ -24,8 +24,6 @@ public class DisplaysCommand : AgentCommand {
         get => [new DisplaysCommand { Cmd = "displays" }];
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new DisplaysCommand());
-
     protected override string? AuditDetails() => "displays";
 
     protected override bool ExecuteCore() {

--- a/src/Commands/DragCommand.cs
+++ b/src/Commands/DragCommand.cs
@@ -43,18 +43,6 @@ public class DragCommand : WindowTargetingAgentCommand {
         get => [new DragCommand { Cmd = "drag" }];
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new DragCommand {
-        FromBy = this.FromBy,
-        FromValue = this.FromValue,
-        FromX = this.FromX,
-        FromY = this.FromY,
-        ToBy = this.ToBy,
-        ToValue = this.ToValue,
-        ToX = this.ToX,
-        ToY = this.ToY,
-        PathSpec = this.PathSpec,
-    });
-
     protected override string? AuditDetails() =>
         $"drag from (by={FromBy} value='{FromValue}' {FromX},{FromY}) to (by={ToBy} value='{ToValue}' {ToX},{ToY}) window handle={Handle} title='{Window}' process='{Process}'";
 

--- a/src/Commands/FindCommand.cs
+++ b/src/Commands/FindCommand.cs
@@ -25,12 +25,6 @@ public class FindCommand : WindowTargetingAgentCommand {
         ];
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new FindCommand {
-        By = this.By,
-        Value = this.Value,
-        Timeout = this.Timeout,
-    });
-
     /// <summary>The effective poll timeout: <c>wait-for</c> defaults to 5000ms when none is given.</summary>
     private int EffectiveTimeout =>
         string.Equals(Cmd, "wait-for", StringComparison.OrdinalIgnoreCase) && Timeout <= 0 ? 5000 : Timeout;

--- a/src/Commands/ICommand.cs
+++ b/src/Commands/ICommand.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Xml;
-using System.Xml.Serialization;
-
 namespace MCEControl;
 // Implements Command Pattern
 public interface ICommand {
@@ -13,5 +6,8 @@ public interface ICommand {
     /// </summary>
     bool Execute();
 
-    Command Clone(Reply reply, Command clone);
+    /// <summary>
+    /// Clones the command (a table prototype) for execution with a fresh reply context.
+    /// </summary>
+    ICommand Clone(Reply reply);
 }

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -22,13 +22,6 @@ public class InvokeCommand : WindowTargetingAgentCommand {
         get => [new InvokeCommand { Cmd = "invoke" }];
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new InvokeCommand {
-        By = this.By,
-        Value = this.Value,
-        Action = this.Action,
-        Text = this.Text,
-    });
-
     protected override string? AuditDetails() =>
         $"invoke action={Action} by={By} value='{Value}' window handle={Handle} title='{Window}' process='{Process}'";
 

--- a/src/Commands/LaunchCommand.cs
+++ b/src/Commands/LaunchCommand.cs
@@ -30,13 +30,6 @@ public class LaunchCommand : AgentCommand {
 
     public LaunchCommand() { }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new LaunchCommand {
-        Path = Path,
-        Arguments = Arguments,
-        WorkingDirectory = WorkingDirectory,
-        Timeout = Timeout,
-    });
-
     // Audits after path validation (below), with the effective timeout — not via AuditDetails.
     protected override bool ExecuteCore() {
         if (string.IsNullOrWhiteSpace(Path)) {

--- a/src/Commands/McecCommand.cs
+++ b/src/Commands/McecCommand.cs
@@ -43,8 +43,6 @@ public class McecCommand : Command {
         return $"Cmd=\"{Cmd}\"";
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new McecCommand());
-
     // ICommand:Execute
     public override bool Execute() {
         if (!base.Execute()) {

--- a/src/Commands/MouseCommand.cs
+++ b/src/Commands/MouseCommand.cs
@@ -68,8 +68,6 @@ public class MouseCommand : Command {
         return $"Cmd=\"{Cmd}\"";
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new MouseCommand());
-
     // ICommand:Execute
     public override bool Execute() {
         if (!base.Execute()) {

--- a/src/Commands/PauseCommand.cs
+++ b/src/Commands/PauseCommand.cs
@@ -38,8 +38,6 @@ public class PauseCommand : Command {
         return $"Cmd=\"{Cmd}\" Args=\"{Args}\"";
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new PauseCommand());
-
     // ICommand:Execute
     public override bool Execute() {
         if (!base.Execute()) {

--- a/src/Commands/QueryCommand.cs
+++ b/src/Commands/QueryCommand.cs
@@ -22,11 +22,6 @@ public class QueryCommand : WindowTargetingAgentCommand {
         get => [new QueryCommand { Cmd = "query" }];
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new QueryCommand {
-        MaxDepth = this.MaxDepth,
-        MaxNodes = this.MaxNodes,
-    });
-
     protected override string? AuditDetails() =>
         $"query window handle={Handle} title='{Window}' process='{Process}' class='{ClassName}' fg={Foreground} maxDepth={MaxDepth} maxNodes={MaxNodes}";
 

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -50,18 +50,6 @@ public class RecordCommand : WindowTargetingAgentCommand {
 
     public RecordCommand() { }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new RecordCommand {
-        Action = Action,
-        X = X,
-        Y = Y,
-        Width = Width,
-        Height = Height,
-        Fps = Fps,
-        DurationMs = DurationMs,
-        MaxWidth = MaxWidth,
-        File = File,
-    });
-
     // Window resolution happens per-target inside BuildGrabber (a virtual test seam that also owns
     // the region-vs-window branch and its distinct error/audit shapes), not in the base template.
     protected override bool RequiresWindowTarget => false;

--- a/src/Commands/SendInputCommand.cs
+++ b/src/Commands/SendInputCommand.cs
@@ -23,7 +23,7 @@ namespace MCEControl;
 /// modifiers.
 /// </summary>
 [Serializable]
-public class SendInputCommand : Command, ICommand {
+public class SendInputCommand : Command {
     private bool alt;
     private bool ctrl;
     private bool shift;
@@ -138,8 +138,6 @@ public class SendInputCommand : Command, ICommand {
     public override string ToString() {
         return $"Cmd=\"{Cmd}\" Args=\"{Args}\" Vk=\"{Vk}\" Shift=\"{Shift}\" Ctrl=\"{Ctrl}\" Alt=\"{Alt}\" Win=\"{Win}\"";
     }
-
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new SendInputCommand(vk, shift, ctrl, alt, win));
 
     private bool ExecuteShiftCmd(string cmd) {
         // TODO: Break this out to a separate command

--- a/src/Commands/SendMessageCommand.cs
+++ b/src/Commands/SendMessageCommand.cs
@@ -60,8 +60,6 @@ public class SendMessageCommand : Command {
         return $"Cmd=\"{Cmd}\" Msg=\"{Msg}\" lParam=\"{LParam}\" wParam=\"{WParam}\" ClassName=\"{ClassName}\" WindowName=\"{WindowName}\"";
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new SendMessageCommand(ClassName, WindowName, Msg, WParam, LParam));
-
     // ICommand:Execute
     public override bool Execute() {
         if (!base.Execute()) {

--- a/src/Commands/SetForegroundWindowCmd.cs
+++ b/src/Commands/SetForegroundWindowCmd.cs
@@ -42,8 +42,6 @@ public class SetForegroundWindowCommand : Command {
         return $"Cmd=\"{Cmd}\" AppName=\"{AppName}\"";
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new SetForegroundWindowCommand(ClassName, AppName));
-
     // ICommand:Execute
     public override bool Execute() {
         if (!base.Execute()) {

--- a/src/Commands/ShutdownCommand.cs
+++ b/src/Commands/ShutdownCommand.cs
@@ -49,8 +49,6 @@ public class ShutdownCommand : Command {
         return $"Cmd=\"{Cmd}\" Type=\"{Type}\" TimeOut=\"{TimeOut}\"";
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new ShutdownCommand(Type, TimeOut));
-
     // ICommand:Execute
     public override bool Execute() {
         if (!base.Execute()) {

--- a/src/Commands/StartProcessCommand.cs
+++ b/src/Commands/StartProcessCommand.cs
@@ -93,12 +93,6 @@ public class StartProcessCommand : Command {
         return $"Cmd=\"{Cmd}\" File=\"{File}\" Arguments=\"{Arguments}\" Verb=\"{Verb}\"";
     }
 
-    public override ICommand Clone(Reply reply) => base.Clone(reply, new StartProcessCommand() {
-        File = this.File,
-        Arguments = this.Arguments,
-        Verb = this.Verb
-    });
-
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Process is long lived")]
     // ICommand:Execute
     public override bool Execute() {

--- a/src/Commands/WindowTargetingAgentCommand.cs
+++ b/src/Commands/WindowTargetingAgentCommand.cs
@@ -77,18 +77,6 @@ public abstract class WindowTargetingAgentCommand : AgentCommand {
     /// </summary>
     protected abstract bool ExecuteCore(WindowInfo? target);
 
-    /// <summary>
-    /// Copies the shared window-target selectors onto <paramref name="clone"/> so subclasses' Clone
-    /// implementations don't have to repeat them (nor can they forget them).
-    /// </summary>
-    public override Command Clone(Reply reply, Command clone) {
-        if (clone is WindowTargetingAgentCommand c) {
-            c.Window = Window;
-            c.Handle = Handle;
-            c.Process = Process;
-            c.ClassName = ClassName;
-            c.Foreground = Foreground;
-        }
-        return base.Clone(reply, clone);
-    }
+    // No Clone override: the shared selectors are value/string-typed, so the base
+    // MemberwiseClone-based Command.Clone (#207) copies them by construction.
 }

--- a/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
+++ b/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
@@ -84,8 +84,9 @@ public class AgentCommandStructuralGateTests {
 
     [Fact]
     public void WindowTargetingClone_CopiesTheSharedSelectors() {
-        // The five window selectors moved to WindowTargetingAgentCommand (#208); its Clone layer —
-        // not each subclass — copies them. Pin that so a future clone refactor can't drop them.
+        // The five window selectors moved to WindowTargetingAgentCommand (#208); since #207 the
+        // MemberwiseClone-based Command.Clone copies them (no per-layer copying anywhere). Pin that
+        // they survive Clone so a future clone refactor can't drop them.
         QueryCommand original = new() {
             Cmd = "query",
             Window = "Notepad",

--- a/tests/MCEControl.xUnit/Commands/CommandClonePropertyRoundTripTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CommandClonePropertyRoundTripTests.cs
@@ -1,0 +1,114 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Clone-drift hygiene (#207): for EVERY concrete <see cref="Command"/> subclass, Clone(reply) must
+/// round-trip EVERY public settable property. Under the old hand-copied field lists, one forgotten
+/// line meant a property that worked from mcec.commands prototypes but arrived 0/null at execution,
+/// silently. The base Clone is now MemberwiseClone-based so this can't happen — this test pins that
+/// guarantee against any future re-introduction of per-property copying (a new command, a new
+/// property, or a subclass override that forgets base state all fail here immediately).
+/// </summary>
+public class CommandClonePropertyRoundTripTests {
+    // Properties Clone deliberately does NOT round-trip:
+    // - Reply: Clone's contract is to REPLACE it with the fresh per-connection reply context (the
+    //   whole reason Enqueue clones). Asserted separately below.
+    // - EmbeddedCommands: reference-typed; Clone deep-clones it rather than copying the reference.
+    //   Covered by CommandTests.Clone_WithEmbeddedCommands_ClonesEmbedded / _AreDeepCopies /
+    //   _KeepTheirOwnEnabled (#183).
+    private static readonly HashSet<string> SkippedProperties = [
+        nameof(Command.Reply),
+        nameof(Command.EmbeddedCommands),
+    ];
+
+    public static TheoryData<Type> ConcreteCommandTypes {
+        get {
+            TheoryData<Type> data = [];
+            foreach (Type type in typeof(Command).Assembly.GetTypes()
+                         .Where(t => t.IsClass && !t.IsAbstract && t.IsSubclassOf(typeof(Command)))
+                         .OrderBy(t => t.FullName, StringComparer.Ordinal)) {
+                data.Add(type);
+            }
+            return data;
+        }
+    }
+
+    [Fact]
+    public void Sweep_FindsTheCommandTypes() {
+        // Guard the reflection sweep itself: if it ever comes back (near-)empty, every theory case
+        // below would vacuously "pass" by not existing.
+        List<Type> types = [.. ConcreteCommandTypes.Cast<object[]>().Select(row => (Type)row[0])];
+        Assert.True(types.Count >= 18, $"expected the sweep to find all command types, got {types.Count}");
+        Assert.Contains(typeof(RecordCommand), types);
+        Assert.Contains(typeof(SendInputCommand), types);
+    }
+
+    [Theory]
+    [MemberData(nameof(ConcreteCommandTypes))]
+    public void Clone_RoundTripsEveryPublicSettableProperty(Type commandType) {
+        Command original = (Command)Activator.CreateInstance(commandType)!;
+
+        List<PropertyInfo> properties = [.. commandType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanWrite && p.SetMethod is { IsPublic: true } && !SkippedProperties.Contains(p.Name))];
+        Assert.NotEmpty(properties); // every Command at least has Cmd/Args/Enabled/UserDefined
+
+        // Drive every property to a non-default probe value. Comparing original-vs-clone (rather
+        // than probe-vs-clone) keeps aliased properties honest (e.g. SetForegroundWindowCommand's
+        // ClassName is an alias for AppName).
+        int salt = 0;
+        foreach (PropertyInfo p in properties) {
+            p.SetValue(original, MakeProbeValue(p, original, salt++));
+        }
+
+        TestReply reply = new();
+        Command clone = original.Clone(reply);
+
+        Assert.NotSame(original, clone);
+        Assert.IsType(commandType, clone);
+        Assert.Same(reply, clone.Reply); // Clone must install the fresh reply context
+
+        foreach (PropertyInfo p in properties) {
+            object? expected = p.GetValue(original);
+            object? actual = p.GetValue(clone);
+            Assert.True(Equals(expected, actual),
+                $"{commandType.Name}.{p.Name} did not survive Clone: expected '{expected}', clone has '{actual}'. " +
+                "Clone must copy every public settable property (#207).");
+        }
+    }
+
+    /// <summary>
+    /// A deterministic, guaranteed non-default probe for the property. Fails loudly on a property
+    /// type it does not know so a future reference-typed/mutable property must be added here — and
+    /// its deep-copy semantics considered in Command.Clone — consciously.
+    /// </summary>
+    private static object MakeProbeValue(PropertyInfo p, Command instance, int salt) {
+        object? current = p.GetValue(instance);
+        if (p.PropertyType == typeof(string)) {
+            return $"probe-{p.Name}-{salt}";
+        }
+        if (p.PropertyType == typeof(bool)) {
+            return !(bool)current!; // invert so a non-false default still changes
+        }
+        if (p.PropertyType == typeof(int)) {
+            return (int)current! + 7001 + salt; // offset clears defaults like Count=1, MaxNodes=1000
+        }
+        if (p.PropertyType == typeof(long)) {
+            return (long)current! + 700001L + salt;
+        }
+        Assert.Fail(
+            $"{p.DeclaringType!.Name}.{p.Name} has unhandled type {p.PropertyType.Name}. " +
+            "Add a probe here AND verify Command.Clone handles it (value/string types are copied by " +
+            "MemberwiseClone; a reference-typed mutable property needs explicit deep-copy in Clone).");
+        return null!; // unreachable
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/CommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CommandTests.cs
@@ -52,7 +52,7 @@ public class CommandTests
             UserDefined = true
         };
 
-        var clone = (TestCommand)original.Clone(null);
+        var clone = (TestCommand)original.Clone(null!);
 
         Assert.Equal(original.Cmd, clone.Cmd);
         Assert.Equal(original.Args, clone.Args);
@@ -84,12 +84,56 @@ public class CommandTests
             ]
         };
 
-        var clone = (TestCommand)original.Clone(null);
+        var clone = (TestCommand)original.Clone(null!);
 
         Assert.NotNull(clone.EmbeddedCommands);
         Assert.Equal(2, clone.EmbeddedCommands.Count);
         Assert.Equal("pause", clone.EmbeddedCommands[0].Cmd);
         Assert.Equal("child", clone.EmbeddedCommands[1].Cmd);
+    }
+
+    [Fact]
+    public void Clone_EmbeddedChildren_KeepTheirOwnEnabled()
+    {
+        // #183: the old base Clone assigned clone.Enabled (the parent) inside the embedded-clone
+        // loop where it meant the child's. Pin that each embedded clone carries its OWN source
+        // child's Enabled — with children on BOTH sides of the parent's value — and that the
+        // parent's Enabled survives the loop.
+        var original = new TestCommand
+        {
+            Cmd = "parent",
+            Enabled = false,
+            EmbeddedCommands =
+            [
+                new PauseCommand { Cmd = "on", Enabled = true },
+                new PauseCommand { Cmd = "off", Enabled = false }
+            ]
+        };
+
+        var clone = (TestCommand)original.Clone(null!);
+
+        Assert.False(clone.Enabled);
+        Assert.True(clone.EmbeddedCommands[0].Enabled);
+        Assert.False(clone.EmbeddedCommands[1].Enabled);
+    }
+
+    [Fact]
+    public void Clone_EmbeddedCommands_AreDeepCopies()
+    {
+        // MemberwiseClone alone would share the EmbeddedCommands list/children; the base Clone
+        // must deep-clone them so mutating a clone's child never leaks into the prototype.
+        var original = new TestCommand
+        {
+            Cmd = "parent",
+            EmbeddedCommands = [new PauseCommand { Cmd = "child", Args = "100", Enabled = true }]
+        };
+
+        var clone = (TestCommand)original.Clone(null!);
+
+        Assert.NotSame(original.EmbeddedCommands, clone.EmbeddedCommands);
+        Assert.NotSame(original.EmbeddedCommands[0], clone.EmbeddedCommands[0]);
+        clone.EmbeddedCommands[0].Args = "changed";
+        Assert.Equal("100", original.EmbeddedCommands[0].Args);
     }
 
     [Fact]

--- a/tests/MCEControl.xUnit/Commands/DelegateTestCommand.cs
+++ b/tests/MCEControl.xUnit/Commands/DelegateTestCommand.cs
@@ -38,8 +38,8 @@ internal sealed class DelegateTestCommand : Command {
         Enabled = true; // enable for testing
     }
 
-    public override ICommand Clone(Reply reply) =>
-        base.Clone(reply, new DelegateTestCommand { OnExecute = OnExecute, SynthesizesInputForTest = SynthesizesInputForTest });
+    // No Clone override needed: the MemberwiseClone-based Command.Clone (#207) copies OnExecute and
+    // SynthesizesInputForTest — clones share the delegate reference, exactly as before.
 
     public override bool Execute() {
         // Don't call base.Execute() to avoid the TelemetryService dependency.

--- a/tests/MCEControl.xUnit/Commands/TestCommand.cs
+++ b/tests/MCEControl.xUnit/Commands/TestCommand.cs
@@ -14,10 +14,7 @@ internal class TestCommand : Command
         Enabled = true; // Enable for testing
     }
 
-    public override ICommand Clone(Reply? reply)
-    {
-        return base.Clone(reply!, new TestCommand());
-    }
+    // No Clone override needed: the MemberwiseClone-based Command.Clone (#207) copies all state.
 
     public override bool Execute()
     {


### PR DESCRIPTION
Fixes #207
Fixes #183

## What

`Command.Clone(Reply)` is now a single MemberwiseClone-based base implementation: shallow memberwise copy of every field, then install the fresh `Reply`, then deep-clone `EmbeddedCommands`. All 18 per-subclass Clone overrides (pure hand-copied field lists — RecordCommand's 14 lines, DragCommand's 14, ClickCommand's 11, ...) and `WindowTargetingAgentCommand`'s selector-copying layer are deleted. A forgotten copy line can no longer make a property work from `mcec.commands` prototypes but arrive `0`/`null` at execution.

## Why this is correct by construction

- Every serializable property on every Command subclass is value- or string-typed (verified by scanning all 19 command classes, including private backing fields like `SendInputCommand.vk/shift/ctrl/alt/win` and `ShutdownCommand.type/timeOut`). MemberwiseClone copies them all.
- The only reference-typed mutable members are `Reply` (deliberately replaced with the fresh context, preserving the old reset) and `EmbeddedCommands` (deep-cloned). Test-only `DelegateTestCommand.OnExecute` intentionally shares its delegate, exactly as its old override did.
- #183 (`clone.Enabled` assigned inside the embedded-clone loop where `eClone.Enabled` was meant) is fixed by construction — the loop has no per-child Enabled bookkeeping left. New tests pin that embedded clones keep their **own** Enabled with children on both sides of the parent's value, and that embedded clones are deep copies.

## Interface fix

`ICommand` now declares the polymorphic contract the invoker actually needs — `bool Execute(); ICommand Clone(Reply)` — instead of the internal two-arg helper (deleted). `Command` satisfies it via an explicit interface implementation over a covariant `public Command Clone(Reply)`, so `CommandInvoker.Enqueue` drops its `(Command)` result cast (only the Clone-cast site touched; #195's dispatcher is unchanged). `CommandDispatchCompletion` keeps implementing `ICommand` directly; its never-called Clone stub just matches the new one-arg shape.

## Hygiene test (closes the drift class permanently)

`CommandClonePropertyRoundTripTests` reflects over **every** concrete Command subclass: sets each public settable property to a non-default probe, clones, and asserts original-vs-clone equality property-for-property (original-vs-clone keeps aliased properties like `SetForegroundWindowCommand.ClassName` honest). `Reply` is asserted to be the fresh context; `EmbeddedCommands` is covered by the dedicated deep-copy/#183 tests. An unhandled property type fails loudly, forcing a conscious deep-copy decision for any future reference-typed member. Existing per-command clone tests are kept — they additionally pin clone independence, which the sweep doesn't duplicate — and #208's clone-selector pin test passes unchanged.

## Verification

- `dotnet build` warning-clean (TreatWarningsAsErrors + MCEC0001/MCEC0002 analyzers)
- Full `dotnet test`: **690 passed, 0 failed** (22 skipped by design — desktop/input)
- New hygiene sweep: 19 tests (1 sweep guard + 18 command types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm