### PR TITLE
Arch: finish the headless seam — no MainWindow.Instance below the UI layer

### DIFF
--- a/docs/agent-server-architecture.md
+++ b/docs/agent-server-architecture.md
@@ -39,6 +39,23 @@ The single ambient hook the commands and server talk to:
 and tiny lets both the WinForms host and the `--mcp` headless bootstrap share one
 configuration/gating point without dependency plumbing.
 
+It also holds the host-capability half of the seam (#209): `Host` is a small `IAppHost`
+each host registers — `MainWindow` in GUI mode (in its settings-apply path, alongside
+`Settings`), `HeadlessAppHost` in `--mcp` mode. Engine code calls the static wrappers:
+
+- `SendLine(line)` — outbound line to all connected transports (GUI: `MainWindow.SendLine`;
+  headless/no host: logged no-op).
+- `RequestShutdown()` — orderly app shutdown (GUI: `MainWindow.ShutDown()`, self-marshaled;
+  headless: deferred clean process exit after in-flight replies flush, so `mcec:exit` over
+  MCP actually exits; no host: logged no-op so tests survive strays).
+- `MessageWindowHandle` — for `RegisterPowerSettingNotification` and the like (GUI: the
+  `MainWindow` handle; headless: throws — the activity monitor never runs headless).
+
+This is what makes "no `MainWindow.Instance` below the UI layer" enforceable:
+`MainWindow.Instance` is explicitly assigned by `Program`'s GUI path (no lazy
+construct-on-touch), and any touch before assignment — or ever, headless — throws a
+pointed exception naming the seam instead of silently constructing a Form.
+
 ### `AgentNativeMethods` (P/Invoke)
 Internal static P/Invoke surface (carries the required CA1060 suppression).
 Provides `PrintWindow` with `PW_RENDERFULLCONTENT` (captures occluded/composited
@@ -140,10 +157,12 @@ to the caller.
 ## `--mcp` headless bootstrap
 
 The `--mcp` command-line switch starts MCEC without the WinForms UI: it initializes
-`AgentRuntime` (settings + invoker), then runs `AgentServer` as an MCP stdio server and
-pumps stdin/stdout until the client disconnects. This path shares the exact same
-commands and gating as the interactive host — the only difference is the absence of UI
-and the stdio transport.
+`AgentRuntime` (settings + invoker + the `HeadlessAppHost`), then runs `AgentServer` as
+an MCP stdio server and pumps stdin/stdout until the client disconnects. This path
+shares the exact same commands and gating as the interactive host — the only difference
+is the absence of UI and the stdio transport. The process exits when the client closes
+stdin (EOF) or when a `mcec:exit` command runs (`HeadlessAppHost.RequestShutdown`
+performs the same teardown as the EOF path after letting the in-flight reply flush).
 
 ## Gating model recap
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -64,7 +64,7 @@ MCEC is a Windows desktop application built on .NET 10 (WinForms) that enables r
 **Location**: `MainWindow.cs`
 
 **Responsibilities**:
-- Singleton pattern - single instance of the application UI
+- Singleton, but explicitly assigned (#209): `Program.Main`'s GUI path constructs the one instance and sets `MainWindow.Instance` before `Application.Run`. It is **not** lazily constructed — touching `Instance` before assignment (or ever, in headless `--mcp` mode) throws a pointed exception. Code below the UI layer must use the `AgentRuntime` seam (`Invoker`, `SendLine`, `RequestShutdown`, `MessageWindowHandle`) instead; MainWindow registers itself as the seam's `IAppHost` when settings are applied.
 - Lifecycle management for all services
 - UI presentation (WinForms with MenuStrip, StatusStrip, system tray icon)
 - Coordination between communication services and command execution
@@ -452,13 +452,13 @@ CodeProject sample) because it is load-bearing for the emergency stop; only the 
 
 ## Design Patterns Used
 
-- **Singleton**: MainWindow, Logger, TelemetryService, UpdateService
+- **Singleton**: MainWindow (explicitly assigned by Program, never lazy — #209), Logger, TelemetryService, UpdateService
 - **Command Pattern**: ICommand, Command, CommandInvoker
 - **Observer Pattern**: ServiceBase notifications via delegates
 - **Factory Pattern**: CommandInvoker.Create(), Command.BuiltInCommands
 - **Strategy Pattern**: Different Command implementations
 - **Facade Pattern**: InputSimulator wraps KeyboardSimulator and MouseSimulator
-- **Lazy Initialization**: Lazy<T> for singletons
+- **Lazy Initialization**: Lazy<T> for service singletons (NOT MainWindow — see #209)
 - **Object Pool**: Command cloning for execution contexts
 
 ## Dependencies (NuGet)

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -92,6 +92,10 @@ in small chunks and verify between chunks so the queue drains. Avoid sending a r
 through `send_command` if it may open a modal dialog — the queue path has no modal grace and the command
 queue stalls until the dialog is dismissed; use the `invoke` tool, which handles modals.
 
+LIFECYCLE: `send_command mcec:exit` (when that command is enabled) shuts MCEC itself down — on the stdio
+transport it ends this MCP server (your call's reply flushes first, then the process exits) — so send it
+only to deliberately end the session, e.g. stopping a provisioned instance before `end-session`.
+
 OVERLAY: MCEC may show a small on-screen overlay (default on) that narrates each command you run so the
 operator can see MCEC is driving. It is deliberately excluded from `query`/`find`/`capture`/UIA targeting
 — you will never see or target it, and it is never a candidate window — but it DOES appear in

--- a/src/Agent/AgentRuntime.cs
+++ b/src/Agent/AgentRuntime.cs
@@ -24,6 +24,55 @@ public static class AgentRuntime {
     public static CommandInvoker? Invoker { get; set; }
 
     /// <summary>
+    /// The host-capability half of the seam (#209): outbound lines, shutdown, and the message-window
+    /// handle — the few genuinely host-specific things engine code needs. GUI mode registers
+    /// <c>MainWindow</c> (in its settings-apply path, alongside <see cref="Settings"/>); headless
+    /// <c>--mcp</c> registers <see cref="HeadlessAppHost"/>. Engine code calls the wrappers below,
+    /// never <c>MainWindow</c> — touching <c>MainWindow.Instance</c> below the UI layer throws.
+    /// </summary>
+    public static IAppHost? Host { get; set; }
+
+    /// <summary>
+    /// Sends a line to every connected transport via the registered <see cref="Host"/>. With no host
+    /// registered (early startup, tests) the line is dropped with a log trace — never an exception,
+    /// because callers include the activity monitor's background dispatch path.
+    /// </summary>
+    public static void SendLine(string line) {
+        IAppHost? host = Host;
+        if (host is null) {
+            Logger.Instance.Log4.Debug($"AgentRuntime: SendLine with no host registered — dropped: {line}");
+            return;
+        }
+        host.SendLine(line);
+    }
+
+    /// <summary>
+    /// Requests an orderly application shutdown via the registered <see cref="Host"/> (GUI:
+    /// <c>MainWindow.ShutDown()</c>; headless: clean process exit after replies flush). With no host
+    /// registered this logs and returns — a stray <c>mcec:exit</c> in a test process must not kill the
+    /// test runner.
+    /// </summary>
+    public static void RequestShutdown() {
+        IAppHost? host = Host;
+        if (host is null) {
+            Logger.Instance.Log4.Warn("AgentRuntime: RequestShutdown with no host registered — ignored.");
+            return;
+        }
+        host.RequestShutdown();
+    }
+
+    /// <summary>
+    /// A window handle for OS notification registration (see <see cref="IAppHost.MessageWindowHandle"/>).
+    /// Throws with a pointed message when no host is registered — better than the silent Form
+    /// construction a stray <c>MainWindow.Instance.Handle</c> used to cause.
+    /// </summary>
+    public static IntPtr MessageWindowHandle =>
+        (Host ?? throw new InvalidOperationException(
+            "AgentRuntime.MessageWindowHandle requires a registered IAppHost (AgentRuntime.Host) — " +
+            "GUI mode registers MainWindow; headless --mcp has no message window."))
+        .MessageWindowHandle;
+
+    /// <summary>
     /// The single gate over the ONE physical desktop input stream (#113/#195). Two actuation paths
     /// synthesize global input and must never interleave: (1) the <see cref="CommandInvoker"/>
     /// dispatcher thread, which holds this around a queued command's <c>Execute</c> when the command

--- a/src/Agent/HeadlessAppHost.cs
+++ b/src/Agent/HeadlessAppHost.cs
@@ -1,0 +1,56 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MCEControl;
+
+/// <summary>
+/// The <see cref="IAppHost"/> for headless <c>--mcp</c> mode (#209), registered by
+/// <c>Program.RunHeadlessMcp</c> next to the rest of the <see cref="AgentRuntime"/> bootstrap.
+/// There is no window, no legacy transports, and no operator at a screen — so <see cref="SendLine"/>
+/// is a logged no-op, <see cref="RequestShutdown"/> performs the same clean teardown the stdio-EOF
+/// path does and exits the process, and <see cref="MessageWindowHandle"/> throws (the only consumer,
+/// the activity monitor's power-broadcast detection, is started exclusively by the GUI host).
+/// </summary>
+internal sealed class HeadlessAppHost : IAppHost {
+    /// <summary>
+    /// How long <see cref="RequestShutdown"/> waits before tearing down. <c>mcec:exit</c> executes on
+    /// the invoker's dispatcher thread; the agent's <c>send_command</c> awaits a completion marker the
+    /// dispatcher signals AFTER Execute returns, and only then writes the JSON-RPC response line. This
+    /// grace lets that response reach the client before the process ends. Internal so tests can shrink it.
+    /// </summary>
+    internal static int ShutdownGraceMs { get; set; } = 500;
+
+    /// <summary>
+    /// TEST SEAM: what actually ends the process. Defaults to <see cref="Environment.Exit"/>; tests
+    /// swap in a probe so exercising the shutdown path doesn't kill the test runner.
+    /// </summary>
+    internal static Action<int> ExitProcess { get; set; } = Environment.Exit;
+
+    public void SendLine(string line) =>
+        // No legacy transports (TCP/serial) exist headless; drop the line but leave a trace so a
+        // misconfigured activity monitor is diagnosable.
+        Logger.Instance.Log4.Debug($"{nameof(HeadlessAppHost)}: no transports in --mcp mode; SendLine dropped: {line}");
+
+    public void RequestShutdown() {
+        Logger.Instance.Log4.Info(
+            $"{nameof(HeadlessAppHost)}: shutdown requested — exiting after in-flight replies flush ({ShutdownGraceMs}ms grace).");
+        // Deferred so the caller (typically mcec:exit on the dispatcher thread) can finish its
+        // Execute, the dispatcher can signal send_command's completion marker, and the stdio writer
+        // (AutoFlush) can emit the JSON-RPC response. Then the same teardown Program's stdio-EOF path
+        // performs: stop the dispatcher (dropping the queue releases any held input), and exit.
+        _ = Task.Run(() => {
+            Thread.Sleep(ShutdownGraceMs);
+            AgentRuntime.Invoker?.Shutdown(joinTimeoutMs: 2000);
+            ExitProcess(0);
+        });
+    }
+
+    public IntPtr MessageWindowHandle =>
+        throw new InvalidOperationException(
+            "No message window exists in headless --mcp mode. UserActivityMonitorService's power-broadcast " +
+            "detection is only started by the GUI host (MainWindow.Start); it cannot run headless.");
+}

--- a/src/Agent/IAppHost.cs
+++ b/src/Agent/IAppHost.cs
@@ -1,0 +1,41 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+
+namespace MCEControl;
+
+/// <summary>
+/// The host-capability half of the <see cref="AgentRuntime"/> seam (#209): the few things engine
+/// code (commands, services) needs from whatever is hosting it that are genuinely host-specific.
+/// The GUI host is <c>MainWindow</c> (registered in its settings-apply path); the headless
+/// <c>--mcp</c> host is <see cref="HeadlessAppHost"/> (registered by <c>Program</c>'s bootstrap).
+/// Engine code calls the <see cref="AgentRuntime"/> wrappers (<see cref="AgentRuntime.SendLine"/>,
+/// <see cref="AgentRuntime.RequestShutdown"/>, <see cref="AgentRuntime.MessageWindowHandle"/>)
+/// rather than holding an <see cref="IAppHost"/> — nothing below the UI layer may touch
+/// <c>MainWindow</c> directly (touching it used to lazily construct the Form headless).
+/// </summary>
+public interface IAppHost {
+    /// <summary>
+    /// Sends a line of text to every connected transport (TCP client/server, serial). GUI:
+    /// <c>MainWindow.SendLine</c>. Headless: there are no legacy transports, so this is a logged no-op.
+    /// </summary>
+    void SendLine(string line);
+
+    /// <summary>
+    /// Requests an orderly application shutdown (<c>mcec:exit</c>, the updater's install-and-restart).
+    /// GUI: <c>MainWindow.ShutDown()</c> (self-marshals to the UI thread). Headless: schedules a clean
+    /// process exit after in-flight protocol replies flush — the same net effect as the MCP client
+    /// closing stdin.
+    /// </summary>
+    void RequestShutdown();
+
+    /// <summary>
+    /// A window handle engine code may register OS notifications against
+    /// (<c>RegisterPowerSettingNotification</c> for <c>UserActivityMonitorService</c>'s
+    /// power-broadcast detection, which needs the host's WndProc to receive
+    /// <c>WM_POWERBROADCAST</c>). GUI: the <c>MainWindow</c> handle. Headless: throws — the activity
+    /// monitor is only ever started by the GUI host, so no headless message window exists.
+    /// </summary>
+    IntPtr MessageWindowHandle { get; }
+}

--- a/src/Commands/McecCommand.cs
+++ b/src/Commands/McecCommand.cs
@@ -67,16 +67,12 @@ public class McecCommand : Command {
             // Cause MCE Controller to exit
             case "exit":
                 Reply.WriteLine("exiting");
-                // #195: commands now execute on the invoker's dispatcher thread. ShutDown()
-                // self-marshals (BeginInvoke when InvokeRequired), so calling it from here is safe
-                // in GUI mode. Headless (--mcp) has no MainWindow — touching the lazy singleton
-                // would construct a Form on this worker thread — so decline there (the MCP client
-                // owns the process lifetime; it exits MCEC by closing stdin).
-                if (AgentRuntime.Headless) {
-                    Logger.Instance.Log4.Info($"{this.GetType().Name}: '{Cmd}{Args}' ignored in headless MCP mode — the MCP client owns the process lifetime.");
-                    return true;
-                }
-                MainWindow.Instance.ShutDown();
+                // #209: shutdown goes through the UI-agnostic host seam. GUI: MainWindow.ShutDown()
+                // (self-marshals, so calling from this dispatcher thread is safe — #195). Headless
+                // (--mcp): HeadlessAppHost schedules a clean deferred process exit so the in-flight
+                // send_command reply reaches the client first — mcec:exit now actually exits
+                // headless instead of the old #195 decline.
+                AgentRuntime.RequestShutdown();
                 return true;
 
             // Return a list of supported commands (really just for testing)

--- a/src/Commands/SerializedCommands.cs
+++ b/src/Commands/SerializedCommands.cs
@@ -146,11 +146,15 @@ public class SerializedCommands {
             new XmlSerializer(typeof(SerializedCommands)).Serialize(ucFS, commands);
         }
         catch (Exception e) {
-            // TODO: Move MessageBox out of here into MainWindow
             string msg = $"Could not create commands file ({userCommandsFile}) - {e.Message}.\n\n" +
                          $"See log file for details: {Logger.Instance.LogFile}\n\n" +
                          $"For help, open an issue at github.com/tig/mcec";
-            MessageBox.Show(msg, Application.ProductName);
+            // #209: same headless gate as LoadCommands above — in --mcp mode there is no operator
+            // and stdout is the protocol stream, so a failed save must log, never block on a dialog
+            // no one can dismiss (SessionProvisioner saves .commands headless).
+            if (!AgentRuntime.Headless) {
+                MessageBox.Show(msg, Application.ProductName);
+            }
             Logger.Instance.Log4.Error($"SerializedCommands: {msg}");
             Logger.DumpException(e);
         }

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -19,10 +19,19 @@ using Microsoft.Win32;
 using static MCEControl.Hooks.PowerNativeMethods;
 
 namespace MCEControl; 
-public partial class MainWindow : Form {
-    // MainWindow is a singleton
-    private static readonly Lazy<MainWindow> _lazy = new(() => new MainWindow());
-    public static MainWindow Instance { get { return _lazy.Value; } }
+public partial class MainWindow : Form, IAppHost {
+    // MainWindow is a singleton, but NOT a lazy one (#209): the instance is explicitly assigned by
+    // Program.Main's GUI path before Application.Run. It used to be a Lazy<MainWindow>, so ANY touch
+    // — including from engine code on a worker thread in headless --mcp mode — silently constructed
+    // the Form. Now a touch before assignment (or ever, headless) throws a pointed exception instead.
+    private static MainWindow? _instance;
+    public static MainWindow Instance {
+        get => _instance ?? throw new InvalidOperationException(
+            "MainWindow.Instance touched in headless mode or before Program assigned it — code below " +
+            "the UI layer must use the AgentRuntime seam instead (AgentRuntime.Invoker / SendLine / " +
+            "RequestShutdown / MessageWindowHandle).");
+        internal set => _instance = value;
+    }
 
     public SocketServer? Server { get; private set; }
     public SocketClient? Client { get; private set; }
@@ -549,18 +558,31 @@ public partial class MainWindow : Form {
         }
     }
 
+    // ----------------------------------------
+    // IAppHost (#209) — the GUI half of the AgentRuntime host seam (non-explicit; CA1033 forbids
+    // explicit-only implementations on an unsealed type). SendLine below already matches.
+
+    // ShutDown() self-marshals (BeginInvoke when InvokeRequired), so this is callable from any
+    // thread — the invoker's dispatcher (mcec:exit) and the updater's async download path both do.
+    public void RequestShutdown() => ShutDown();
+
+    // Control.Handle is safe to READ cross-thread once created; the only consumer
+    // (UserActivityMonitorService.StartPowerBroadcastDetection) runs on the UI thread anyway,
+    // called from Start() during load/settings-apply.
+    public IntPtr MessageWindowHandle => Handle;
+
     // Sends a line of text (adds a "\n" to end) to connected client and server
-    public void SendLine(string v) {
-        //Logger.Instance.Log4.Info($"Send: {v}");
+    public void SendLine(string line) {
+        //Logger.Instance.Log4.Info($"Send: {line}");
         if (Client != null) {
-            Client.Send(v + "\n");
+            Client.Send(line + "\n");
         }
         else if (Server != null) {
-            Server.Send(v + "\n");
+            Server.Send(line + "\n");
         }
 
         if (SerialServer != null) {
-            SerialServer.Send(v + "\n");
+            SerialServer.Send(line + "\n");
         }
     }
 
@@ -883,6 +905,11 @@ public partial class MainWindow : Form {
     private void ApplySettings(AppSettings settings) {
         Settings = settings;
         PublishAgentRuntimeSettings(settings);
+
+        // #209: register the GUI host capabilities (SendLine / RequestShutdown / message-window
+        // handle) on the same seam, in the same place the settings are published. Idempotent —
+        // the dialog-OK path re-runs this with the same instance.
+        AgentRuntime.Host = this;
 
         Logger.Instance.TextBoxThreshold = LogManager.GetLogger("MCEControl")!.Logger!.Repository!.LevelMap![settings.TextBoxLogThreshold]!;
     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -94,7 +94,12 @@ internal static class Program {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
 
-        Application.Run(MainWindow.Instance);
+        // #209: the ONLY place the MainWindow Form is constructed. MainWindow.Instance is explicitly
+        // assigned here (no more lazy construct-on-touch); anything that touches it earlier — or ever,
+        // in headless --mcp mode — gets a pointed exception instead of a silent Form on the wrong thread.
+        MainWindow mainWindow = new();
+        MainWindow.Instance = mainWindow;
+        Application.Run(mainWindow);
 
         Logger.Instance.Log4.Debug($"------ END runtime: {TelemetryService.Instance.RunTime!.Elapsed:g} ------");
     }
@@ -127,6 +132,10 @@ internal static class Program {
         AgentRuntime.Settings = settings;
         AgentRuntime.Invoker = CommandInvoker.Create(
             $@"{ConfigPath}mcec.commands", Application.ProductVersion, settings.DisableInternalCommands);
+        // #209: the headless host capabilities — SendLine is a logged no-op (no legacy transports),
+        // RequestShutdown is a clean deferred process exit (so mcec:exit over MCP works headless),
+        // and MessageWindowHandle throws (the activity monitor never runs headless).
+        AgentRuntime.Host = new HeadlessAppHost();
 
         Logger.Instance.Log4.Info($"MCEC: headless MCP mode (AgentCommandsEnabled={settings.AgentCommandsEnabled}).");
 

--- a/src/Services/ServiceBase.cs
+++ b/src/Services/ServiceBase.cs
@@ -40,11 +40,13 @@ public abstract class ServiceBase {
 
         Logger.Instance.Log4.Info($"{this.GetType().Name}: Sending \"{Regex.Escape(text)}\"");
 
-        // TELEMETRY: 
+        // TELEMETRY:
         // what: the number of commands of each type (key) sent
         // why: to understand what commands are used to control other systems and which are not
         // how is PII protected: we only collect the text if it is a key for a built-in command
-        Command? userDefined = MainWindow.Instance.Invoker.Values.Cast<Command>().FirstOrDefault(q => (q.Cmd == text.Trim('\r').Trim('\n') && q.UserDefined == false));
+        // #209: read the command table via the UI-agnostic AgentRuntime seam (populated by both the
+        // GUI and headless hosts) — never MainWindow, which this engine-layer code must not touch.
+        Command? userDefined = AgentRuntime.Invoker?.Values.Cast<Command>().FirstOrDefault(q => (q.Cmd == text.Trim('\r').Trim('\n') && q.UserDefined == false));
         TelemetryService.Instance.TrackMetric($"{(userDefined == null ? "<userDefined>" : text.Trim('\r').Trim('\n'))} Sent", 1);
     }
 

--- a/src/Services/UpdateService.cs
+++ b/src/Services/UpdateService.cs
@@ -284,7 +284,9 @@ public class UpdateService {
                 return;
             }
 
-            MainWindow.Instance.BeginInvoke((Action)(() => { MainWindow.Instance.ShutDown(); }));
+            // #209: shutdown via the UI-agnostic host seam (GUI: MainWindow.ShutDown(), which
+            // already self-marshals to the UI thread — the old explicit BeginInvoke was redundant).
+            AgentRuntime.RequestShutdown();
         }
         catch (Exception ex) {
             Logger.Instance.Log4.Error($"{GetType().Name}: Upgrade failed: {ex.Message}");

--- a/src/Services/UserActivityMonitorService.cs
+++ b/src/Services/UserActivityMonitorService.cs
@@ -216,15 +216,21 @@ public sealed class UserActivityMonitorService : IDisposable {
     }
 
     private void StartPowerBroadcastDetection() {
-        _hUserPresence = RegisterPowerSettingNotification(MainWindow.Instance.Handle,
+        // #209: the handle comes from the AgentRuntime host seam, not MainWindow directly. In GUI
+        // mode this is the MainWindow handle (whose WndProc forwards WM_POWERBROADCAST to
+        // HandlePowerBroadcast); this service is only ever started by the GUI host, so headless the
+        // seam throws with a pointed message rather than lazily constructing a Form.
+        IntPtr messageWindowHandle = AgentRuntime.MessageWindowHandle;
+
+        _hUserPresence = RegisterPowerSettingNotification(messageWindowHandle,
             ref GUID_SESSION_USER_PRESENCE,
             DEVICE_NOTIFY_WINDOW_HANDLE);
 
-        _hAwayMode = RegisterPowerSettingNotification(MainWindow.Instance.Handle,
+        _hAwayMode = RegisterPowerSettingNotification(messageWindowHandle,
             ref GUID_SYSTEM_AWAYMODE,
             DEVICE_NOTIFY_WINDOW_HANDLE);
 
-        _hMonitorPower = RegisterPowerSettingNotification(MainWindow.Instance.Handle,
+        _hMonitorPower = RegisterPowerSettingNotification(messageWindowHandle,
             ref GUID_MONITOR_POWER_ON,
             DEVICE_NOTIFY_WINDOW_HANDLE);
     }
@@ -424,7 +430,10 @@ public sealed class UserActivityMonitorService : IDisposable {
         // how is PII protected: the frequency of activity is not PII
         TelemetryService.Instance.TrackMetric("activity Sent", 1);
 
-        MainWindow.Instance.SendLine(ActivityMsg);
+        // #209: outbound line goes through the AgentRuntime host seam (GUI: MainWindow.SendLine to
+        // the connected transports; no host registered: logged drop — never an exception on this
+        // background dispatch path).
+        AgentRuntime.SendLine(ActivityMsg);
     }
 
     private void HookManager_KeyDown(object? sender, KeyEventArgs e) {

--- a/tests/MCEControl.xUnit/Agent/AppHostSeamTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AppHostSeamTests.cs
@@ -1,0 +1,205 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Tests for the #209 host seam: no code below the UI layer may touch <c>MainWindow.Instance</c>,
+/// which is now explicitly assigned by <c>Program</c>'s GUI path (never lazily constructed). Engine
+/// code uses <see cref="AgentRuntime.SendLine"/> / <see cref="AgentRuntime.RequestShutdown"/> /
+/// <see cref="AgentRuntime.MessageWindowHandle"/>, all callable headless with no WinForms side
+/// effects. Mutates AgentRuntime statics, so serialized via the AgentSerial collection and every
+/// test saves/restores in finally.
+/// </summary>
+[Collection("AgentSerial")]
+public class AppHostSeamTests {
+    // -------------------------------------------------------------------------------------------
+    // MainWindow.Instance: explicit assignment, pointed failure — never a silent Form construction
+    // -------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void MainWindowInstance_Unassigned_ThrowsPointedException_NotFormConstruction() {
+        // In this (headless) test process nothing ever assigns MainWindow.Instance, exactly like
+        // --mcp mode. The old Lazy<MainWindow> would CONSTRUCT the Form right here, on an xUnit
+        // worker thread; now the touch must fail fast and point at the seam.
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => MainWindow.Instance);
+
+        Assert.Contains("headless", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AgentRuntime", ex.Message, StringComparison.Ordinal);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // AgentRuntime.SendLine / RequestShutdown / MessageWindowHandle
+    // -------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void SendLine_NoHost_IsLoggedNoOp_NeverThrows() {
+        IAppHost? savedHost = AgentRuntime.Host;
+        try {
+            AgentRuntime.Host = null;
+
+            // Callers include the activity monitor's background dispatch — must never throw.
+            Exception? ex = Record.Exception(() => AgentRuntime.SendLine("activity"));
+
+            Assert.Null(ex);
+        }
+        finally {
+            AgentRuntime.Host = savedHost;
+        }
+    }
+
+    [Fact]
+    public void SendLine_ForwardsToRegisteredHost() {
+        IAppHost? savedHost = AgentRuntime.Host;
+        try {
+            RecordingAppHost host = new();
+            AgentRuntime.Host = host;
+
+            AgentRuntime.SendLine("activity");
+
+            Assert.Equal(["activity"], host.Lines);
+        }
+        finally {
+            AgentRuntime.Host = savedHost;
+        }
+    }
+
+    [Fact]
+    public void RequestShutdown_NoHost_IsLoggedNoOp_NeverThrows() {
+        IAppHost? savedHost = AgentRuntime.Host;
+        try {
+            AgentRuntime.Host = null;
+
+            // A stray mcec:exit in a hostless process (tests!) must not do anything drastic.
+            Exception? ex = Record.Exception(AgentRuntime.RequestShutdown);
+
+            Assert.Null(ex);
+        }
+        finally {
+            AgentRuntime.Host = savedHost;
+        }
+    }
+
+    [Fact]
+    public void RequestShutdown_ForwardsToRegisteredHost() {
+        IAppHost? savedHost = AgentRuntime.Host;
+        try {
+            RecordingAppHost host = new();
+            AgentRuntime.Host = host;
+
+            AgentRuntime.RequestShutdown();
+
+            Assert.Equal(1, host.ShutdownRequests);
+        }
+        finally {
+            AgentRuntime.Host = savedHost;
+        }
+    }
+
+    [Fact]
+    public void MessageWindowHandle_NoHost_ThrowsPointedException() {
+        IAppHost? savedHost = AgentRuntime.Host;
+        try {
+            AgentRuntime.Host = null;
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => AgentRuntime.MessageWindowHandle);
+
+            Assert.Contains("IAppHost", ex.Message, StringComparison.Ordinal);
+        }
+        finally {
+            AgentRuntime.Host = savedHost;
+        }
+    }
+
+    [Fact]
+    public void MessageWindowHandle_ForwardsToRegisteredHost() {
+        IAppHost? savedHost = AgentRuntime.Host;
+        try {
+            RecordingAppHost host = new() { Handle = new IntPtr(0xBEEF) };
+            AgentRuntime.Host = host;
+
+            Assert.Equal(new IntPtr(0xBEEF), AgentRuntime.MessageWindowHandle);
+        }
+        finally {
+            AgentRuntime.Host = savedHost;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // HeadlessAppHost
+    // -------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void HeadlessHost_SendLine_IsNoOp() {
+        Exception? ex = Record.Exception(() => new HeadlessAppHost().SendLine("activity"));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void HeadlessHost_MessageWindowHandle_ThrowsPointedException() {
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => ((IAppHost)new HeadlessAppHost()).MessageWindowHandle);
+
+        Assert.Contains("headless", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HeadlessHost_RequestShutdown_ExitsCleanly_AfterGrace() {
+        // Swap the process-exit seam so exercising the real shutdown path can't kill the test runner.
+        Action<int> savedExit = HeadlessAppHost.ExitProcess;
+        int savedGrace = HeadlessAppHost.ShutdownGraceMs;
+        CommandInvoker? savedInvoker = AgentRuntime.Invoker;
+        using ManualResetEventSlim exited = new(false);
+        int? exitCode = null;
+        try {
+            // The teardown path also stops the ambient invoker; don't stop one another test owns.
+            AgentRuntime.Invoker = null;
+            HeadlessAppHost.ShutdownGraceMs = 10;
+            HeadlessAppHost.ExitProcess = code => { exitCode = code; exited.Set(); };
+
+            new HeadlessAppHost().RequestShutdown();
+
+            // Deferred: exits on a background task after the grace, with a clean (0) exit code.
+            Assert.True(exited.Wait(TimeSpan.FromSeconds(10)), "HeadlessAppHost never reached the process-exit call");
+            Assert.Equal(0, exitCode);
+        }
+        finally {
+            HeadlessAppHost.ExitProcess = savedExit;
+            HeadlessAppHost.ShutdownGraceMs = savedGrace;
+            AgentRuntime.Invoker = savedInvoker;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // SaveCommands headless guard (#209): a failed save in --mcp mode must log, not block on UI
+    // -------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void SaveCommands_FailureWhileHeadless_LogsAndReturns_NoDialog() {
+        bool savedHeadless = AgentRuntime.Headless;
+        try {
+            AgentRuntime.Headless = true;
+
+            // A directory that does not exist makes FileStream creation throw — the failure branch
+            // that used to show an unconditional MessageBox. Headless, a dialog would block this
+            // test forever (nobody can dismiss it), so completing at all is the assertion.
+            string unwritable = Path.Combine(Path.GetTempPath(), "mcec-tests", Guid.NewGuid().ToString("N"), "nope", "mcec.commands");
+            SerializedCommands commands = new() { commandArray = [] };
+
+            Exception? ex = Record.Exception(() => SerializedCommands.SaveCommands(unwritable, commands, "9.9.9"));
+
+            Assert.Null(ex);
+        }
+        finally {
+            AgentRuntime.Headless = savedHeadless;
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/RecordingAppHost.cs
+++ b/tests/MCEControl.xUnit/Agent/RecordingAppHost.cs
@@ -1,0 +1,22 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// A recording <see cref="IAppHost"/> for the #209 seam tests: captures <see cref="SendLine"/>
+/// lines and <see cref="RequestShutdown"/> calls, and serves a settable fake message-window handle.
+/// </summary>
+internal sealed class RecordingAppHost : IAppHost {
+    public List<string> Lines { get; } = [];
+    public int ShutdownRequests { get; private set; }
+    public IntPtr Handle { get; set; } = new(0x1234);
+
+    public void SendLine(string line) => Lines.Add(line);
+    public void RequestShutdown() => ShutdownRequests++;
+    public IntPtr MessageWindowHandle => Handle;
+}

--- a/tests/MCEControl.xUnit/Services/UserActivityMonitorServiceTests.cs
+++ b/tests/MCEControl.xUnit/Services/UserActivityMonitorServiceTests.cs
@@ -83,8 +83,10 @@ public class UserActivityMonitorServiceTests {
     /// work (log I/O, telemetry, SendLine's synchronous socket/serial writes) — never run it inline in
     /// the hook callback. Windows silently evicts an LL hook whose callback exceeds
     /// LowLevelHooksTimeout, and the #135 emergency-stop hotkey rides the same WH_KEYBOARD_LL hook.
-    /// The heavy work would throw here if executed (no MainWindow in the test process), so the handler
-    /// completing with the work merely captured proves it was not invoked synchronously.
+    /// The dispatch seam captures the work without running it; the dispatch count proves the handler
+    /// hands the work off exactly once (post-#209 the work itself is harmless in-proc — SendLine goes
+    /// through AgentRuntime, a logged no-op with no host registered — but it must still never run
+    /// inline on the hook path).
     /// </summary>
     [Fact]
     public void Activity_DispatchesHeavyWorkOffHookPath_AndDebouncesInHandler() {


### PR DESCRIPTION
Fixes #209

`MainWindow.Instance` was a `Lazy<MainWindow>`, so any touch below the UI layer — including from a stdio worker thread in headless `--mcp` mode — silently constructed the Form. Five sites punched through, and `SaveCommands` could block `--mcp` on a MessageBox no one can dismiss.

## Seam design

`AgentRuntime` (still the static seam) gains the host-capability half via a small **`IAppHost`** it holds (`AgentRuntime.Host`), plus static wrappers engine code calls:

- **`SendLine(line)`** — outbound line to connected transports. GUI: `MainWindow.SendLine`; headless / no host: logged drop (never throws — callers include the activity monitor's background dispatch).
- **`RequestShutdown()`** — GUI: `MainWindow.ShutDown()` (self-marshals); headless: `HeadlessAppHost` performs the same teardown as the stdio-EOF path (invoker shutdown → exit 0) after a short grace so the in-flight `send_command` reply flushes. **`mcec:exit` over MCP now actually exits headless** instead of the #195 decline. No host (tests): logged no-op.
- **`MessageWindowHandle`** — GUI: the `MainWindow` handle; headless / no host: throws with a pointed message (the activity monitor is only ever started by the GUI host, so no headless message window is needed — the seam stays honest by refusing loudly).

Registration: `MainWindow` registers itself in `ApplySettings` (the #196 path that already publishes `AgentRuntime.Settings`); `Program`'s `--mcp` bootstrap registers `HeadlessAppHost` next to its existing `AgentRuntime` setup.

## Punch-throughs migrated

- `McecCommand` `mcec:exit` → `AgentRuntime.RequestShutdown()` (headless decline upgraded to a real clean exit)
- `ServiceBase.Send` telemetry lookup → `AgentRuntime.Invoker` (null-safe, same scan/behavior)
- `UserActivityMonitorService` → `AgentRuntime.MessageWindowHandle` + `AgentRuntime.SendLine`
- `UpdateService` → `AgentRuntime.RequestShutdown()` (the explicit `BeginInvoke` was redundant)
- `SerializedCommands.SaveCommands` → mirrors `LoadCommands`' `AgentRuntime.Headless` guard on the failure MessageBox (smaller honest change; callers include the headless `SessionProvisioner`). Serialization attributes/serializer untouched — #204 owns those.

## Instance mechanism

`MainWindow.Instance` is now explicitly assigned by `Program.Main`'s GUI path before `Application.Run` (the only place the Form is constructed). Touching it unassigned — or ever, headless — throws `InvalidOperationException` naming the `AgentRuntime` seam instead of constructing a Form. All remaining `Instance` uses are UI-layer (`CommandWindow`, created in `mainWindow_Load` after assignment).

## Verification

- `dotnet build` green (TreatWarningsAsErrors + custom analyzers)
- `dotnet test`: **729 passed, 0 failed** (22 skipped, pre-existing desktop-gated), including 11 new `AppHostSeamTests` (`[Collection("AgentSerial")]`, save/restore in finally; process-exit swapped for a probe)
- `mcec.exe --mcp` stdio smoke (build-dir config only; installed config untouched): `initialize` + `tools/list` + `tools/call send_command mcec:ver` all respond, clean exit 0 on stdin EOF
- Bonus smoke: with `mcec:` enabled in a build-dir `.commands`, `send_command mcec:exit` returns its reply (`output:"exiting"`) **then the process exits on its own with code 0** — no EOF sent

## Docs

`docs/agent-server-architecture.md` (seam + `--mcp` lifecycle), `src/ARCHITECTURE.md` §1/patterns, and one `AgentInstructions.md` LIFECYCLE line (agent-visible behavior change: `mcec:exit` over stdio now ends the MCP server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm