### PR TITLE
Arch: one ToolDescriptor registry for the gated agent tools

### DIFF
--- a/docs/agent-server-architecture.md
+++ b/docs/agent-server-architecture.md
@@ -21,7 +21,8 @@ pattern and adds no breaking changes to any existing command, transport, or defa
               CommandInvoker  (existing)
                       │  resolves + Execute()s
                       ▼
-   capture / query / find / wait-for / invoke   (new Commands)
+   capture / query / displays / find / wait-for / invoke /
+   drag / click / record / launch   (the ToolCatalog set — new Commands)
         │            │           │
    ScreenCapture  WindowResolver  UiaService
    (PrintWindow)  (Win32 enum)    (FlaUI / UIA3)
@@ -60,6 +61,20 @@ resources.
 UI Automation access (UIA3 via FlaUI) backing element-level `find` / `wait-for`
 queries. Isolated behind a service so the rest of the subsystem has no hard FlaUI
 coupling at the command layer.
+
+### `ToolCatalog` / `ToolDescriptor` (#205)
+The single registry of the gated agent tools. Each `ToolDescriptor` carries the tool's
+name, its `tools/list` schema, its MCP-arguments→`Command` mapping, its overlay
+tersifier, and its policy flags (`SerializesOnInput`, `IsObservation`,
+`ProvisionedByDefault`). The former hand-synced switch/list sites — `AgentServer`'s
+schema builder, tools/call gate whitelist, and `BuildCommand` mapping,
+`SerializesOnInputLock`, `AgentSession.IsObservationTool`,
+`CommandTersifier.ForAgentTool`, and `SessionProvisioner`'s
+`DefaultCommands`/`CreateEnabledCommand` — are all catalog lookups, so adding a tool is
+one descriptor plus its command class. The meta-tools (`send_command`,
+`provision-session`, `end-session`) are deliberately NOT in the catalog: they do not map
+1:1 onto a `Command` and keep their own gating, special-cased in `AgentServer` next to
+the catalog dispatch.
 
 ## Structured replies
 
@@ -106,8 +121,10 @@ MCP/HTTP façade — no special-casing in the command pipeline.
 ## `AgentServer` (MCP / HTTP)
 
 `AgentServer` is the network façade, gated by `AppSettings.McpServerEnabled`. It exposes
-the tools `capture`, `query`, `find`, `invoke`, and `send_command` (a generic raw
-command-line passthrough). Two transports share one dispatch path:
+the gated agent tools registered in `ToolCatalog` (`capture`, `query`, `displays`, `find`,
+`wait-for`, `invoke`, `drag`, `click`, `record`, `launch`) plus the meta-tools
+`send_command` (a generic raw command-line passthrough), `provision-session`, and
+`end-session`. Two transports share one dispatch path:
 
 - **MCP stdio** — used by the `--mcp` headless bootstrap.
 - **HTTP floor** — one JSON-RPC request per `POST` to `/mcp`, bound to

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -14,7 +14,7 @@ AI agents and scripts running on a Windows PC. It gives an agent three things:
   drive all of the above over **MCP** (Model Context Protocol) or a tiny **HTTP** floor.
 
 The agent surface is a set of new commands — `capture`, `query`, `displays`, `find`,
-`wait-for`, `invoke`, `launch`, `drag`, and `click` — exposed as **tools over MCP/HTTP**
+`wait-for`, `invoke`, `record`, `launch`, `drag`, and `click` — exposed as **tools over MCP/HTTP**
 so an agent can call them directly. Each tool call returns a **structured JSON result
 envelope** (`{ ok, result, … }`) instead of free text, so an agent can reason about
 success and failure uniformly.

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -113,7 +113,7 @@ session from any window. If ANY tool returns `error.code:emergency-stopped` (the
 `error.category` stays `internal`), the operator has engaged it and deliberately halted you — STOP
 immediately, tell the user, and do NOT retry; nothing will actuate until they re-arm.
 
-SECURITY: the agent tools (capture/query/displays/find/invoke/record/launch/drag/click) only work when the operator has set
+SECURITY: the agent tools (capture/query/displays/find/wait-for/invoke/record/launch/drag/click) only work when the operator has set
 AgentCommandsEnabled=true; otherwise they return an error — surface that to the user rather than retrying.
 `send_command` is also gated by AgentCommandsEnabled when you are connected over the HTTP transport (it is
 refused with `error.code:agent-commands-disabled` if the agent surface is not opted in); over the local

--- a/src/Agent/AgentSession.cs
+++ b/src/Agent/AgentSession.cs
@@ -146,8 +146,9 @@ public sealed class AgentSession {
         }
     }
 
+    /// <summary>The observation set is the <see cref="ToolDescriptor.IsObservation"/> flag in the catalog (#205).</summary>
     private static bool IsObservationTool(string toolName) =>
-        toolName is "query" or "capture" or "find" or "wait-for";
+        ToolCatalog.TryGet(toolName, out ToolDescriptor descriptor) && descriptor.IsObservation;
 
     /// <summary>Creates the per-session artifact directory if it does not yet exist and returns its path.</summary>
     public string EnsureArtifactDir() {

--- a/src/Agent/CommandTersifier.cs
+++ b/src/Agent/CommandTersifier.cs
@@ -14,20 +14,14 @@ namespace MCEControl;
 public static class CommandTersifier {
     /// <summary>
     /// Terse label for an agent tool call, e.g. <c>capture window="About"</c>, <c>invoke expand "Help"</c>,
-    /// <c>wait-for "OK" → timeout</c>. <paramref name="detail"/> (e.g. an error category) is appended only
-    /// on a <see cref="CommandOutcome.Failed"/> outcome.
+    /// <c>wait-for "OK" → timeout</c>. The per-tool body comes from the tool's
+    /// <see cref="ToolDescriptor.Tersify"/> formatter in <see cref="ToolCatalog"/> (#205 — one registry,
+    /// so a new tool cannot silently render as its bare name); an unknown name falls back to the name.
+    /// <paramref name="detail"/> (e.g. an error category) is appended only on a
+    /// <see cref="CommandOutcome.Failed"/> outcome.
     /// </summary>
     public static string ForAgentTool(string tool, JsonObject args, CommandOutcome outcome, string? detail = null) {
-        string body = tool switch {
-            "capture" => $"capture {Target(args)}",
-            "query" => $"query {Target(args)}",
-            "find" or "wait-for" => $"{tool} {Selector(args)}",
-            "invoke" => $"invoke {Str(args, "action") ?? "invoke"} \"{Str(args, "value") ?? ""}\"",
-            "drag" => $"drag {Endpoint(args, "from")} → {Endpoint(args, "to")}",
-            "click" => $"click {Endpoint(args, "at")}",
-            "displays" => "displays",
-            _ => tool,
-        };
+        string body = ToolCatalog.TryGet(tool, out ToolDescriptor descriptor) ? descriptor.Tersify(args) : tool;
         if (outcome == CommandOutcome.Pending) {
             body += " …";
         }
@@ -50,23 +44,24 @@ public static class CommandTersifier {
     /// The target descriptor the way <see cref="WindowResolver"/> actually resolves it: handle &gt;
     /// foreground &gt; window &gt; process &gt; className. Showing the filter text first would mislabel a
     /// call that reused a handle (or asked for foreground) with a stale title/process the resolver ignored.
+    /// Internal: the per-tool formatters in <see cref="ToolCatalog"/> compose from these building blocks.
     /// </summary>
-    private static string Target(JsonObject args) {
+    internal static string Target(JsonObject args) {
         if (args["handle"] is JsonValue hv && hv.TryGetValue(out long handle) && handle > 0) {
             return $"handle=0x{handle:X}";
         }
         if (args["foreground"] is JsonValue fv && fv.TryGetValue(out bool fg) && fg) {
             return "foreground";
         }
-        string? window = Str(args, "window");
+        string? window = Arg(args, "window");
         if (window is not null) {
             return $"window=\"{window}\"";
         }
-        string? process = Str(args, "process");
+        string? process = Arg(args, "process");
         if (process is not null) {
             return $"process=\"{process}\"";
         }
-        string? className = Str(args, "className");
+        string? className = Arg(args, "className");
         if (className is not null) {
             return $"class=\"{className}\"";
         }
@@ -74,30 +69,31 @@ public static class CommandTersifier {
     }
 
     /// <summary>The element selector for find/wait-for/invoke: a bare quoted value for <c>by=name</c>, else <c>by="value"</c>.</summary>
-    private static string Selector(JsonObject args) {
-        string value = Str(args, "value") ?? "";
-        string by = Str(args, "by") ?? "name";
+    internal static string Selector(JsonObject args) {
+        string value = Arg(args, "value") ?? "";
+        string by = Arg(args, "by") ?? "name";
         return by.Equals("name", StringComparison.OrdinalIgnoreCase)
             ? $"\"{value}\""
             : $"{by}=\"{value}\"";
     }
 
-    /// <summary>A drag endpoint label: an element value (quoted) if present, else a pixel pair.</summary>
-    private static string Endpoint(JsonObject args, string key) {
+    /// <summary>A drag/click endpoint label: an element value (quoted) if present, else a pixel pair.</summary>
+    internal static string Endpoint(JsonObject args, string key) {
         if (args[key] is not JsonObject ep) {
             return "?";
         }
-        string? value = Str(ep, key: "value");
+        string? value = Arg(ep, key: "value");
         if (value is not null) {
-            string by = Str(ep, "by") ?? "name";
+            string by = Arg(ep, "by") ?? "name";
             return by.Equals("name", StringComparison.OrdinalIgnoreCase) ? $"\"{value}\"" : $"{by}=\"{value}\"";
         }
         return $"{Int(ep, "x")},{Int(ep, "y")}";
     }
 
+    /// <summary>A string argument for display: null when absent OR empty (an empty value renders as a default, not "").</summary>
+    internal static string? Arg(JsonObject args, string key) =>
+        args[key] is JsonValue v && v.TryGetValue(out string? s) && !string.IsNullOrEmpty(s) ? s : null;
+
     private static int Int(JsonObject args, string key) =>
         args[key] is JsonValue v && v.TryGetValue(out int i) ? i : 0;
-
-    private static string? Str(JsonObject args, string key) =>
-        args[key] is JsonValue v && v.TryGetValue(out string? s) && !string.IsNullOrEmpty(s) ? s : null;
 }

--- a/src/Agent/SessionProvisioner.cs
+++ b/src/Agent/SessionProvisioner.cs
@@ -26,9 +26,13 @@ namespace MCEControl;
 /// <c>mcec.commands</c> are never read or written.</para>
 /// </summary>
 public static class SessionProvisioner {
-    /// <summary>The agent observation/action commands enabled in a provisioned session's co-located command table.</summary>
+    /// <summary>
+    /// The agent observation/action commands enabled in a provisioned session's co-located command
+    /// table: the <see cref="ToolDescriptor.ProvisionedByDefault"/> members of the
+    /// <see cref="ToolCatalog"/> (#205) — today every gated tool except <c>launch</c>.
+    /// </summary>
     public static readonly string[] DefaultCommands =
-        ["capture", "query", "displays", "find", "wait-for", "invoke", "drag", "click", "record"];
+        [.. ToolCatalog.All.Where(d => d.ProvisionedByDefault).Select(d => d.Name)];
 
     // A provisioned session id is a bare 12-char lowercase-hex token (Guid "N"[..12]). end-session accepts
     // ONLY this shape so a caller can never pass a path/traversal token (e.g. ".." or "a/b") that would make
@@ -244,21 +248,21 @@ public static class SessionProvisioner {
 
     /// <summary>
     /// Builds the correctly-typed <see cref="Command"/> for a name, enabled, so it serializes under the
-    /// right element (query/capture/invoke/…) and loads back as the right derived type. Returns null for an
-    /// unknown name.
+    /// right element (query/capture/invoke/…) and loads back as the right derived type — via the tool's
+    /// <see cref="ToolDescriptor.CreateCommandInstance"/> in the <see cref="ToolCatalog"/> (#205).
+    /// Returns null for an unknown name or one that is not provisionable
+    /// (<see cref="ToolDescriptor.ProvisionedByDefault"/> — today that excludes only <c>launch</c>,
+    /// preserving this provisioner's historical command set).
     /// </summary>
-    private static Command? CreateEnabledCommand(string name) => name.ToLowerInvariant() switch {
-        "capture" => new CaptureCommand { Cmd = "capture", Enabled = true },
-        "query" => new QueryCommand { Cmd = "query", Enabled = true },
-        "displays" => new DisplaysCommand { Cmd = "displays", Enabled = true },
-        "find" => new FindCommand { Cmd = "find", Enabled = true },
-        "wait-for" => new FindCommand { Cmd = "wait-for", Enabled = true },
-        "invoke" => new InvokeCommand { Cmd = "invoke", Enabled = true },
-        "drag" => new DragCommand { Cmd = "drag", Enabled = true },
-        "click" => new ClickCommand { Cmd = "click", Enabled = true },
-        "record" => new RecordCommand { Cmd = "record", Enabled = true },
-        _ => null,
-    };
+    private static Command? CreateEnabledCommand(string name) {
+        if (!ToolCatalog.TryGet(name.ToLowerInvariant(), out ToolDescriptor descriptor) || !descriptor.ProvisionedByDefault) {
+            return null;
+        }
+        Command cmd = descriptor.CreateCommandInstance();
+        cmd.Cmd = descriptor.Name;
+        cmd.Enabled = true;
+        return cmd;
+    }
 
     /// <summary>Asks the OS for a free loopback TCP port by binding to port 0 and reading the assignment.</summary>
     private static int FindFreeLoopbackPort() {

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -1,0 +1,435 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// The single registry of the gated agent tools (#205): one <see cref="ToolDescriptor"/> per tool —
+/// capture, query, displays, find, wait-for, invoke, drag, click, record, launch — carrying its
+/// <c>tools/list</c> schema, its argument→<see cref="Command"/> mapping, its overlay tersifier, and its
+/// policy flags. Every consumer (the <see cref="AgentServer"/> gate/dispatch/schema sites,
+/// <see cref="AgentSession"/>, <see cref="CommandTersifier"/>, <see cref="SessionProvisioner"/>) looks
+/// tools up here, so adding a tool is one descriptor + its command class, not shotgun surgery.
+///
+/// <para>The META-TOOLS — <c>send_command</c>, <c>provision-session</c>, <c>end-session</c> — are
+/// deliberately NOT in the catalog: they do not map 1:1 onto a <see cref="Command"/> in the loaded
+/// table (raw pass-through / session lifecycle), have their own transport-sensitive gating (#153,
+/// #138), and are special-cased in <see cref="AgentServer"/> right next to the catalog dispatch.</para>
+///
+/// <para>Lookups are case-SENSITIVE (ordinal), preserving the historical <c>name is "capture" or …</c>
+/// gate and switch behavior; <see cref="SessionProvisioner"/> lower-cases requested names first, as it
+/// always did.</para>
+/// </summary>
+public static class ToolCatalog {
+    /// <summary>Every gated agent tool, in the order <c>tools/list</c> advertises them.</summary>
+    public static IReadOnlyList<ToolDescriptor> All { get; } = BuildCatalog();
+
+    private static readonly Dictionary<string, ToolDescriptor> ByName = BuildIndex();
+
+    /// <summary>Whether <paramref name="name"/> is a gated agent tool (the tools/call gate membership test).</summary>
+    public static bool Contains(string name) => ByName.ContainsKey(name);
+
+    /// <summary>Looks up the descriptor for <paramref name="name"/> (ordinal match).</summary>
+    public static bool TryGet(string name, out ToolDescriptor descriptor) {
+        if (ByName.TryGetValue(name, out ToolDescriptor? found)) {
+            descriptor = found;
+            return true;
+        }
+        descriptor = null!;
+        return false;
+    }
+
+    private static Dictionary<string, ToolDescriptor> BuildIndex() {
+        Dictionary<string, ToolDescriptor> index = new(StringComparer.Ordinal);
+        foreach (ToolDescriptor d in All) {
+            index.Add(d.Name, d);
+        }
+        return index;
+    }
+
+    private static IReadOnlyList<ToolDescriptor> BuildCatalog() => [
+        new ToolDescriptor {
+            Name = "capture",
+            BuildSchema = BuildCaptureSchema,
+            BuildCommand = args => new CaptureCommand {
+                Window = Str(args, "window")!,
+                Handle = Long(args, "handle"),
+                Process = Str(args, "process")!,
+                ClassName = Str(args, "className")!,
+                Foreground = Bool(args, "foreground"),
+                X = Int(args, "x"),
+                Y = Int(args, "y"),
+                Width = Int(args, "width"),
+                Height = Int(args, "height"),
+                File = Str(args, "file")!,
+            },
+            CreateCommandInstance = () => new CaptureCommand(),
+            Tersify = args => $"capture {CommandTersifier.Target(args)}",
+            IsObservation = true,
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "query",
+            BuildSchema = BuildQuerySchema,
+            BuildCommand = args => new QueryCommand {
+                Window = Str(args, "window")!,
+                Handle = Long(args, "handle"),
+                Process = Str(args, "process")!,
+                ClassName = Str(args, "className")!,
+                Foreground = Bool(args, "foreground"),
+                MaxDepth = Int(args, "maxDepth") is int d and > 0 ? d : 6,
+                MaxNodes = Int(args, "maxNodes") is int n and > 0 ? n : 1000,
+            },
+            CreateCommandInstance = () => new QueryCommand(),
+            Tersify = args => $"query {CommandTersifier.Target(args)}",
+            IsObservation = true,
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "displays",
+            BuildSchema = BuildDisplaysSchema,
+            BuildCommand = _ => new DisplaysCommand(),
+            CreateCommandInstance = () => new DisplaysCommand(),
+            Tersify = _ => "displays",
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "find",
+            BuildSchema = BuildFindSchema,
+            BuildCommand = BuildFindCommand,
+            CreateCommandInstance = () => new FindCommand(),
+            Tersify = args => $"find {CommandTersifier.Selector(args)}",
+            IsObservation = true,
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "wait-for",
+            BuildSchema = BuildWaitForSchema,
+            BuildCommand = BuildFindCommand,
+            CreateCommandInstance = () => new FindCommand(),
+            Tersify = args => $"wait-for {CommandTersifier.Selector(args)}",
+            IsObservation = true,
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "invoke",
+            BuildSchema = BuildInvokeSchema,
+            BuildCommand = args => new InvokeCommand {
+                Window = Str(args, "window")!,
+                Handle = Long(args, "handle"),
+                Process = Str(args, "process")!,
+                ClassName = Str(args, "className")!,
+                Foreground = Bool(args, "foreground"),
+                By = Str(args, "by") ?? "name",
+                Value = Str(args, "value")!,
+                Action = Str(args, "action") ?? "invoke",
+                Text = Str(args, "text")!,
+            },
+            CreateCommandInstance = () => new InvokeCommand(),
+            Tersify = args => $"invoke {CommandTersifier.Arg(args, "action") ?? "invoke"} \"{CommandTersifier.Arg(args, "value") ?? ""}\"",
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "drag",
+            BuildSchema = BuildDragSchema,
+            BuildCommand = BuildDragCommand,
+            CreateCommandInstance = () => new DragCommand(),
+            Tersify = args => $"drag {CommandTersifier.Endpoint(args, "from")} → {CommandTersifier.Endpoint(args, "to")}",
+            SerializesOnInput = true,
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "click",
+            BuildSchema = BuildClickSchema,
+            BuildCommand = BuildClickCommand,
+            CreateCommandInstance = () => new ClickCommand(),
+            Tersify = args => $"click {CommandTersifier.Endpoint(args, "at")}",
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "record",
+            BuildSchema = BuildRecordSchema,
+            BuildCommand = args => new RecordCommand {
+                Action = Str(args, "action")!,
+                Window = Str(args, "window")!,
+                Handle = Long(args, "handle"),
+                Process = Str(args, "process")!,
+                ClassName = Str(args, "className")!,
+                Foreground = Bool(args, "foreground"),
+                X = Int(args, "x"),
+                Y = Int(args, "y"),
+                Width = Int(args, "width"),
+                Height = Int(args, "height"),
+                Fps = Int(args, "fps"),
+                DurationMs = Int(args, "durationMs"),
+                MaxWidth = Int(args, "maxWidth"),
+                File = Str(args, "file")!,
+            },
+            CreateCommandInstance = () => new RecordCommand(),
+            // Mirrors capture: record shares its window-or-region targeting semantics. (#205 fixed the
+            // drift where record rendered as a bare "record" on the overlay.)
+            Tersify = args => $"record {CommandTersifier.Target(args)}",
+            ProvisionedByDefault = true,
+        },
+        new ToolDescriptor {
+            Name = "launch",
+            BuildSchema = BuildLaunchSchema,
+            BuildCommand = args => new LaunchCommand {
+                Path = Str(args, "path")!,
+                Arguments = Str(args, "arguments")!,
+                WorkingDirectory = Str(args, "workingDirectory")!,
+                Timeout = Int(args, "timeout"),
+            },
+            CreateCommandInstance = () => new LaunchCommand(),
+            // (#205 fixed the drift where launch rendered as a bare "launch" on the overlay.)
+            Tersify = args => $"launch \"{CommandTersifier.Arg(args, "path") ?? ""}\"",
+            // Not in SessionProvisioner's command set: a provisioned session's default posture is
+            // observe/act-on-UI; direct process launch stays an explicit operator decision.
+            ProvisionedByDefault = false,
+        },
+    ];
+
+    // -------------------------------------------------------------------------------------------
+    // tools/list schemas (relocated verbatim from AgentServer.BuildToolsList, #205 — content unchanged)
+    // -------------------------------------------------------------------------------------------
+
+    private static JsonObject BuildCaptureSchema() {
+        JsonObject captureProps = WindowTargetProps();
+        captureProps["x"] = PropSchema("integer", "Region left (use with width/height instead of a window)");
+        captureProps["y"] = PropSchema("integer", "Region top");
+        captureProps["width"] = PropSchema("integer", "Region width (max 16384/side, 64000000 px total; oversized fails with region-too-large)");
+        captureProps["height"] = PropSchema("integer", "Region height (same limits as width)");
+        captureProps["file"] = PropSchema("string", "Optional path to also save the PNG to");
+        return Tool("capture",
+            "Screenshot a window (PrintWindow PW_RENDERFULLCONTENT, captures WinUI/WPF surfaces) or a screen region; returns PNG. Blank/black frames are detected and reported as a capture-blank error (window) or warning (region) rather than a silent bad image.",
+            captureProps, []);
+    }
+
+    private static JsonObject BuildQuerySchema() {
+        JsonObject queryProps = WindowTargetProps();
+        queryProps["maxDepth"] = PropSchema("integer", "Max UI Automation tree depth (default 6)");
+        queryProps["maxNodes"] = PropSchema("integer", "Max UI Automation nodes returned (default 1000); a clipped tree is flagged with a tree-truncated warning");
+        return Tool("query",
+            "Dump the UI Automation tree of a window: control type, name, automation id, bounds, state. Returns nodeCount/truncated and warns when the node cap clips the tree.",
+            queryProps, []);
+    }
+
+    private static JsonObject BuildDisplaysSchema() => Tool("displays",
+        "Report display geometry: every monitor's pixel bounds, working area, primary flag, and DPI/scale, plus the union virtualBounds. Use it to interpret the absolute-pixel bounds query/find return and to place pixel clicks/drags — no arguments.",
+        [], []);
+
+    private static JsonObject BuildFindSchema() {
+        JsonObject findProps = WindowTargetProps();
+        findProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
+        findProps["value"] = PropSchema("string", "Value to match");
+        findProps["timeout"] = PropSchema("integer", "Milliseconds to wait for the element (0 = no wait)");
+        return Tool("find",
+            "Find (or wait for, with a timeout) a UI Automation element by name / automation id / class.",
+            findProps, ["value"]);
+    }
+
+    private static JsonObject BuildWaitForSchema() {
+        JsonObject waitForProps = WindowTargetProps();
+        waitForProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
+        waitForProps["value"] = PropSchema("string", "Value to match");
+        waitForProps["timeout"] = PropSchema("integer", "Milliseconds to wait for the element (default 5000)");
+        return Tool("wait-for",
+            "Wait for a UI Automation element to appear: polls until found or the timeout elapses (default 5s).",
+            waitForProps, ["value"]);
+    }
+
+    private static JsonObject BuildInvokeSchema() {
+        JsonObject invokeProps = WindowTargetProps();
+        invokeProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
+        invokeProps["value"] = PropSchema("string", "Value to match");
+        invokeProps["action"] = PropSchema("string", "invoke | toggle | setvalue | setfocus | expand | collapse | select (default invoke). Use expand to open a menu before invoking its items; use select for TabItem, ListItem, RadioButton etc.");
+        invokeProps["text"] = PropSchema("string", "Text for the setvalue action");
+        return Tool("invoke",
+            "Drive a UI Automation element (Invoke/Toggle/Value/SetFocus/Expand/Collapse/Select) — more reliable than coordinate clicks. Use 'select' for tabs, list items, radios (SelectionItem pattern).",
+            invokeProps, ["value"]);
+    }
+
+    private static JsonObject BuildDragSchema() {
+        JsonObject dragProps = WindowTargetProps();
+        dragProps["from"] = EndpointSchema("Drag start: an element ({ by, value }) in the target window, or a pixel ({ x, y }).");
+        dragProps["to"] = EndpointSchema("Drag end: an element ({ by, value }) in the target window, or a pixel ({ x, y }).");
+        dragProps["path"] = new JsonObject {
+            ["type"] = "array",
+            ["description"] = "Optional intermediate waypoints (absolute screen pixels) between from and to.",
+            ["items"] = new JsonObject {
+                ["type"] = "object",
+                ["properties"] = new JsonObject {
+                    ["x"] = PropSchema("integer", "Waypoint X (screen pixels)"),
+                    ["y"] = PropSchema("integer", "Waypoint Y (screen pixels)"),
+                },
+            },
+        };
+        return Tool("drag",
+            "Press → move along a path → release, dispatched atomically (no interleaving). Endpoints are an element (by/value, dragged from/to its centre) or an absolute screen pixel; add path waypoints for a curved/multi-stop drag. Covers window resize/move by chrome, sliders, marquee select, drag-reorder. Give a window target when either endpoint is an element.",
+            dragProps, ["from", "to"]);
+    }
+
+    private static JsonObject BuildClickSchema() {
+        JsonObject clickProps = WindowTargetProps();
+        clickProps["at"] = EndpointSchema("Where to click: an element ({ by, value }) in the target window (its centre) or an absolute screen pixel ({ x, y }).");
+        clickProps["button"] = PropSchema("string", "Button: left | right | middle (default left)");
+        clickProps["count"] = PropSchema("integer", "Click count: 1 = single, 2 = double (default 1)");
+        return Tool("click",
+            "Click at a point — an element (by/value, clicked at its centre) or an absolute screen pixel (the space query/find bounds report). Move+click is dispatched atomically. Prefer invoke for buttons/menus; use click for element types invoke cannot drive or when you must target a pixel. Give a window target when 'at' is an element.",
+            clickProps, ["at"]);
+    }
+
+    private static JsonObject BuildRecordSchema() {
+        JsonObject recordProps = WindowTargetProps();
+        recordProps["x"] = PropSchema("integer", "Region left (use with width/height instead of a window)");
+        recordProps["y"] = PropSchema("integer", "Region top");
+        recordProps["width"] = PropSchema("integer", "Region width (max 16384/side, 64000000 px total; oversized fails with region-too-large)");
+        recordProps["height"] = PropSchema("integer", "Region height (same limits as width)");
+        recordProps["action"] = PropSchema("string", "start | stop | oneshot (default: oneshot if durationMs given, else start)");
+        recordProps["fps"] = PropSchema("integer", "Frames per second (default 5, clamped to the operator limit)");
+        recordProps["durationMs"] = PropSchema("integer", "For a one-shot: how long to record (clamped to the operator limit)");
+        recordProps["maxWidth"] = PropSchema("integer", "Downscale frames so width fits this (default 1280)");
+        recordProps["file"] = PropSchema("string", "Output .gif path (a temp path is generated if omitted)");
+        return Tool("record",
+            "Record a window or region to an animated GIF over time (start/stop or a bounded one-shot). Use only to show CHANGE over time; for a single state check use capture.",
+            recordProps, []);
+    }
+
+    private static JsonObject BuildLaunchSchema() {
+        JsonObject launchProps = new() {
+            ["path"] = PropSchema("string", "Path to executable, shell: protocol target (e.g. shell:AppsFolder\\...), or .lnk (required)"),
+            ["arguments"] = PropSchema("string", "Command line arguments to pass to the process"),
+            ["workingDirectory"] = PropSchema("string", "Initial working directory for the launched process"),
+            ["timeout"] = PropSchema("integer", "Milliseconds to wait for the app window to appear (default 5000)"),
+        };
+        return Tool("launch",
+            "Launch an application directly as a gated agent action. Starts the process and returns its pid plus the primary window (handle + descriptor) when it appears within timeout. Preferred over send_command winr dance for reliability.",
+            launchProps, ["path"]);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Schema building blocks (shared with AgentServer's meta-tool schemas)
+    // -------------------------------------------------------------------------------------------
+
+    /// <summary>The five shared window-targeting selector properties.</summary>
+    internal static JsonObject WindowTargetProps() => new() {
+        ["window"] = PropSchema("string", "Window title substring (case-insensitive) to target"),
+        ["handle"] = PropSchema("integer", "Explicit window handle (HWND) to target"),
+        ["process"] = PropSchema("string", "Process name (without .exe) to target"),
+        ["className"] = PropSchema("string", "Window class name to target"),
+        ["foreground"] = PropSchema("boolean", "Target the current foreground window"),
+    };
+
+    /// <summary>A single JSON-schema property node.</summary>
+    internal static JsonObject PropSchema(string type, string description) =>
+        new() { ["type"] = type, ["description"] = description };
+
+    /// <summary>Schema for a drag/click endpoint: either an element ({ by, value }) or a pixel ({ x, y }).</summary>
+    internal static JsonObject EndpointSchema(string description) => new() {
+        ["type"] = "object",
+        ["description"] = description,
+        ["properties"] = new JsonObject {
+            ["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)"),
+            ["value"] = PropSchema("string", "Element value to match (omit for a pixel endpoint)"),
+            ["x"] = PropSchema("integer", "Endpoint X in absolute screen pixels (omit for an element endpoint)"),
+            ["y"] = PropSchema("integer", "Endpoint Y in absolute screen pixels (omit for an element endpoint)"),
+        },
+    };
+
+    /// <summary>Assembles a complete <c>tools/list</c> entry.</summary>
+    internal static JsonObject Tool(string name, string description, JsonObject properties, JsonArray required) => new() {
+        ["name"] = name,
+        ["description"] = description,
+        ["inputSchema"] = new JsonObject {
+            ["type"] = "object",
+            ["properties"] = properties,
+            ["required"] = required,
+        },
+    };
+
+    // -------------------------------------------------------------------------------------------
+    // Argument mapping helpers (relocated from AgentServer, #205 — behavior unchanged)
+    // -------------------------------------------------------------------------------------------
+
+    /// <summary>Maps find/wait-for arguments onto a <see cref="FindCommand"/> (shared by both tool names).</summary>
+    private static FindCommand BuildFindCommand(JsonObject args) => new() {
+        Window = Str(args, "window")!,
+        Handle = Long(args, "handle"),
+        Process = Str(args, "process")!,
+        ClassName = Str(args, "className")!,
+        Foreground = Bool(args, "foreground"),
+        By = Str(args, "by") ?? "name",
+        Value = Str(args, "value")!,
+        Timeout = Int(args, "timeout"),
+    };
+
+    /// <summary>Maps the drag tool's nested <c>from</c>/<c>to</c>/<c>path</c> arguments onto a <see cref="DragCommand"/>.</summary>
+    private static DragCommand BuildDragCommand(JsonObject args) {
+        JsonObject from = args["from"] as JsonObject ?? [];
+        JsonObject to = args["to"] as JsonObject ?? [];
+        return new DragCommand {
+            Window = Str(args, "window")!,
+            Handle = Long(args, "handle"),
+            Process = Str(args, "process")!,
+            ClassName = Str(args, "className")!,
+            Foreground = Bool(args, "foreground"),
+            FromBy = Str(from, "by") ?? "name",
+            FromValue = Str(from, "value")!,
+            FromX = Int(from, "x"),
+            FromY = Int(from, "y"),
+            ToBy = Str(to, "by") ?? "name",
+            ToValue = Str(to, "value")!,
+            ToX = Int(to, "x"),
+            ToY = Int(to, "y"),
+            PathSpec = BuildPathSpec(args["path"] as JsonArray),
+        };
+    }
+
+    /// <summary>Maps the click tool's nested <c>at</c> endpoint and button/count onto a <see cref="ClickCommand"/>.</summary>
+    private static ClickCommand BuildClickCommand(JsonObject args) {
+        JsonObject at = args["at"] as JsonObject ?? [];
+        return new ClickCommand {
+            Window = Str(args, "window")!,
+            Handle = Long(args, "handle"),
+            Process = Str(args, "process")!,
+            ClassName = Str(args, "className")!,
+            Foreground = Bool(args, "foreground"),
+            By = Str(at, "by") ?? "name",
+            Value = Str(at, "value")!,
+            X = Int(at, "x"),
+            Y = Int(at, "y"),
+            Button = Str(args, "button") ?? "left",
+            Count = Int(args, "count") is int c and > 0 ? c : 1,
+        };
+    }
+
+    /// <summary>Flattens the drag tool's <c>path</c> array of <c>{ x, y }</c> points into DragCommand's <c>x,y;x,y</c> spec.</summary>
+    private static string BuildPathSpec(JsonArray? path) {
+        if (path is null || path.Count == 0) {
+            return string.Empty;
+        }
+        List<string> pairs = [];
+        foreach (JsonNode? node in path) {
+            if (node is JsonObject p) {
+                pairs.Add($"{Int(p, "x")},{Int(p, "y")}");
+            }
+        }
+        return string.Join(";", pairs);
+    }
+
+    private static string? Str(JsonObject a, string key) =>
+        a[key] is JsonValue v && v.TryGetValue(out string? s) ? s : null;
+
+    private static long Long(JsonObject a, string key) =>
+        a[key] is JsonValue v && v.TryGetValue(out long l) ? l : 0;
+
+    private static int Int(JsonObject a, string key) =>
+        a[key] is JsonValue v && v.TryGetValue(out int i) ? i : 0;
+
+    private static bool Bool(JsonObject a, string key) =>
+        a[key] is JsonValue v && v.TryGetValue(out bool b) && b;
+}

--- a/src/Agent/ToolDescriptor.cs
+++ b/src/Agent/ToolDescriptor.cs
@@ -1,0 +1,71 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Text.Json.Nodes;
+
+namespace MCEControl;
+
+/// <summary>
+/// Everything the agent surface knows about one gated agent tool, in one record (#205). Before this,
+/// per-tool knowledge was scattered across ~8 hand-synced sites — the <c>tools/list</c> schema builder,
+/// the tools/call gate whitelist, the arg-mapping switch, <c>SerializesOnInputLock</c>,
+/// <c>AgentSession.IsObservationTool</c>, <c>CommandTersifier.ForAgentTool</c>, and
+/// <c>SessionProvisioner</c>'s default/enabled command lists — so adding a tool was shotgun surgery
+/// and drift was routine (the tersifier had already lost <c>record</c>/<c>launch</c>). Those sites are
+/// now lookups into <see cref="ToolCatalog"/>, which holds one of these per tool.
+/// </summary>
+public sealed record ToolDescriptor {
+    /// <summary>The MCP tool name (also the command name in the loaded command table).</summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Builds the tool's complete <c>tools/list</c> entry (<c>name</c>/<c>description</c>/
+    /// <c>inputSchema</c>). A factory rather than a cached object because a <see cref="JsonObject"/>
+    /// can only be parented into one document at a time.
+    /// </summary>
+    public required Func<JsonObject> BuildSchema { get; init; }
+
+    /// <summary>
+    /// Maps the MCP <c>tools/call</c> arguments onto a populated <see cref="Command"/> instance
+    /// (the #201 exhaustive mapping — unknown names never reach a descriptor).
+    /// </summary>
+    public required Func<JsonObject, Command> BuildCommand { get; init; }
+
+    /// <summary>
+    /// Creates a bare, correctly-typed <see cref="Command"/> instance for serialization into a
+    /// provisioned session's <c>mcec.commands</c> (see <see cref="SessionProvisioner"/>). Separate from
+    /// <see cref="BuildCommand"/> so the serialized command carries the type's own property defaults,
+    /// not the tool-call argument defaults.
+    /// </summary>
+    public required Func<Command> CreateCommandInstance { get; init; }
+
+    /// <summary>
+    /// Builds the condensed one-line overlay/log label body for a call's arguments (#119). The shared
+    /// outcome suffix (<c>…</c> / <c>→ failed</c>) is appended by
+    /// <see cref="CommandTersifier.ForAgentTool"/>.
+    /// </summary>
+    public required Func<JsonObject, string> Tersify { get; init; }
+
+    /// <summary>
+    /// Whether the tool serializes on the shared input gate (<see cref="AgentRuntime.InputGate"/> — the
+    /// #113 contract) because it synthesizes global physical mouse/keyboard input directly on its MCP
+    /// worker. Note <c>send_command</c> is a meta-tool outside the catalog: it serializes INDIRECTLY
+    /// via the <see cref="CommandInvoker"/> dispatcher thread (#195) and is special-cased in
+    /// <see cref="AgentServer.SerializesOnInputLock"/>.
+    /// </summary>
+    public bool SerializesOnInput { get; init; }
+
+    /// <summary>
+    /// Whether a successful call is an observation whose payload the ambient session records as
+    /// <see cref="AgentSession.LastObservation"/> (query/capture/find/wait-for).
+    /// </summary>
+    public bool IsObservation { get; init; }
+
+    /// <summary>
+    /// Whether a provisioned session (#138) enables this command by default — and at all: a tool
+    /// without this flag (today only <c>launch</c>) is not provisionable even by explicit request,
+    /// matching <see cref="SessionProvisioner"/>'s historical command set.
+    /// </summary>
+    public bool ProvisionedByDefault { get; init; }
+}

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -82,7 +82,8 @@ public static class UiaService {
     }
 
     /// <summary>
-    /// Finds an element (5s timeout) and dispatches <paramref name="action"/>
+    /// Finds an element (a short <see cref="InvokeFindTimeoutMs"/> lookup — invoke fast-fails rather
+    /// than waiting; see that constant) and dispatches <paramref name="action"/>
     /// (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>).
     /// Returns true on success, false if the element wasn't found or the required pattern is
     /// unsupported. <c>expand</c> opens a collapsed menu/treeitem so its children become reachable —

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -21,7 +21,8 @@ namespace MCEControl;
 /// Python/Node runtime: the same self-contained native binary, with MCP/HTTP as just one more
 /// transport over the existing command core.
 ///
-/// SECURITY: the observation tools (capture/query/find/invoke) only run when
+/// SECURITY: the gated agent tools (the <see cref="ToolCatalog"/> set — capture, query, displays,
+/// find, wait-for, invoke, drag, click, record, launch) only run when
 /// <see cref="AgentRuntime.AgentCommandsEnabled"/> is true; otherwise a tool call is reported as an
 /// error. The HTTP listener binds to <see cref="AppSettings.McpBindAddress"/> (127.0.0.1 by default).
 /// A loopback bind is canonicalized before it reaches <see cref="HttpListener"/> (#152, see
@@ -67,13 +68,16 @@ public static class AgentServer {
     /// (<see cref="AgentRuntime.InputGate"/> — the #113 contract). Global-input actuation
     /// (<c>drag</c>, <c>send_command</c>) does — it synthesizes physical mouse/keyboard, one shared
     /// stream that concurrent requests must not interleave. <c>drag</c> actuates directly under the
-    /// gate on its MCP worker; <c>send_command</c> serializes INDIRECTLY (#195): it enqueues into the
-    /// <see cref="CommandInvoker"/>, whose single dispatcher thread holds the gate around each queued
-    /// command's Execute. Observation (<c>query</c>/<c>capture</c>/<c>find</c>/<c>wait-for</c>/
-    /// <c>record</c>) does not (it runs concurrently); <c>invoke</c> is UIA-pattern actuation
-    /// dispatched on a worker with the modal grace, not under this lock (#105).
+    /// gate on its MCP worker (its <see cref="ToolDescriptor.SerializesOnInput"/> flag);
+    /// <c>send_command</c> is a meta-tool outside the <see cref="ToolCatalog"/> and serializes
+    /// INDIRECTLY (#195): it enqueues into the <see cref="CommandInvoker"/>, whose single dispatcher
+    /// thread holds the gate around each queued command's Execute — so it is special-cased here.
+    /// Observation (<c>query</c>/<c>capture</c>/<c>find</c>/<c>wait-for</c>/<c>record</c>) does not
+    /// (it runs concurrently); <c>invoke</c> is UIA-pattern actuation dispatched on a worker with the
+    /// modal grace, not under this lock (#105).
     /// </summary>
-    public static bool SerializesOnInputLock(string tool) => tool is "drag" or "send_command";
+    public static bool SerializesOnInputLock(string tool) =>
+        tool == "send_command" || (ToolCatalog.TryGet(tool, out ToolDescriptor descriptor) && descriptor.SerializesOnInput);
 
     // -------------------------------------------------------------------------------------------
     // JSON-RPC dispatch (shared by stdio + HTTP)
@@ -169,164 +173,45 @@ public static class AgentServer {
     // Tool catalog
     // -------------------------------------------------------------------------------------------
 
-    private static JsonObject WindowTargetProps() => new() {
-        ["window"] = PropSchema("string", "Window title substring (case-insensitive) to target"),
-        ["handle"] = PropSchema("integer", "Explicit window handle (HWND) to target"),
-        ["process"] = PropSchema("string", "Process name (without .exe) to target"),
-        ["className"] = PropSchema("string", "Window class name to target"),
-        ["foreground"] = PropSchema("boolean", "Target the current foreground window"),
-    };
-
-    private static JsonObject PropSchema(string type, string description) =>
-        new() { ["type"] = type, ["description"] = description };
-
-    /// <summary>Schema for a drag endpoint: either an element ({ by, value }) or a pixel ({ x, y }).</summary>
-    private static JsonObject EndpointSchema(string description) => new() {
-        ["type"] = "object",
-        ["description"] = description,
-        ["properties"] = new JsonObject {
-            ["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)"),
-            ["value"] = PropSchema("string", "Element value to match (omit for a pixel endpoint)"),
-            ["x"] = PropSchema("integer", "Endpoint X in absolute screen pixels (omit for an element endpoint)"),
-            ["y"] = PropSchema("integer", "Endpoint Y in absolute screen pixels (omit for an element endpoint)"),
-        },
-    };
-
     private static JsonArray BuildToolsList() {
         JsonArray tools = [];
 
-        JsonObject captureProps = WindowTargetProps();
-        captureProps["x"] = PropSchema("integer", "Region left (use with width/height instead of a window)");
-        captureProps["y"] = PropSchema("integer", "Region top");
-        captureProps["width"] = PropSchema("integer", "Region width (max 16384/side, 64000000 px total; oversized fails with region-too-large)");
-        captureProps["height"] = PropSchema("integer", "Region height (same limits as width)");
-        captureProps["file"] = PropSchema("string", "Optional path to also save the PNG to");
-        tools.Add(Tool("capture",
-            "Screenshot a window (PrintWindow PW_RENDERFULLCONTENT, captures WinUI/WPF surfaces) or a screen region; returns PNG. Blank/black frames are detected and reported as a capture-blank error (window) or warning (region) rather than a silent bad image.",
-            captureProps, []));
+        // The gated agent tools — one descriptor per tool, schema included — live in ToolCatalog (#205).
+        foreach (ToolDescriptor descriptor in ToolCatalog.All) {
+            tools.Add(descriptor.BuildSchema());
+        }
 
-        JsonObject queryProps = WindowTargetProps();
-        queryProps["maxDepth"] = PropSchema("integer", "Max UI Automation tree depth (default 6)");
-        queryProps["maxNodes"] = PropSchema("integer", "Max UI Automation nodes returned (default 1000); a clipped tree is flagged with a tree-truncated warning");
-        tools.Add(Tool("query",
-            "Dump the UI Automation tree of a window: control type, name, automation id, bounds, state. Returns nodeCount/truncated and warns when the node cap clips the tree.",
-            queryProps, []));
-
-        tools.Add(Tool("displays",
-            "Report display geometry: every monitor's pixel bounds, working area, primary flag, and DPI/scale, plus the union virtualBounds. Use it to interpret the absolute-pixel bounds query/find return and to place pixel clicks/drags — no arguments.",
-            [], []));
-
-        JsonObject findProps = WindowTargetProps();
-        findProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
-        findProps["value"] = PropSchema("string", "Value to match");
-        findProps["timeout"] = PropSchema("integer", "Milliseconds to wait for the element (0 = no wait)");
-        tools.Add(Tool("find",
-            "Find (or wait for, with a timeout) a UI Automation element by name / automation id / class.",
-            findProps, ["value"]));
-
-        JsonObject waitForProps = WindowTargetProps();
-        waitForProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
-        waitForProps["value"] = PropSchema("string", "Value to match");
-        waitForProps["timeout"] = PropSchema("integer", "Milliseconds to wait for the element (default 5000)");
-        tools.Add(Tool("wait-for",
-            "Wait for a UI Automation element to appear: polls until found or the timeout elapses (default 5s).",
-            waitForProps, ["value"]));
-
-        JsonObject invokeProps = WindowTargetProps();
-        invokeProps["by"] = PropSchema("string", "Match by: name | automationid | classname (default name)");
-        invokeProps["value"] = PropSchema("string", "Value to match");
-        invokeProps["action"] = PropSchema("string", "invoke | toggle | setvalue | setfocus | expand | collapse | select (default invoke). Use expand to open a menu before invoking its items; use select for TabItem, ListItem, RadioButton etc.");
-        invokeProps["text"] = PropSchema("string", "Text for the setvalue action");
-        tools.Add(Tool("invoke",
-            "Drive a UI Automation element (Invoke/Toggle/Value/SetFocus/Expand/Collapse/Select) — more reliable than coordinate clicks. Use 'select' for tabs, list items, radios (SelectionItem pattern).",
-            invokeProps, ["value"]));
-
-        JsonObject dragProps = WindowTargetProps();
-        dragProps["from"] = EndpointSchema("Drag start: an element ({ by, value }) in the target window, or a pixel ({ x, y }).");
-        dragProps["to"] = EndpointSchema("Drag end: an element ({ by, value }) in the target window, or a pixel ({ x, y }).");
-        dragProps["path"] = new JsonObject {
-            ["type"] = "array",
-            ["description"] = "Optional intermediate waypoints (absolute screen pixels) between from and to.",
-            ["items"] = new JsonObject {
-                ["type"] = "object",
-                ["properties"] = new JsonObject {
-                    ["x"] = PropSchema("integer", "Waypoint X (screen pixels)"),
-                    ["y"] = PropSchema("integer", "Waypoint Y (screen pixels)"),
-                },
-            },
-        };
-        tools.Add(Tool("drag",
-            "Press → move along a path → release, dispatched atomically (no interleaving). Endpoints are an element (by/value, dragged from/to its centre) or an absolute screen pixel; add path waypoints for a curved/multi-stop drag. Covers window resize/move by chrome, sliders, marquee select, drag-reorder. Give a window target when either endpoint is an element.",
-            dragProps, ["from", "to"]));
-
-        JsonObject clickProps = WindowTargetProps();
-        clickProps["at"] = EndpointSchema("Where to click: an element ({ by, value }) in the target window (its centre) or an absolute screen pixel ({ x, y }).");
-        clickProps["button"] = PropSchema("string", "Button: left | right | middle (default left)");
-        clickProps["count"] = PropSchema("integer", "Click count: 1 = single, 2 = double (default 1)");
-        tools.Add(Tool("click",
-            "Click at a point — an element (by/value, clicked at its centre) or an absolute screen pixel (the space query/find bounds report). Move+click is dispatched atomically. Prefer invoke for buttons/menus; use click for element types invoke cannot drive or when you must target a pixel. Give a window target when 'at' is an element.",
-            clickProps, ["at"]));
-
-        JsonObject recordProps = WindowTargetProps();
-        recordProps["x"] = PropSchema("integer", "Region left (use with width/height instead of a window)");
-        recordProps["y"] = PropSchema("integer", "Region top");
-        recordProps["width"] = PropSchema("integer", "Region width (max 16384/side, 64000000 px total; oversized fails with region-too-large)");
-        recordProps["height"] = PropSchema("integer", "Region height (same limits as width)");
-        recordProps["action"] = PropSchema("string", "start | stop | oneshot (default: oneshot if durationMs given, else start)");
-        recordProps["fps"] = PropSchema("integer", "Frames per second (default 5, clamped to the operator limit)");
-        recordProps["durationMs"] = PropSchema("integer", "For a one-shot: how long to record (clamped to the operator limit)");
-        recordProps["maxWidth"] = PropSchema("integer", "Downscale frames so width fits this (default 1280)");
-        recordProps["file"] = PropSchema("string", "Output .gif path (a temp path is generated if omitted)");
-        tools.Add(Tool("record",
-            "Record a window or region to an animated GIF over time (start/stop or a bounded one-shot). Use only to show CHANGE over time; for a single state check use capture.",
-            recordProps, []));
-
-        JsonObject launchProps = new() {
-            ["path"] = PropSchema("string", "Path to executable, shell: protocol target (e.g. shell:AppsFolder\\...), or .lnk (required)"),
-            ["arguments"] = PropSchema("string", "Command line arguments to pass to the process"),
-            ["workingDirectory"] = PropSchema("string", "Initial working directory for the launched process"),
-            ["timeout"] = PropSchema("integer", "Milliseconds to wait for the app window to appear (default 5000)"),
-        };
-        tools.Add(Tool("launch",
-            "Launch an application directly as a gated agent action. Starts the process and returns its pid plus the primary window (handle + descriptor) when it appears within timeout. Preferred over send_command winr dance for reliability.",
-            launchProps, ["path"]));
-
-        tools.Add(Tool("send_command",
+        // META-TOOLS: deliberately NOT in the catalog, because they do not map 1:1 onto a Command in
+        // the loaded table and have their own gating. send_command is the raw pass-through into the
+        // CommandInvoker queue (transport-sensitive gate, #153); provision-session/end-session are the
+        // isolated-session lifecycle (#138, gated by the operator's AllowSessionProvisioning). They are
+        // special-cased here and in CallTool, right next to the catalog dispatch.
+        tools.Add(ToolCatalog.Tool("send_command",
             "Send any raw MCEC command string to the existing command core (e.g. actuation commands).",
-            new JsonObject { ["command"] = PropSchema("string", "The MCEC command string to enqueue") },
+            new JsonObject { ["command"] = ToolCatalog.PropSchema("string", "The MCEC command string to enqueue") },
             ["command"]));
 
         // Isolated session provisioning (#138). Requires the operator to have opted in
         // (AllowSessionProvisioning); it never mutates the installed config.
         JsonObject provisionProps = new() {
-            ["mcpServer"] = PropSchema("boolean", "Enable the provisioned instance's localhost MCP/HTTP server (default true)"),
+            ["mcpServer"] = ToolCatalog.PropSchema("boolean", "Enable the provisioned instance's localhost MCP/HTTP server (default true)"),
             ["commands"] = new JsonObject {
                 ["type"] = "array",
                 ["description"] = "Command names to enable in the session (default: the agent observation/action set)",
                 ["items"] = new JsonObject { ["type"] = "string" },
             },
         };
-        tools.Add(Tool("provision-session",
+        tools.Add(ToolCatalog.Tool("provision-session",
             "Get a fresh, disposable, isolated MCEC instance to run from instead of enabling the installed one. Returns a directory containing mcec.exe + an agent-ready co-located config (agent commands enabled ONLY inside the copy), plus how to launch/connect and the sessionId to tear it down. Requires the operator to have enabled AllowSessionProvisioning; the installed config is never touched. Call end-session (or delete the directory) when finished.",
             provisionProps, []));
 
-        tools.Add(Tool("end-session",
+        tools.Add(ToolCatalog.Tool("end-session",
             "Tear down a provisioned session (from provision-session) by deleting its directory. Stop the session's mcec.exe first, or its files stay locked. MCEC also reaps stale session dirs on launch.",
-            new JsonObject { ["sessionId"] = PropSchema("string", "The sessionId returned by provision-session") },
+            new JsonObject { ["sessionId"] = ToolCatalog.PropSchema("string", "The sessionId returned by provision-session") },
             ["sessionId"]));
 
         return tools;
     }
-
-    private static JsonObject Tool(string name, string description, JsonObject properties, JsonArray required) => new() {
-        ["name"] = name,
-        ["description"] = description,
-        ["inputSchema"] = new JsonObject {
-            ["type"] = "object",
-            ["properties"] = properties,
-            ["required"] = required,
-        },
-    };
 
     // -------------------------------------------------------------------------------------------
     // tools/call
@@ -371,7 +256,8 @@ public static class AgentServer {
             return RunEndSession(args);
         }
 
-        if (name is "capture" or "query" or "displays" or "find" or "wait-for" or "invoke" or "record" or "launch" or "drag" or "click") {
+        // The gated agent tools are exactly the ToolCatalog membership (#205) — no hand-synced whitelist.
+        if (ToolCatalog.Contains(name)) {
             if (!AgentRuntime.AgentCommandsEnabled) {
                 AgentRuntime.Audit(name, "BLOCKED — agent commands disabled");
                 return ToolError("Agent commands are disabled. Set AgentCommandsEnabled=true to opt in.", "agent-commands-disabled");
@@ -432,10 +318,10 @@ public static class AgentServer {
     // Internal so tests can exercise the unknown-tool refusal for a name that passed the
     // tools/call gate but has no argument mapping (InternalsVisibleTo). See #201.
     internal static JsonObject RunAgentCommand(string name, JsonObject args) {
-        // #201: the tools/call gate whitelist and BuildCommand's arg-mapping switch are two
-        // hand-maintained lists. If a name passes the gate but has no mapping, refuse with a
-        // structured error — the old default arm silently mapped unknown names onto InvokeCommand
-        // (an ACTUATION) with garbage selector args.
+        // #201: if a name passes the gate but has no command mapping, refuse with a structured error
+        // — the old default arm silently mapped unknown names onto InvokeCommand (an ACTUATION) with
+        // garbage selector args. Since #205 the gate and the mapping are the SAME ToolCatalog, so
+        // this can only trip for a caller that bypassed the gate (tests exercise it directly).
         if (BuildCommand(name, args) is not Command cmd) {
             AgentRuntime.Audit(name, "BLOCKED — tool has no argument mapping; refusing to run it as another command");
             return ToolError($"Unknown tool: {name}", "unknown-tool");
@@ -695,135 +581,16 @@ public static class AgentServer {
     }
 
     /// <summary>
-    /// Builds and populates an agent command instance from MCP tool arguments. Exhaustive over the
-    /// agent tool names: an unknown name returns <c>null</c> (the caller refuses it as
+    /// Builds and populates an agent command instance from MCP tool arguments, dispatching through the
+    /// tool's <see cref="ToolDescriptor.BuildCommand"/> in <see cref="ToolCatalog"/> (#205). Exhaustive
+    /// over the agent tool names: an unknown name returns <c>null</c> (the caller refuses it as
     /// <c>unknown-tool</c>) rather than falling through to a default command (#201). Internal so
     /// tests can pin the mapping (InternalsVisibleTo).
     /// </summary>
-    internal static Command? BuildCommand(string name, JsonObject args) => name switch {
-        "capture" => new CaptureCommand {
-            Window = Str(args, "window")!,
-            Handle = Long(args, "handle"),
-            Process = Str(args, "process")!,
-            ClassName = Str(args, "className")!,
-            Foreground = Bool(args, "foreground"),
-            X = Int(args, "x"),
-            Y = Int(args, "y"),
-            Width = Int(args, "width"),
-            Height = Int(args, "height"),
-            File = Str(args, "file")!,
-        },
-        "query" => new QueryCommand {
-            Window = Str(args, "window")!,
-            Handle = Long(args, "handle"),
-            Process = Str(args, "process")!,
-            ClassName = Str(args, "className")!,
-            Foreground = Bool(args, "foreground"),
-            MaxDepth = Int(args, "maxDepth") is int d and > 0 ? d : 6,
-            MaxNodes = Int(args, "maxNodes") is int n and > 0 ? n : 1000,
-        },
-        "find" or "wait-for" => new FindCommand {
-            Window = Str(args, "window")!,
-            Handle = Long(args, "handle"),
-            Process = Str(args, "process")!,
-            ClassName = Str(args, "className")!,
-            Foreground = Bool(args, "foreground"),
-            By = Str(args, "by") ?? "name",
-            Value = Str(args, "value")!,
-            Timeout = Int(args, "timeout"),
-        },
-        "record" => new RecordCommand {
-            Action = Str(args, "action")!,
-            Window = Str(args, "window")!,
-            Handle = Long(args, "handle"),
-            Process = Str(args, "process")!,
-            ClassName = Str(args, "className")!,
-            Foreground = Bool(args, "foreground"),
-            X = Int(args, "x"),
-            Y = Int(args, "y"),
-            Width = Int(args, "width"),
-            Height = Int(args, "height"),
-            Fps = Int(args, "fps"),
-            DurationMs = Int(args, "durationMs"),
-            MaxWidth = Int(args, "maxWidth"),
-            File = Str(args, "file")!,
-        },
-        "launch" => new LaunchCommand {
-            Path = Str(args, "path")!,
-            Arguments = Str(args, "arguments")!,
-            WorkingDirectory = Str(args, "workingDirectory")!,
-            Timeout = Int(args, "timeout"),
-        },
-        "drag" => BuildDragCommand(args),
-        "click" => BuildClickCommand(args),
-        "displays" => new DisplaysCommand(),
-        "invoke" => new InvokeCommand {
-            Window = Str(args, "window")!,
-            Handle = Long(args, "handle"),
-            Process = Str(args, "process")!,
-            ClassName = Str(args, "className")!,
-            Foreground = Bool(args, "foreground"),
-            By = Str(args, "by") ?? "name",
-            Value = Str(args, "value")!,
-            Action = Str(args, "action") ?? "invoke",
-            Text = Str(args, "text")!,
-        },
-        _ => null, // unknown name — the caller reports unknown-tool; never guess a command (#201)
-    };
-
-    /// <summary>Maps the drag tool's nested <c>from</c>/<c>to</c>/<c>path</c> arguments onto a <see cref="DragCommand"/>.</summary>
-    private static DragCommand BuildDragCommand(JsonObject args) {
-        JsonObject from = args["from"] as JsonObject ?? [];
-        JsonObject to = args["to"] as JsonObject ?? [];
-        return new DragCommand {
-            Window = Str(args, "window")!,
-            Handle = Long(args, "handle"),
-            Process = Str(args, "process")!,
-            ClassName = Str(args, "className")!,
-            Foreground = Bool(args, "foreground"),
-            FromBy = Str(from, "by") ?? "name",
-            FromValue = Str(from, "value")!,
-            FromX = Int(from, "x"),
-            FromY = Int(from, "y"),
-            ToBy = Str(to, "by") ?? "name",
-            ToValue = Str(to, "value")!,
-            ToX = Int(to, "x"),
-            ToY = Int(to, "y"),
-            PathSpec = BuildPathSpec(args["path"] as JsonArray),
-        };
-    }
-
-    /// <summary>Maps the click tool's nested <c>at</c> endpoint and button/count onto a <see cref="ClickCommand"/>.</summary>
-    private static ClickCommand BuildClickCommand(JsonObject args) {
-        JsonObject at = args["at"] as JsonObject ?? [];
-        return new ClickCommand {
-            Window = Str(args, "window")!,
-            Handle = Long(args, "handle"),
-            Process = Str(args, "process")!,
-            ClassName = Str(args, "className")!,
-            Foreground = Bool(args, "foreground"),
-            By = Str(at, "by") ?? "name",
-            Value = Str(at, "value")!,
-            X = Int(at, "x"),
-            Y = Int(at, "y"),
-            Button = Str(args, "button") ?? "left",
-            Count = Int(args, "count") is int c and > 0 ? c : 1,
-        };
-    }
-
-    /// <summary>Flattens the drag tool's <c>path</c> array of <c>{ x, y }</c> points into DragCommand's <c>x,y;x,y</c> spec.</summary>
-    private static string BuildPathSpec(JsonArray? path) {
-        if (path is null || path.Count == 0) {
-            return string.Empty;
-        }
-        List<string> pairs = [];
-        foreach (JsonNode? node in path) {
-            if (node is JsonObject p) {
-                pairs.Add($"{Int(p, "x")},{Int(p, "y")}");
-            }
-        }
-        return string.Join(";", pairs);
-    }
+    internal static Command? BuildCommand(string name, JsonObject args) =>
+        ToolCatalog.TryGet(name, out ToolDescriptor descriptor)
+            ? descriptor.BuildCommand(args)
+            : null; // unknown name — the caller reports unknown-tool; never guess a command (#201)
 
     // -------------------------------------------------------------------------------------------
     // stdio transport
@@ -1341,13 +1108,4 @@ public static class AgentServer {
 
     private static string? Str(JsonObject a, string key) =>
         a[key] is JsonValue v && v.TryGetValue(out string? s) ? s : null;
-
-    private static long Long(JsonObject a, string key) =>
-        a[key] is JsonValue v && v.TryGetValue(out long l) ? l : 0;
-
-    private static int Int(JsonObject a, string key) =>
-        a[key] is JsonValue v && v.TryGetValue(out int i) ? i : 0;
-
-    private static bool Bool(JsonObject a, string key) =>
-        a[key] is JsonValue v && v.TryGetValue(out bool b) && b;
 }

--- a/tests/MCEControl.xUnit/Agent/CommandTersifierTests.cs
+++ b/tests/MCEControl.xUnit/Agent/CommandTersifierTests.cs
@@ -86,6 +86,38 @@ public class CommandTersifierTests {
     }
 
     [Fact]
+    public void Record_ShowsTarget_NotABareName() {
+        // #205: record had NO formatter and rendered as a bare "record" on the overlay. It mirrors
+        // capture (same window-or-region targeting).
+        string s = CommandTersifier.ForAgentTool("record", new JsonObject { ["window"] = "Clock" }, CommandOutcome.Ok);
+        Assert.Equal("record window=\"Clock\"", s);
+    }
+
+    [Fact]
+    public void Launch_ShowsQuotedPath_NotABareName() {
+        // #205: launch had NO formatter and rendered as a bare "launch" on the overlay.
+        string s = CommandTersifier.ForAgentTool("launch", new JsonObject { ["path"] = @"C:\Windows\notepad.exe" }, CommandOutcome.Ok);
+        Assert.Equal("launch \"C:\\Windows\\notepad.exe\"", s);
+    }
+
+    [Fact]
+    public void Click_PixelEndpoint_ShowsCoordinates() {
+        JsonObject args = new() { ["at"] = new JsonObject { ["x"] = 10, ["y"] = 20 } };
+        string s = CommandTersifier.ForAgentTool("click", args, CommandOutcome.Ok);
+        Assert.Equal("click 10,20", s);
+    }
+
+    [Fact]
+    public void Displays_IsArgumentless_RendersAsItsName() {
+        Assert.Equal("displays", CommandTersifier.ForAgentTool("displays", [], CommandOutcome.Ok));
+    }
+
+    [Fact]
+    public void UnknownTool_FallsBackToTheBareName() {
+        Assert.Equal("hover", CommandTersifier.ForAgentTool("hover", [], CommandOutcome.Ok));
+    }
+
+    [Fact]
     public void RawCommand_PrefixesSend_AndClipsLongCommands() {
         Assert.Equal("send winr", CommandTersifier.ForRawCommand("winr"));
         Assert.StartsWith("send ", CommandTersifier.ForRawCommand(new string('x', 80)));

--- a/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
+++ b/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
@@ -1,0 +1,141 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Registry completeness and equivalence pins for the #205 <see cref="ToolCatalog"/>. The catalog
+/// replaced ~8 hand-synced switches/lists; these tests pin the tool NAMES and the migrated policy
+/// sets so an accidental drop (or a silent flag flip) fails loudly instead of drifting.
+/// </summary>
+[Collection("AgentSerial")]
+public class ToolCatalogTests {
+    /// <summary>The ten gated agent tools, in the order tools/list advertises them. Pinned by name.</summary>
+    private static readonly string[] CatalogNames = [
+        "capture", "query", "displays", "find", "wait-for", "invoke", "drag", "click", "record", "launch",
+    ];
+
+    /// <summary>The meta-tools that are deliberately NOT in the catalog (no 1:1 Command mapping).</summary>
+    private static readonly string[] MetaToolNames = ["send_command", "provision-session", "end-session"];
+
+    [Fact]
+    public void Catalog_ContainsExactlyTheGatedAgentTools_InToolsListOrder() {
+        Assert.Equal(CatalogNames, ToolCatalog.All.Select(d => d.Name));
+    }
+
+    [Fact]
+    public void EveryDescriptor_IsComplete_SchemaFactoryInstanceAndTersifier() {
+        foreach (ToolDescriptor d in ToolCatalog.All) {
+            // Schema: a complete tools/list entry whose name matches the descriptor.
+            JsonObject schema = d.BuildSchema();
+            Assert.Equal(d.Name, schema["name"]!.GetValue<string>());
+            Assert.False(string.IsNullOrWhiteSpace(schema["description"]!.GetValue<string>()));
+            JsonObject inputSchema = schema["inputSchema"]!.AsObject();
+            Assert.Equal("object", inputSchema["type"]!.GetValue<string>());
+            Assert.NotNull(inputSchema["properties"]);
+            Assert.NotNull(inputSchema["required"]);
+
+            // Factories: both the tool-call mapping and the provisioning instance produce a command.
+            Assert.NotNull(d.BuildCommand([]));
+            Assert.NotNull(d.CreateCommandInstance());
+
+            // Tersifier: every tool has a REAL formatter. Only the argument-less `displays` may render
+            // as its bare name — a bare name for any other tool is exactly the record/launch drift
+            // this registry fixed (#205).
+            string label = d.Tersify([]);
+            Assert.False(string.IsNullOrWhiteSpace(label));
+            Assert.StartsWith(d.Name, label, System.StringComparison.Ordinal);
+            if (d.Name != "displays") {
+                Assert.NotEqual(d.Name, label);
+            }
+        }
+    }
+
+    [Fact]
+    public void ToolsList_IsExactlyTheCatalogPlusTheMetaTools() {
+        JsonObject resp = AgentServer.Dispatch(new JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"] = 1,
+            ["method"] = "tools/list",
+        })!;
+
+        List<string> names = [];
+        foreach (JsonNode? tool in resp["result"]!.AsObject()["tools"]!.AsArray()) {
+            names.Add(tool!["name"]!.GetValue<string>());
+        }
+
+        // Exact, ordered pin: dropping a tool from the catalog (or a meta-tool from BuildToolsList)
+        // must fail this test, not silently shrink the advertised surface.
+        Assert.Equal([.. CatalogNames, .. MetaToolNames], names);
+    }
+
+    [Fact]
+    public void GateMembership_IsCatalogMembership() {
+        foreach (string name in CatalogNames) {
+            Assert.True(ToolCatalog.Contains(name), $"'{name}' must be in the catalog (tools/call gate).");
+        }
+        // Meta-tools are dispatched by their own special cases BEFORE the catalog gate — they must not
+        // also be catalog members, or they'd be double-dispatched as agent commands.
+        foreach (string name in MetaToolNames) {
+            Assert.False(ToolCatalog.Contains(name), $"meta-tool '{name}' must NOT be in the catalog.");
+        }
+        Assert.False(ToolCatalog.Contains("hover"));
+        // The historical gate pattern was case-sensitive; the catalog lookup must stay ordinal.
+        Assert.False(ToolCatalog.Contains("Capture"));
+    }
+
+    [Fact]
+    public void IsObservation_ExactlyQueryCaptureFindWaitFor() {
+        string[] observation = ["query", "capture", "find", "wait-for"];
+        foreach (ToolDescriptor d in ToolCatalog.All) {
+            Assert.Equal(observation.Contains(d.Name), d.IsObservation);
+        }
+    }
+
+    [Fact]
+    public void SerializesOnInput_ExactlyDrag_InTheCatalog() {
+        foreach (ToolDescriptor d in ToolCatalog.All) {
+            Assert.Equal(d.Name == "drag", d.SerializesOnInput);
+        }
+        // send_command is a meta-tool special case in AgentServer (it serializes indirectly via the
+        // dispatcher thread, #195) — the public predicate must still report it.
+        Assert.True(AgentServer.SerializesOnInputLock("send_command"));
+    }
+
+    [Fact]
+    public void ProvisionedByDefault_EverythingExceptLaunch_AndDefaultCommandsMatch() {
+        foreach (ToolDescriptor d in ToolCatalog.All) {
+            Assert.Equal(d.Name != "launch", d.ProvisionedByDefault);
+        }
+        // SessionProvisioner.DefaultCommands is derived from the catalog; pin the exact historical set.
+        Assert.Equal(
+            ["capture", "query", "displays", "find", "wait-for", "invoke", "drag", "click", "record"],
+            SessionProvisioner.DefaultCommands);
+    }
+
+    [Fact]
+    public void BuildCommand_EveryTool_ProducesItsCommandType() {
+        Dictionary<string, System.Type> expected = new() {
+            ["capture"] = typeof(CaptureCommand),
+            ["query"] = typeof(QueryCommand),
+            ["displays"] = typeof(DisplaysCommand),
+            ["find"] = typeof(FindCommand),
+            ["wait-for"] = typeof(FindCommand),
+            ["invoke"] = typeof(InvokeCommand),
+            ["drag"] = typeof(DragCommand),
+            ["click"] = typeof(ClickCommand),
+            ["record"] = typeof(RecordCommand),
+            ["launch"] = typeof(LaunchCommand),
+        };
+        foreach (ToolDescriptor d in ToolCatalog.All) {
+            Assert.Equal(expected[d.Name], d.BuildCommand([]).GetType());
+            Assert.Equal(expected[d.Name], d.CreateCommandInstance().GetType());
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
+++ b/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
@@ -19,10 +19,10 @@ namespace MCEControl.xUnit.Commands;
 /// </summary>
 public class AgentCommandStructuralGateTests {
     /// <summary>
-    /// Every tool name in AgentServer's tools/call gate whitelist (the
-    /// <c>name is "capture" or "query" or ...</c> pattern the AgentCommandsEnabled check guards).
-    /// Kept as a test-side list because the whitelist is a C# pattern, not reflectable data; if a
-    /// name is added there without being added here, the reviewer checklist is this comment.
+    /// Every tool name in AgentServer's tools/call gate — which since #205 is exactly the
+    /// <see cref="ToolCatalog"/> membership. Kept as an INDEPENDENT test-side pin (not read from the
+    /// catalog) so removing or renaming a catalog entry can't silently shrink this enforcement;
+    /// <c>ToolCatalogTests</c> pins the same list against the catalog itself.
     /// </summary>
     private static readonly string[] GatedToolNames = [
         "capture", "query", "displays", "find", "wait-for", "invoke", "record", "launch", "drag", "click",

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -46,6 +46,9 @@ public class AgentServerTests {
     [InlineData("wait-for", false)]
     [InlineData("record", false)]
     [InlineData("invoke", false)]
+    [InlineData("click", false)]
+    [InlineData("displays", false)]
+    [InlineData("launch", false)]
     public void SerializesOnInputLock_OnlyGlobalInputActuation(string tool, bool expected) {
         Assert.Equal(expected, AgentServer.SerializesOnInputLock(tool));
     }


### PR DESCRIPTION
Fixes #205

## What

Per-tool knowledge for the ten gated agent tools was scattered across ~8 hand-synced sites; each new tool was shotgun surgery and drift had already landed (`CommandTersifier.ForAgentTool` was missing `record`/`launch`; the `AgentServer` header comment still said four tools). This PR consolidates all of it into one registry.

- **`ToolDescriptor`** (`src/Agent/ToolDescriptor.cs`): one record per tool — `Name`, `BuildSchema` (the existing hand-written `tools/list` schema, relocated verbatim), `BuildCommand` (MCP args → `Command`), `CreateCommandInstance` (provisioning serialization), `Tersify`, and the policy flags `SerializesOnInput`, `IsObservation`, `ProvisionedByDefault`.
- **`ToolCatalog`** (`src/Agent/ToolCatalog.cs`): the static registry of the ten gated tools, in `tools/list` order: `capture`, `query`, `displays`, `find`, `wait-for`, `invoke`, `drag`, `click`, `record`, `launch`.

## Sites collapsed into catalog lookups

1. `AgentServer.BuildToolsList()` — iterates the catalog, then adds the meta-tools.
2. The tools/call gate whitelist (`name is "capture" or …`) — now `ToolCatalog.Contains(name)` (ordinal, preserving case-sensitivity).
3. `AgentServer.BuildCommand` — dispatches through `descriptor.BuildCommand`; unknown name still returns `null` → the #201 `unknown-tool` refusal (tests unchanged and green).
4. `AgentServer.SerializesOnInputLock` — catalog flag, plus the explicit `send_command` special case (it serializes **indirectly** via the dispatcher thread per #195; membership preserved exactly — the predicate still returns `true` for it).
5. `AgentSession.IsObservationTool` — the `IsObservation` flag (`query`/`capture`/`find`/`wait-for`).
6. `CommandTersifier.ForAgentTool` — per-tool body from `descriptor.Tersify`; formatting building blocks (`Target`/`Selector`/`Endpoint`) stay in `CommandTersifier` as internals.
7. `SessionProvisioner.DefaultCommands` — derived from `ProvisionedByDefault` (everything but `launch`, matching the historical set exactly, order included).
8. `SessionProvisioner.CreateEnabledCommand` — catalog lookup gated on `ProvisionedByDefault`, so `launch` remains non-provisionable exactly as before.

**Meta-tools** (`send_command`, `provision-session`, `end-session`) stay explicitly special-cased next to the catalog in `AgentServer`, with comments explaining why: they don't map 1:1 onto a `Command` in the loaded table and carry their own gating (#153 transport-sensitive gate, #138 provisioning opt-in).

## Behavior

Identical by design — schemas, error envelopes, gating, and the #195 dispatch/threading flow (`RunSendCommand`/`RunAgentCommand`) are untouched; the schemas and argument mappings were relocated verbatim. The **only** behavior change is the deliberate drift fix: `record` and `launch` now tersify on the overlay/log (`record window="Clock"`, `launch "C:\…\notepad.exe"`) instead of rendering as bare tool names. No pre-existing test had pinned that gap, so none needed updating.

## Doc drift fixed (standing rule: guidance must match the surface)

- `AgentServer` header comment: "capture/query/find/invoke" → the catalog set.
- `AgentInstructions.md`: the SECURITY gated-tool list was missing `wait-for`.
- `docs/agent-server-architecture.md`: stale four/five-tool enumerations updated; new `ToolCatalog`/`ToolDescriptor` seam section.
- `docs/agent-server.md`: intro enumeration was missing `record`.
- `UiaService.Invoke` doc said "5s timeout" vs the 500 ms `InvokeFindTimeoutMs` code — now references the constant.

## Tests

`dotnet build` and full `dotnet test` green locally: **685 passed, 0 failed, 22 skipped** (the usual desktop-input skips). New `ToolCatalogTests` pin the registry by NAME (catalog order, tools/list = catalog + meta-tools exactly, descriptor completeness incl. "no bare-name tersifier", gate membership, and the three policy sets); `CommandTersifierTests` gain `record`/`launch`/`click`/`displays`/unknown-fallback pins; the `SerializesOnInputLock` theory gains `click`/`displays`/`launch` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm