### PR TITLE
Arch: one explicit CommandRegistry replaces three hidden command-registration conventions

### DIFF
--- a/docs/agent-server-architecture.md
+++ b/docs/agent-server-architecture.md
@@ -96,7 +96,10 @@ the house pattern:
   installs the fresh `Reply`, and deep-clones `EmbeddedCommands`. A reflection hygiene test
   (`CommandClonePropertyRoundTripTests`) round-trips every public settable property of every
   command through Clone.
-- `BuiltInCommands` returning the command with `Enabled=false` by default.
+- `BuiltInCommands` returning the command with `Enabled=false` by default, referenced
+  explicitly by the type's one-line `CommandRegistry.Entries` entry (#204) — the single
+  registration point that drives serialization, the invoker's built-ins table, and the
+  registry-completeness hygiene test (`CommandRegistryTests`).
 - `[XmlAttribute]` on serializable props (all-lowercase names — see `XmlNameCasingTests`, #200).
 
 `AgentCommand` owns a **sealed** `Execute()` template method: the base

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -445,7 +445,7 @@ CodeProject sample) because it is load-bearing for the emergency stop; only the 
 
 ## Extensibility Points
 
-1. **New Command Types**: Inherit from `Command`, implement `Execute()`, add to `Command.GetDerivedClassesCollection()`
+1. **New Command Types** (#204): Inherit from `Command` (agent tools: from the gated `AgentCommand` bases, #208), implement `Execute()`, give the type a `public static List<Command> BuiltInCommands` property, and add **one line** to `CommandRegistry.Entries` (`src/Commands/CommandRegistry.cs`) — `(xmlName, type, builtIns factory)`. That single entry drives XML serialization (both the top-level `commandArray` and embedded-command element maps, via `XmlAttributeOverrides`), the invoker's built-ins table, and the command hygiene tests (`CommandRegistryTests` fails the build for an unregistered command type)
 2. **New Communication Services**: Inherit from `ServiceBase`, implement notification pattern
 3. **Custom Input Simulation**: Extend `WindowsInput` namespace
 4. **Plugin System**: None currently (all commands compiled in)
@@ -455,7 +455,7 @@ CodeProject sample) because it is load-bearing for the emergency stop; only the 
 - **Singleton**: MainWindow, Logger, TelemetryService, UpdateService
 - **Command Pattern**: ICommand, Command, CommandInvoker
 - **Observer Pattern**: ServiceBase notifications via delegates
-- **Factory Pattern**: CommandInvoker.Create(), Command.BuiltInCommands
+- **Factory Pattern**: CommandInvoker.Create(), the per-command `BuiltInCommands` factories referenced explicitly by `CommandRegistry.Entries` (#204)
 - **Strategy Pattern**: Different Command implementations
 - **Facade Pattern**: InputSimulator wraps KeyboardSimulator and MouseSimulator
 - **Lazy Initialization**: Lazy<T> for singletons

--- a/src/Commands/CaptureCommand.cs
+++ b/src/Commands/CaptureCommand.cs
@@ -34,7 +34,7 @@ public class CaptureCommand : WindowTargetingAgentCommand {
     [XmlAttribute("file")]
     public string File { get; set; } = null!;
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [new CaptureCommand { Cmd = "capture" }];
     }
 

--- a/src/Commands/CharsCommand.cs
+++ b/src/Commands/CharsCommand.cs
@@ -19,7 +19,7 @@ namespace MCEControl;
 public class CharsCommand : Command {
     public const string CmdPrefix = "chars:";
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
             new CharsCommand { Cmd = $"{CmdPrefix}" },
         ];

--- a/src/Commands/ClickCommand.cs
+++ b/src/Commands/ClickCommand.cs
@@ -34,7 +34,7 @@ public class ClickCommand : WindowTargetingAgentCommand {
     // "wait a beat, then fail cleanly" rather than blocking indefinitely.
     private const int FindTimeoutMs = 3000;
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [new ClickCommand { Cmd = "click" }];
     }
 

--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -12,9 +12,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Xml;
 using System.Xml.Serialization;
 
 namespace MCEControl;
@@ -30,29 +27,14 @@ public abstract class Command : ICommand {
         Enabled = false; // SECURITY: Explicity
         UserDefined = false; // TELEMERTRY: Explicit
     }
-    public static List<Command> BuiltInCommands { get => []; }
 
     [XmlAttribute("cmd")]
     public string Cmd { get => cmd; set => cmd = value; }
-    [XmlElement("chars", typeof(CharsCommand))]
-    [XmlElement("startprocess", typeof(StartProcessCommand))]
-    [XmlElement("sendinput", typeof(SendInputCommand))]
-    [XmlElement("sendmessage", typeof(SendMessageCommand))]
-    [XmlElement("setforegroundwindow", typeof(SetForegroundWindowCommand))]
-    [XmlElement("shutdown", typeof(ShutdownCommand))]
-    [XmlElement("pause", typeof(PauseCommand))]
-    [XmlElement("mouse", typeof(MouseCommand))]
-    [XmlElement("mceccommand", typeof(McecCommand))]
-    [XmlElement("capture", typeof(CaptureCommand))]
-    [XmlElement("query", typeof(QueryCommand))]
-    [XmlElement("find", typeof(FindCommand))]
-    [XmlElement("invoke", typeof(InvokeCommand))]
-    [XmlElement("drag", typeof(DragCommand))]
-    [XmlElement("launch", typeof(LaunchCommand))]
-    [XmlElement("click", typeof(ClickCommand))]
-    [XmlElement("displays", typeof(DisplaysCommand))]
-    [XmlElement("record", typeof(RecordCommand))]
-    [XmlElement(typeof(Command))]
+
+    // SERIALIZATION (#204): the polymorphic element-name map for embedded commands (one
+    // [XmlElement("name", typeof(T))] per command type, formerly hardcoded here) now comes from
+    // CommandRegistry.CreateXmlOverrides(), applied by SerializedCommands' cached serializer —
+    // register a new command type there, not here.
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Serializable")]
     public List<Command> EmbeddedCommands { get; set; } = null!;
 
@@ -124,17 +106,5 @@ public abstract class Command : ICommand {
         // how is PII protected: the name of the command, key, is not user definable
         TelemetryService.Instance.TrackMetric($"{(UserDefined ? "<userDefined>" : cmd)} Executed", 1);
         return true;
-    }
-
-    /// <summary>
-    /// https://stackoverflow.com/questions/5411694/get-all-inherited-classes-of-an-abstract-class
-    /// </summary>
-    public static ICollection<Command> GetDerivedClassesCollection() {
-        List<Command> objects = [];
-        foreach (Type type in typeof(Command).Assembly.GetTypes()
-            .Where(myType => myType.IsClass && !myType.IsAbstract && myType.IsSubclassOf(typeof(Command)))) {
-            objects.Add((Command)Activator.CreateInstance(type)!);
-        }
-        return objects;
     }
 }

--- a/src/Commands/CommandDispatchCompletion.cs
+++ b/src/Commands/CommandDispatchCompletion.cs
@@ -15,9 +15,10 @@ namespace MCEControl;
 ///
 /// Deliberately implements <see cref="ICommand"/> directly rather than deriving from
 /// <see cref="Command"/>: it is dispatcher bookkeeping, not a command — it must never appear in the
-/// command table (<see cref="Command.GetDerivedClassesCollection"/> reflects over Command
-/// subclasses), is never gated on <c>Enabled</c>, and is exempt from the #154 queue bounds (one per
-/// completion-tracked enqueue, bounded by the caller's own concurrency).
+/// command table or in <see cref="CommandRegistry.Entries"/> (whose completeness test sweeps
+/// concrete <see cref="Command"/> subclasses, #204), is never gated on <c>Enabled</c>, and is
+/// exempt from the #154 queue bounds (one per completion-tracked enqueue, bounded by the caller's
+/// own concurrency).
 /// </summary>
 internal sealed class CommandDispatchCompletion : ICommand {
     // RunContinuationsAsynchronously so completing on the dispatcher thread never inlines an

--- a/src/Commands/CommandInvoker.cs
+++ b/src/Commands/CommandInvoker.cs
@@ -12,7 +12,6 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -91,21 +90,23 @@ public class CommandInvoker : Hashtable {
     /// </summary>
     /// <returns></returns>
     private static CommandInvoker CreateBuiltIns(bool disableInternalCommands = false) {
+        // Debug backstop (#204): a concrete Command subclass without a CommandRegistry entry would
+        // silently ship no built-ins and be unserializable — fail loudly at startup in DEBUG builds.
+        // The real gate is CommandRegistryTests, which reds the build for the same drift.
+        CommandRegistry.DebugAssertComplete();
+
         CommandInvoker commands = [];
 
-        // Add the built-ins that are defiend in the `Command`-derived classes
         // SECURITY: Note, by default `Enabled` is set to `false` for all of these.
         if (disableInternalCommands)
             return commands;
 
-        // Add the built-ins defined in the Command-derived classes
-        foreach (Command cmdType in Command.GetDerivedClassesCollection()) {
-            PropertyInfo? propertyInfo = cmdType.GetType().GetProperty("BuiltInCommands", BindingFlags.Public | BindingFlags.Static);
-            if (propertyInfo != null) {
-                // Use the PropertyInfo to retrieve the value from the type by not passing in an instance
-                foreach (Command builtinCmd in (List<Command>)propertyInfo.GetValue(null, null)!) {
-                    commands.Add(builtinCmd);
-                }
+        // One explicit registry (#204): each command type's built-in prototypes come from its
+        // registry entry — no assembly scan instantiating every type, no magic static discovered
+        // by reflection that silently registers nothing when misdeclared.
+        foreach (CommandRegistryEntry entry in CommandRegistry.Entries) {
+            foreach (Command builtinCmd in entry.BuiltIns()) {
+                commands.Add(builtinCmd);
             }
         }
         Logger.Instance.Log4.Info($"{commands.GetType().Name}: {commands.Count} built-in commands defined");

--- a/src/Commands/CommandRegistry.cs
+++ b/src/Commands/CommandRegistry.cs
@@ -1,0 +1,113 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Xml.Serialization;
+
+namespace MCEControl;
+
+/// <summary>
+/// THE single place a command type is registered (#204). Adding a command used to require edits in
+/// three invisible places, each failing silently when forgotten:
+/// <list type="number">
+/// <item>an <c>[XmlElement("name", typeof(T))]</c> on <see cref="Command.EmbeddedCommands"/>,</item>
+/// <item>the same list repeated as <c>[XmlArrayItem]</c> on <see cref="SerializedCommands.commandArray"/>,</item>
+/// <item>a magic <c>public static new BuiltInCommands</c> property discovered by reflection
+/// (without <c>FlattenHierarchy</c> — misdeclare it and the command registered nothing).</item>
+/// </list>
+/// Now ONE entry in <see cref="Entries"/> drives all three: the serializer's polymorphic
+/// element-name maps (<see cref="CreateXmlOverrides"/>), the invoker's built-ins table
+/// (<c>CommandInvoker.CreateBuiltIns</c>), and the hygiene gate
+/// (<c>CommandRegistryTests</c> — an unregistered command type is a red build, plus the
+/// <see cref="DebugAssertComplete"/> debug backstop).
+///
+/// <para><b>To add a command type</b>: derive from <see cref="Command"/> (agent tools: from the
+/// gated <c>AgentCommand</c> bases, #208), give it a <c>public static List&lt;Command&gt;
+/// BuiltInCommands</c> property, and add ONE line to <see cref="Entries"/>.</para>
+/// </summary>
+public static class CommandRegistry {
+    /// <summary>
+    /// One line per command type. Order matches the legacy attribute lists for wire-format parity.
+    /// WIRE FORMAT: XmlName is what .commands files contain — never rename an existing entry.
+    /// </summary>
+    public static IReadOnlyList<CommandRegistryEntry> Entries { get; } = [
+        new("chars", typeof(CharsCommand), () => CharsCommand.BuiltInCommands),
+        new("startprocess", typeof(StartProcessCommand), () => StartProcessCommand.BuiltInCommands),
+        new("sendinput", typeof(SendInputCommand), () => SendInputCommand.BuiltInCommands),
+        new("sendmessage", typeof(SendMessageCommand), () => SendMessageCommand.BuiltInCommands),
+        new("setforegroundwindow", typeof(SetForegroundWindowCommand), () => SetForegroundWindowCommand.BuiltInCommands),
+        new("shutdown", typeof(ShutdownCommand), () => ShutdownCommand.BuiltInCommands),
+        new("pause", typeof(PauseCommand), () => PauseCommand.BuiltInCommands),
+        new("mouse", typeof(MouseCommand), () => MouseCommand.BuiltInCommands),
+        new("mceccommand", typeof(McecCommand), () => McecCommand.BuiltInCommands),
+        new("capture", typeof(CaptureCommand), () => CaptureCommand.BuiltInCommands),
+        new("query", typeof(QueryCommand), () => QueryCommand.BuiltInCommands),
+        new("find", typeof(FindCommand), () => FindCommand.BuiltInCommands),
+        new("invoke", typeof(InvokeCommand), () => InvokeCommand.BuiltInCommands),
+        new("drag", typeof(DragCommand), () => DragCommand.BuiltInCommands),
+        new("launch", typeof(LaunchCommand), () => LaunchCommand.BuiltInCommands),
+        new("click", typeof(ClickCommand), () => ClickCommand.BuiltInCommands),
+        new("displays", typeof(DisplaysCommand), () => DisplaysCommand.BuiltInCommands),
+        new("record", typeof(RecordCommand), () => RecordCommand.BuiltInCommands),
+    ];
+
+    /// <summary>
+    /// Builds the serializer attribute overrides that used to live as hardcoded attribute lists on
+    /// <see cref="Command.EmbeddedCommands"/> (the <c>[XmlElement]</c> set) and
+    /// <see cref="SerializedCommands.commandArray"/> (the <c>[XmlArrayItem]</c> set). An override
+    /// REPLACES the member's reflected attributes wholesale, so the <c>commandArray</c> wrapper
+    /// (<c>[XmlArray("commands", Order = 1)]</c> — Order required because the sibling
+    /// <c>XmlComment</c> member carries <c>Order = 0</c>) is restated here too.
+    ///
+    /// CRITICAL (caller contract): an <see cref="XmlSerializer"/> constructed WITH overrides is NOT
+    /// cached by the runtime — each construction emits a new dynamic assembly that is never
+    /// unloaded. The ONLY consumer must be a cached static serializer
+    /// (<c>SerializedCommands.Serializer</c>); never call this per-serialize.
+    /// </summary>
+    internal static XmlAttributeOverrides CreateXmlOverrides() {
+        XmlAttributes embedded = new();
+        XmlAttributes arrayItems = new() {
+            XmlArray = new XmlArrayAttribute("commands") { Order = 1 },
+        };
+        foreach (CommandRegistryEntry entry in Entries) {
+            embedded.XmlElements.Add(new XmlElementAttribute(entry.XmlName, entry.CommandType));
+            arrayItems.XmlArrayItems.Add(new XmlArrayItemAttribute(entry.XmlName, entry.CommandType));
+        }
+        // Parity with the legacy lists' un-named catch-all entries for the abstract base.
+        embedded.XmlElements.Add(new XmlElementAttribute(typeof(Command)));
+        arrayItems.XmlArrayItems.Add(new XmlArrayItemAttribute(typeof(Command)));
+
+        XmlAttributeOverrides overrides = new();
+        overrides.Add(typeof(Command), nameof(Command.EmbeddedCommands), embedded);
+        overrides.Add(typeof(SerializedCommands), nameof(SerializedCommands.commandArray), arrayItems);
+        return overrides;
+    }
+
+    /// <summary>
+    /// Debug-build backstop (#204): asserts every concrete <see cref="Command"/> subclass in the
+    /// product assembly has exactly one registry entry. Runs once per invoker creation — cheap, and
+    /// it catches a locally added-but-unregistered command the moment the app starts instead of at
+    /// test time. The REAL gate is <c>CommandRegistryTests</c>, which fails the build for the same
+    /// drift (both directions) on every CI run.
+    /// </summary>
+    [Conditional("DEBUG")]
+    internal static void DebugAssertComplete() {
+        List<Type> concrete = [.. typeof(Command).Assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && t.IsSubclassOf(typeof(Command)))];
+        List<string> missing = [.. concrete
+            .Where(t => !Entries.Any(e => e.CommandType == t))
+            .Select(t => t.Name)];
+        List<string> duplicates = [.. Entries
+            .GroupBy(e => e.CommandType)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key.Name)];
+        Debug.Assert(missing.Count == 0 && duplicates.Count == 0,
+            $"CommandRegistry (#204) is out of sync. Missing: [{string.Join(", ", missing)}]; " +
+            $"duplicated: [{string.Join(", ", duplicates)}]. Every concrete Command subclass needs " +
+            "exactly ONE CommandRegistry.Entries line — it drives serialization, the invoker's " +
+            "built-ins, and the hygiene tests (CommandRegistryTests).");
+    }
+}

--- a/src/Commands/CommandRegistryEntry.cs
+++ b/src/Commands/CommandRegistryEntry.cs
@@ -1,0 +1,26 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+
+namespace MCEControl;
+
+/// <summary>
+/// One row of <see cref="CommandRegistry.Entries"/> (#204) — everything the engine needs to know
+/// about one <see cref="Command"/> type, stated explicitly in one place.
+/// </summary>
+/// <param name="XmlName">
+/// The wire name of the command's element in .commands files (both as a top-level
+/// <c>commandArray</c> item and as an <c>EmbeddedCommands</c> child). MUST be all-lowercase:
+/// loading pipes every file through a lower-casing XSLT, so an uppercase name could be written but
+/// never read back (#200). Changing an existing name breaks every installed .commands file.
+/// </param>
+/// <param name="CommandType">The concrete <see cref="Command"/> subclass serialized under <paramref name="XmlName"/>.</param>
+/// <param name="BuiltIns">
+/// Factory for the command's built-in prototypes (each with <c>Enabled=false</c> by default —
+/// SECURITY). By convention this points at the type's <c>public static List&lt;Command&gt;
+/// BuiltInCommands</c> property — referenced EXPLICITLY here, never discovered by reflection (the
+/// old magic-static convention silently registered nothing when the property was misdeclared).
+/// </param>
+public sealed record CommandRegistryEntry(string XmlName, Type CommandType, Func<IEnumerable<Command>> BuiltIns);

--- a/src/Commands/DisplaysCommand.cs
+++ b/src/Commands/DisplaysCommand.cs
@@ -20,7 +20,7 @@ namespace MCEControl;
 /// <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
 public class DisplaysCommand : AgentCommand {
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [new DisplaysCommand { Cmd = "displays" }];
     }
 

--- a/src/Commands/DragCommand.cs
+++ b/src/Commands/DragCommand.cs
@@ -39,7 +39,7 @@ public class DragCommand : WindowTargetingAgentCommand {
     // fail cleanly" behaviour of invoke rather than blocking indefinitely.
     private const int FindTimeoutMs = 3000;
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [new DragCommand { Cmd = "drag" }];
     }
 

--- a/src/Commands/FindCommand.cs
+++ b/src/Commands/FindCommand.cs
@@ -18,7 +18,7 @@ public class FindCommand : WindowTargetingAgentCommand {
     [XmlAttribute("value")] public string Value { get; set; } = null!;
     [XmlAttribute("timeout")] public int Timeout { get; set; }
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
             new FindCommand { Cmd = "find" },
             new FindCommand { Cmd = "wait-for" },

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -18,7 +18,7 @@ public class InvokeCommand : WindowTargetingAgentCommand {
     [XmlAttribute("action")] public string Action { get; set; } = "invoke";
     [XmlAttribute("text")] public string Text { get; set; } = null!;
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [new InvokeCommand { Cmd = "invoke" }];
     }
 

--- a/src/Commands/LaunchCommand.cs
+++ b/src/Commands/LaunchCommand.cs
@@ -24,7 +24,7 @@ public class LaunchCommand : AgentCommand {
     [XmlAttribute("workingdirectory")] public string WorkingDirectory { get; set; } = null!;
     [XmlAttribute("timeout")] public int Timeout { get; set; }
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [new LaunchCommand { Cmd = "launch" }];
     }
 

--- a/src/Commands/McecCommand.cs
+++ b/src/Commands/McecCommand.cs
@@ -20,7 +20,7 @@ namespace MCEControl;
 /// </summary>
 public class McecCommand : Command {
     public const string CmdPrefix = "mcec:";
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
         new McecCommand { Cmd = $"{CmdPrefix}" },   // Commands that use form of "cmd:" must define a blank version
         new McecCommand { Cmd = $"{CmdPrefix }ver" },

--- a/src/Commands/MouseCommand.cs
+++ b/src/Commands/MouseCommand.cs
@@ -23,7 +23,7 @@ namespace MCEControl;
 public class MouseCommand : Command {
     public const string CmdPrefix = "mouse:";
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
             new MouseCommand{ Cmd = $"{CmdPrefix }" },  // Commands that use form of "cmd:" must define a blank version
             new MouseCommand{ Cmd = $"{CmdPrefix }lbc" },

--- a/src/Commands/PauseCommand.cs
+++ b/src/Commands/PauseCommand.cs
@@ -19,7 +19,7 @@ namespace MCEControl;
 public class PauseCommand : Command {
     public const string CmdPrefix = "pause:";
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
             new PauseCommand { Cmd = $"{CmdPrefix}" } // Commands that use form of "cmd:" must define a blank version
         ];

--- a/src/Commands/QueryCommand.cs
+++ b/src/Commands/QueryCommand.cs
@@ -18,7 +18,7 @@ public class QueryCommand : WindowTargetingAgentCommand {
     /// A clipped walk is reported via a <c>tree-truncated</c> warning. 0 means unbounded.</summary>
     [XmlAttribute("maxnodes")] public int MaxNodes { get; set; } = 1000;
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [new QueryCommand { Cmd = "query" }];
     }
 

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -44,7 +44,7 @@ public class RecordCommand : WindowTargetingAgentCommand {
     private const string DiscardedWarningDetail =
         "A previous recording auto-stopped and its GIF was never fetched; it has been discarded and replaced by this recording.";
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [new RecordCommand { Cmd = "record" }];
     }
 

--- a/src/Commands/SendInputCommand.cs
+++ b/src/Commands/SendInputCommand.cs
@@ -99,7 +99,7 @@ public class SendInputCommand : Command {
             new SendInputCommand() { Cmd="snapshot", vk="44", Shift=false, Ctrl=false, Alt=false },
             new SendInputCommand() { Cmd="zoom", vk="90", Shift=false, Ctrl=false, Alt=false },
         ];
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => _builtins;
     }
 

--- a/src/Commands/SendMessageCommand.cs
+++ b/src/Commands/SendMessageCommand.cs
@@ -36,7 +36,7 @@ public class SendMessageCommand : Command {
     private String windowName = null!;
     [XmlAttribute("windowname")] public String WindowName { get => windowName; set => windowName = value; }
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
               new SendMessageCommand() { Cmd = "maximize", Msg=274, wParam=61488, lParam=0 },
               new SendMessageCommand() { Cmd = "screensaver", Msg=274, wParam=61760, lParam=0 },

--- a/src/Commands/SerializedCommands.cs
+++ b/src/Commands/SerializedCommands.cs
@@ -35,32 +35,25 @@ public class SerializedCommands {
     [XmlAttribute("version")]
     public string Version = null!;
 
-    [XmlArray("commands", Order = 1)]
-    [XmlArrayItem("chars", typeof(CharsCommand))]
-    [XmlArrayItem("startprocess", typeof(StartProcessCommand))]
-    [XmlArrayItem("sendinput", typeof(SendInputCommand))]
-    [XmlArrayItem("sendmessage", typeof(SendMessageCommand))]
-    [XmlArrayItem("setforegroundwindow", typeof(SetForegroundWindowCommand))]
-    [XmlArrayItem("shutdown", typeof(ShutdownCommand))]
-    [XmlArrayItem("pause", typeof(PauseCommand))]
-    [XmlArrayItem("mouse", typeof(MouseCommand))]
-    [XmlArrayItem("mceccommand", typeof(McecCommand))]
-    [XmlArrayItem("capture", typeof(CaptureCommand))]
-    [XmlArrayItem("query", typeof(QueryCommand))]
-    [XmlArrayItem("find", typeof(FindCommand))]
-    [XmlArrayItem("invoke", typeof(InvokeCommand))]
-    [XmlArrayItem("drag", typeof(DragCommand))]
-    [XmlArrayItem("launch", typeof(LaunchCommand))]
-    [XmlArrayItem("click", typeof(ClickCommand))]
-    [XmlArrayItem("displays", typeof(DisplaysCommand))]
-    [XmlArrayItem("record", typeof(RecordCommand))]
-    [XmlArrayItem(typeof(Command))]
-
+    // SERIALIZATION (#204): the [XmlArray("commands", Order = 1)] wrapper and the polymorphic
+    // [XmlArrayItem("name", typeof(T))] map (one per command type, formerly hardcoded here) now
+    // come from CommandRegistry.CreateXmlOverrides(), applied via the cached Serializer below —
+    // register a new command type there, not here.
+    //
     // XmlSerialization does not work with List<>. Must use an array.
     // Must be public for serialization to work
     public Command[] commandArray = null!;
 
     [XmlIgnore] public int Count { get => (commandArray == null ? 0 : commandArray.Length); }
+
+    /// <summary>
+    /// THE XmlSerializer for .commands files, wired to the one explicit command registry (#204) via
+    /// XmlAttributeOverrides. CRITICAL: serializers constructed WITH overrides are NOT cached by the
+    /// runtime — every construction emits a fresh dynamic assembly that is never unloaded (a leak).
+    /// This static is the process-wide cache; XmlSerializer instance methods are thread-safe. Always
+    /// use it — never write `new XmlSerializer(typeof(SerializedCommands), ...)` at a call site.
+    /// </summary>
+    private static readonly XmlSerializer Serializer = new(typeof(SerializedCommands), CommandRegistry.CreateXmlOverrides());
 
     public SerializedCommands() {
     }
@@ -143,7 +136,7 @@ public class SerializedCommands {
         try {
             commands.Version = currentVersion;
             ucFS = new FileStream(userCommandsFile, FileMode.Create);
-            new XmlSerializer(typeof(SerializedCommands)).Serialize(ucFS, commands);
+            Serializer.Serialize(ucFS, commands);
         }
         catch (Exception e) {
             // TODO: Move MessageBox out of here into MainWindow
@@ -187,7 +180,7 @@ public class SerializedCommands {
             stm.Position = 0;
             lcReader = new XmlTextReader(stm); // lower-case reader
 
-            cmds = (SerializedCommands)new XmlSerializer(typeof(SerializedCommands)).Deserialize(lcReader)!;
+            cmds = (SerializedCommands)Serializer.Deserialize(lcReader)!;
         }
         catch (InvalidOperationException ex) {
             Logger.Instance.Log4.Error($"SerializedCommands: No commands loaded. Error parsing .commands XML. {ex.FullMessage()}");

--- a/src/Commands/SetForegroundWindowCmd.cs
+++ b/src/Commands/SetForegroundWindowCmd.cs
@@ -23,7 +23,7 @@ public class SetForegroundWindowCommand : Command {
     [XmlAttribute("appname")]
     public string AppName { get; set; } = null!;
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
               new SetForegroundWindowCommand() { Cmd = "activatecode", AppName ="code" },
               new SetForegroundWindowCommand() { Cmd = "activatenotepad", AppName="Notepad"  },

--- a/src/Commands/ShutdownCommand.cs
+++ b/src/Commands/ShutdownCommand.cs
@@ -17,7 +17,7 @@ namespace MCEControl;
 /// Summary description for ShutdownCommands.
 /// </summary>
 public class ShutdownCommand : Command {
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
             new ShutdownCommand{ Cmd = $"shutdown", Type = $"shutdown" },
             new ShutdownCommand{ Cmd = $"shutdown-hybrid", Type = $"shutdown-hybrid" },

--- a/src/Commands/StartProcessCommand.cs
+++ b/src/Commands/StartProcessCommand.cs
@@ -23,7 +23,7 @@ public class StartProcessCommand : Command {
     private String verb = null!;
     [XmlAttribute("verb")] public string Verb { get => verb; set => verb = value; }
 
-    public static new List<Command> BuiltInCommands {
+    public static List<Command> BuiltInCommands {
         get => [
               new StartProcessCommand() { Cmd = "code", File ="code" },
               new StartProcessCommand() { Cmd = "tada", File=@"C:\Windows\Media\tada.wav", Verb="Open"  },

--- a/tests/MCEControl.xUnit/CommandInvokerTests.cs
+++ b/tests/MCEControl.xUnit/CommandInvokerTests.cs
@@ -11,46 +11,10 @@ namespace MCEControl.xUnit;
 
 public class CommandInvokerTests
 {
-    // NOTE: This test is disabled because it uses MSTest PrivateType which is not available in .NET Core
-    // TODO: Refactor to use reflection or make the tested members internal with InternalsVisibleTo
-    /*
-    [Fact]
-    public void CreateBuiltIns_Test()
-    {
-        // There are currently 9 classses derived from Command
-        var cmdTypes = Command.GetDerivedClassesCollection();
-        Assert.Equal(9, cmdTypes.Count);
-
-        // Get # of built in commands defined
-        var builtIns = new List<Command>();
-        foreach (var cmdType in cmdTypes)
-        {
-            mstest.PrivateType cmdPt = new mstest.PrivateType(cmdType.GetType());
-            List<Command> listOfType = (List<Command>)cmdPt.GetStaticProperty(nameof(Command.BuiltInCommands));
-            foreach (var c in listOfType)
-                builtIns.Add(c);
-        }
-
-        // Ensure there are no duplicates
-        var query = builtIns.GroupBy(x => x.Cmd)
-          .Where(g => g.Count() > 1)
-          .Select(y => y.Key)
-          .ToList();
-        Assert.Empty(query);
-
-        // Invoke the CreateBuiltIns method and compare result to expected
-        // https://stackoverflow.com/questions/9122708/unit-testing-private-methods-in-c-sharp
-        CommandInvoker target = new CommandInvoker();
-        mstest.PrivateType pt = new mstest.PrivateType(typeof(CommandInvoker));
-        CommandInvoker returnedBuiltIns = (CommandInvoker)pt.InvokeStatic("CreateBuiltIns", false);
-        Assert.NotEmpty(returnedBuiltIns);
-        Assert.Equal(builtIns.Count, returnedBuiltIns.Count);
-
-        // Now test with disableBuiltIns true
-        returnedBuiltIns = (CommandInvoker)pt.InvokeStatic("CreateBuiltIns", true);
-        Assert.Empty(returnedBuiltIns);
-    }
-    */
+    // NOTE (#204): a long-dead commented-out CreateBuiltIns_Test lived here, written against the
+    // old reflection dance (Command.GetDerivedClassesCollection + magic BuiltInCommands statics),
+    // both now deleted. CommandRegistryTests covers built-in registration against the explicit
+    // CommandRegistry.
 
     [Fact]
     public void Create_Test()

--- a/tests/MCEControl.xUnit/Commands/CommandRegistryTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CommandRegistryTests.cs
@@ -1,0 +1,248 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// <para><b>THE COMMAND HYGIENE SUITE — index.</b> Four test classes together turn four kinds of
+/// silent drift into red builds whenever a command type is added or changed:</para>
+/// <list type="bullet">
+/// <item><b><c>CommandRegistryTests</c></b> (this file, #204): every concrete <see cref="Command"/>
+/// subclass appears exactly once in <see cref="CommandRegistry.Entries"/> (and vice versa), wire
+/// names are all-lowercase and unique, every entry's built-ins factory yields usable disabled-by-
+/// default prototypes, and the registry-driven serializer still writes/reads the established
+/// .commands wire format. Closes: "a new command compiles but silently can't be serialized and
+/// registers no built-ins" (the old three-hidden-conventions trap).</item>
+/// <item><b><c>XmlNameCasingTests</c></b> (#200): every serialized XML name reachable from the
+/// command types is all-lowercase. Closes: "a property saves fine but is silently dropped on load
+/// by the lower-casing XSLT".</item>
+/// <item><b><c>CommandClonePropertyRoundTripTests</c></b> (#207): <c>Clone(reply)</c> round-trips
+/// every public settable property of every command. Closes: "a property works from mcec.commands
+/// prototypes but arrives 0/null at execution".</item>
+/// <item><b><c>AgentCommandStructuralGateTests</c></b> (#208): every agent tool name maps to a
+/// command deriving from the gated <c>AgentCommand</c> base, whose sealed <c>Execute()</c> enforces
+/// <c>AgentCommandsEnabled</c>. Closes: "a new agent command skips the operator opt-in gate on the
+/// TCP/serial transports".</item>
+/// </list>
+/// <para>To add a command type: derive from <see cref="Command"/> (or the gated agent bases), give
+/// it a <c>public static List&lt;Command&gt; BuiltInCommands</c>, and add ONE line to
+/// <see cref="CommandRegistry.Entries"/> — this suite verifies everything else.</para>
+/// </summary>
+public class CommandRegistryTests {
+    private static List<Type> ConcreteCommandTypes => [.. typeof(Command).Assembly.GetTypes()
+        .Where(t => t.IsClass && !t.IsAbstract && t.IsSubclassOf(typeof(Command)))
+        .OrderBy(t => t.FullName, StringComparer.Ordinal)];
+
+    [Fact]
+    public void Sweep_FindsTheCommandTypes() {
+        // Guard the reflection sweep itself: if it ever came back (near-)empty, the completeness
+        // assertions below would vacuously pass.
+        List<Type> types = ConcreteCommandTypes;
+        Assert.True(types.Count >= 18, $"expected the sweep to find all command types, got {types.Count}");
+        Assert.Contains(typeof(CharsCommand), types);
+        Assert.Contains(typeof(RecordCommand), types);
+    }
+
+    [Fact]
+    public void EveryConcreteCommandSubclass_IsRegisteredExactlyOnce() {
+        List<Type> concrete = ConcreteCommandTypes;
+
+        List<string> missing = [.. concrete
+            .Where(t => !CommandRegistry.Entries.Any(e => e.CommandType == t))
+            .Select(t => t.Name)];
+        List<string> duplicated = [.. CommandRegistry.Entries
+            .GroupBy(e => e.CommandType)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key.Name)];
+        // The reverse direction: an entry whose type is not a concrete Command subclass (abstract,
+        // deleted, or foreign) would explode at serialize/built-ins time.
+        List<string> bogus = [.. CommandRegistry.Entries
+            .Where(e => !concrete.Contains(e.CommandType))
+            .Select(e => $"{e.XmlName} ({e.CommandType.Name})")];
+
+        Assert.True(missing.Count == 0,
+            $"Concrete Command subclass(es) missing from CommandRegistry.Entries: {string.Join(", ", missing)}. " +
+            "Add ONE registry line per command type (#204) — without it the command cannot be serialized " +
+            "and registers no built-ins.");
+        Assert.True(duplicated.Count == 0,
+            $"Command type(s) registered more than once in CommandRegistry.Entries: {string.Join(", ", duplicated)}.");
+        Assert.True(bogus.Count == 0,
+            $"CommandRegistry entries that are not concrete Command subclasses: {string.Join(", ", bogus)}.");
+    }
+
+    [Fact]
+    public void RegistryXmlNames_AreLowercaseAndUnique() {
+        // Loading pipes .commands files through a lower-casing XSLT (#200): an uppercase wire name
+        // could be written but would never bind on load. Uniqueness: two entries sharing a name
+        // would make deserialization of that element ambiguous.
+        List<string> notLowercase = [.. CommandRegistry.Entries
+            .Where(e => e.XmlName.Any(char.IsUpper) || string.IsNullOrWhiteSpace(e.XmlName))
+            .Select(e => e.XmlName)];
+        List<string> duplicated = [.. CommandRegistry.Entries
+            .GroupBy(e => e.XmlName, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)];
+
+        Assert.True(notLowercase.Count == 0,
+            $"Registry XmlName(s) not all-lowercase (or blank): {string.Join(", ", notLowercase)} — " +
+            "the .commands lower-casing XSLT means such an element is written but silently never read back (#200).");
+        Assert.True(duplicated.Count == 0,
+            $"Registry XmlName(s) used by more than one entry: {string.Join(", ", duplicated)}.");
+    }
+
+    [Fact]
+    public void RegistryBuiltInsFactories_YieldDisabledNamedPrototypes() {
+        foreach (CommandRegistryEntry entry in CommandRegistry.Entries) {
+            List<Command> builtIns = [.. entry.BuiltIns()];
+            Assert.True(builtIns.Count > 0,
+                $"Registry entry '{entry.XmlName}' produced no built-in prototypes — point BuiltIns at the type's BuiltInCommands.");
+            foreach (Command builtIn in builtIns) {
+                Assert.False(string.IsNullOrWhiteSpace(builtIn.Cmd),
+                    $"A built-in from registry entry '{entry.XmlName}' has a blank Cmd — the invoker would reject it.");
+                // SECURITY: built-ins ship disabled; the operator opts in per command.
+                Assert.False(builtIn.Enabled,
+                    $"Built-in '{builtIn.Cmd}' (registry entry '{entry.XmlName}') is Enabled by default — built-ins must ship disabled.");
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Wire format (#204): moving the [XmlElement]/[XmlArrayItem] maps into registry-built
+    // XmlAttributeOverrides must not change what .commands files look like.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Save_WritesEveryRegisteredType_UnderItsRegistryName() {
+        string tempFile = Path.GetTempFileName();
+        File.Delete(tempFile);
+        try {
+            SerializedCommands sc = new() {
+                commandArray = [.. CommandRegistry.Entries.Select(e => NewInstance(e, "hygiene_"))],
+            };
+            SerializedCommands.SaveCommands(tempFile, sc, "1.0.0.0");
+
+            XDocument doc = XDocument.Load(tempFile);
+            XElement commands = doc.Descendants().Single(el => el.Name.LocalName == "commands");
+            Assert.Equal("http://www.kindel.com/products/mcecontroller", commands.Name.NamespaceName);
+            Assert.Equal(
+                CommandRegistry.Entries.Select(e => e.XmlName),
+                commands.Elements().Select(el => el.Name.LocalName));
+        }
+        finally {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SaveLoad_RoundTrips_OneOfEveryRegisteredType_TopLevelAndEmbedded() {
+        string tempFile = Path.GetTempFileName();
+        File.Delete(tempFile);
+        try {
+            // Top level: one of each registered type. Embedded: a parent carrying one of each, to
+            // exercise the Command.EmbeddedCommands override map (distinct from commandArray's).
+            StartProcessCommand parent = new() {
+                Cmd = "hygiene_parent",
+                File = "x.exe",
+                EmbeddedCommands = [.. CommandRegistry.Entries.Select(e => NewInstance(e, "embedded_"))],
+            };
+            SerializedCommands original = new() {
+                commandArray = [.. CommandRegistry.Entries.Select(e => NewInstance(e, "hygiene_")), parent],
+            };
+
+            SerializedCommands.SaveCommands(tempFile, original, "1.0.0.0");
+            SerializedCommands loaded = SerializedCommands.LoadCommands(tempFile, "1.0.0.0");
+
+            Assert.NotNull(loaded);
+            Assert.Equal(CommandRegistry.Entries.Count + 1, loaded.commandArray.Length);
+            foreach (CommandRegistryEntry entry in CommandRegistry.Entries) {
+                Command topLevel = Assert.Single(loaded.commandArray, c => c.Cmd == $"hygiene_{entry.XmlName}");
+                Assert.IsType(entry.CommandType, topLevel);
+            }
+
+            StartProcessCommand? loadedParent = loaded.commandArray.Single(c => c.Cmd == "hygiene_parent") as StartProcessCommand;
+            Assert.NotNull(loadedParent);
+            Assert.NotNull(loadedParent.EmbeddedCommands);
+            Assert.Equal(CommandRegistry.Entries.Count, loadedParent.EmbeddedCommands.Count);
+            foreach (CommandRegistryEntry entry in CommandRegistry.Entries) {
+                Command embedded = Assert.Single(loadedParent.EmbeddedCommands, c => c.Cmd == $"embedded_{entry.XmlName}");
+                Assert.IsType(entry.CommandType, embedded);
+            }
+        }
+        finally {
+            File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// The established v3.0 wire names, FROZEN. Installed .commands files contain these element
+    /// names; whatever refactoring happens to how the serializer is built, these must keep loading
+    /// as these types forever. New commands ADD names (add them to the registry, not here — this
+    /// list deliberately does not chase the registry); renaming or unregistering any of these
+    /// breaks users and fails here.
+    /// </summary>
+    private static readonly (string XmlName, Type CommandType)[] FrozenV3WireNames = [
+        ("chars", typeof(CharsCommand)),
+        ("startprocess", typeof(StartProcessCommand)),
+        ("sendinput", typeof(SendInputCommand)),
+        ("sendmessage", typeof(SendMessageCommand)),
+        ("setforegroundwindow", typeof(SetForegroundWindowCommand)),
+        ("shutdown", typeof(ShutdownCommand)),
+        ("pause", typeof(PauseCommand)),
+        ("mouse", typeof(MouseCommand)),
+        ("mceccommand", typeof(McecCommand)),
+        ("capture", typeof(CaptureCommand)),
+        ("query", typeof(QueryCommand)),
+        ("find", typeof(FindCommand)),
+        ("invoke", typeof(InvokeCommand)),
+        ("drag", typeof(DragCommand)),
+        ("launch", typeof(LaunchCommand)),
+        ("click", typeof(ClickCommand)),
+        ("displays", typeof(DisplaysCommand)),
+        ("record", typeof(RecordCommand)),
+    ];
+
+    [Fact]
+    public void LoadCommands_CurrentFormatFixture_BindsEveryFrozenWireName() {
+        // A hand-frozen current-format file (NOT generated from the registry, so a registry-side
+        // rename cannot silently rewrite the expectation): every established element name must
+        // still deserialize to its established type.
+        string fixture =
+            "<?xml version=\"1.0\"?>\r\n" +
+            "<mcecontroller version=\"1.0.0.0\">\r\n" +
+            "  <commands xmlns=\"http://www.kindel.com/products/mcecontroller\">\r\n" +
+            string.Concat(FrozenV3WireNames.Select(f => $"    <{f.XmlName} cmd=\"fix_{f.XmlName}\" enabled=\"true\" />\r\n")) +
+            "  </commands>\r\n" +
+            "</mcecontroller>\r\n";
+
+        string tempFile = Path.GetTempFileName();
+        try {
+            File.WriteAllText(tempFile, fixture);
+            SerializedCommands loaded = SerializedCommands.LoadCommands(tempFile, "1.0.0.0");
+
+            Assert.NotNull(loaded);
+            Assert.Equal(FrozenV3WireNames.Length, loaded.commandArray.Length);
+            foreach ((string xmlName, Type commandType) in FrozenV3WireNames) {
+                Command cmd = Assert.Single(loaded.commandArray, c => c.Cmd == $"fix_{xmlName}");
+                Assert.IsType(commandType, cmd);
+                Assert.True(cmd.Enabled);
+            }
+        }
+        finally {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static Command NewInstance(CommandRegistryEntry entry, string cmdPrefix) {
+        Command command = (Command)Activator.CreateInstance(entry.CommandType)!;
+        command.Cmd = cmdPrefix + entry.XmlName;
+        return command;
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/CommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CommandTests.cs
@@ -151,22 +151,7 @@ public class CommandTests
         Assert.Contains("testargs", result);
     }
 
-    [Fact]
-    public void GetDerivedClassesCollection_ReturnsAllCommandTypes()
-    {
-        var commandTypes = Command.GetDerivedClassesCollection();
-
-        Assert.NotEmpty(commandTypes);
-
-        // Should include all standard command types
-        Assert.Contains(commandTypes, c => c is SendInputCommand);
-        Assert.Contains(commandTypes, c => c is CharsCommand);
-        Assert.Contains(commandTypes, c => c is MouseCommand);
-        Assert.Contains(commandTypes, c => c is StartProcessCommand);
-        Assert.Contains(commandTypes, c => c is PauseCommand);
-        Assert.Contains(commandTypes, c => c is ShutdownCommand);
-        Assert.Contains(commandTypes, c => c is SendMessageCommand);
-        Assert.Contains(commandTypes, c => c is SetForegroundWindowCommand);
-        Assert.Contains(commandTypes, c => c is McecCommand);
-    }
+    // NOTE (#204): GetDerivedClassesCollection_ReturnsAllCommandTypes used to live here. The
+    // reflection sweep it tested is gone — command types are declared in CommandRegistry.Entries,
+    // and CommandRegistryTests asserts the registry covers every concrete Command subclass.
 }


### PR DESCRIPTION
Fixes #204

## What

Adding a command type required edits in **three invisible places**, each failing silently when forgotten: the ~18 hardcoded `[XmlElement]` attributes on `Command.EmbeddedCommands`, the same list repeated as `[XmlArrayItem]` on `SerializedCommands.commandArray`, and a magic `public static new BuiltInCommands` property discovered by reflection without `FlattenHierarchy`. `GetDerivedClassesCollection` instantiated every command type just to reflect a static, and ARCHITECTURE.md's extensibility recipe pointed at it.

Now **one `static readonly` registry** — `CommandRegistry.Entries`, one `(xmlName, type, builtIns factory)` line per command type — drives all three:

- **Invoker built-ins**: `CommandInvoker.CreateBuiltIns` iterates the registry. `Command.GetDerivedClassesCollection`, the base magic-static `Command.BuiltInCommands`, and the reflected-property dance are **deleted**. Each command keeps its `BuiltInCommands` property (no longer `new`-shadowing), referenced **explicitly** by its registry entry — per-command tests keep reading them.
- **Serialization**: both duplicated attribute lists collapse into `CommandRegistry.CreateXmlOverrides()`. Because `XmlSerializer` instances constructed **with overrides are not runtime-cached** (each construction leaks a dynamic assembly), `SerializedCommands` holds ONE cached static `Serializer` used by both Save and Load; a grep confirms no other `typeof(SerializedCommands)`/`typeof(Command)` serializer site remains (the `AppSettings` ones use the runtime-cached overload, untouched).
- **Hygiene gate**: new `CommandRegistryTests` asserts every concrete `Command` subclass appears exactly once in the registry (both directions) — an unregistered command is a red build. A `[Conditional("DEBUG")]` startup backstop (`CommandRegistry.DebugAssertComplete`, called from `CreateBuiltIns`) catches the same drift the moment a debug build starts.

## Wire format unchanged (proven)

- Registry order matches the legacy attribute lists; the `[XmlArray("commands", Order=1)]` wrapper and abstract catch-all entries are restated in the overrides.
- `CommandRegistryTests` pins it: raw-XML assertion that `SaveCommands` writes each registered type under its registry name in the kindel namespace; save/load round-trip of one-of-every-type both top-level and **embedded**; and a hand-frozen current-format fixture (deliberately not generated from the registry) proving the established v3.0 element names keep binding to their established types. The #200 `SerializedCommandsTests` round-trips (including the legacy camelCase file) all still pass.

## Hygiene suite consolidation

`CommandRegistryTests` doubles as the suite index — its doc comment lists all four members and the silent-drift class each closes: **CommandRegistryTests** (#204), **XmlNameCasingTests** (#200), **CommandClonePropertyRoundTripTests** (#207), **AgentCommandStructuralGateTests** (#208). The existing three are untouched. It also carries the registry-side lowercase-name check, since the polymorphic element names no longer exist as reflectable attributes for XmlNameCasingTests to see.

## Docs

ARCHITECTURE.md's extensibility recipe now describes the real one-line registry step; `docs/agent-server-architecture.md`'s house pattern names the registry as the single registration point.

## Scope notes

- Dispatcher/queue logic in `CommandInvoker` untouched (only `CreateBuiltIns` changed); `AgentServer.cs` untouched; agent command behavior (#206) untouched.
- The `Hashtable` → typed-registry inheritance cleanup did **not** ride along — replacing `CommandInvoker : Hashtable` touches every indexer/cast call site and would balloon this diff well past the issue's core.

## Testing

- `dotnet build` green in Debug and Release (TreatWarningsAsErrors + house analyzers).
- Full `dotnet test`: **724 passed, 0 failed** (22 skipped: desktop/input-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm