### PR TITLE
Agent results as objects; categorical failures; no prose-sniffing (#206, #191)

### DIFF
--- a/docs/agent-server-architecture.md
+++ b/docs/agent-server-architecture.md
@@ -76,14 +76,24 @@ one descriptor plus its command class. The meta-tools (`send_command`,
 1:1 onto a `Command` and keep their own gating, special-cased in `AgentServer` next to
 the catalog dispatch.
 
-## Structured replies
+## Structured replies (#206: objects, not re-parsed strings)
 
-Agent commands do not write free text. They write a `CommandResult` (in
-`System.Text.Json.Nodes`): `Success`, `Command`, `Error?`, `Data?` with factory helpers
-`Ok(command, data?)` / `Fail(command, error)` and `ToJson()` / `ToJsonObject()`.
-Serialization options live in `AgentJson` (`Serialize<T>`). For in-process tool dispatch
-the server runs a command against a `CapturingReply : Reply` and reads back
-`Captured` rather than going through a socket.
+Agent commands do not write free text. `ExecuteCore()` **returns** a `CommandResult` (in
+`System.Text.Json.Nodes`): `Success`, `Command`, `Error?`, `Data?`, plus the mandatory failure
+taxonomy `ErrorCode`/`ErrorCategory` and `Warnings`, with factory helpers `Ok(command, data?)` /
+`Fail(command, error, code, category, data?)` and `ToJson()` / `ToJsonObject()`. Serialization
+options live in `AgentJson` (`Serialize<T>`).
+
+`AgentCommand`'s sealed template emits the result once per transport: a legacy TCP/serial `Reply`
+receives the single `ToJson()` line (unchanged wire format), while a `CapturingReply : Reply` —
+the in-process tool dispatch — receives the **object** in its typed `Result` slot. The server
+consumes that object directly (`AgentToolResult.FromCommandResult`) to build the #101 envelope:
+no `ToJson → JsonNode.Parse` round-trip of its own output (a capture's base64 PNG used to be
+materialized 3–4×), no prose-sniffing categorization (deleted with `FromLegacy`/`Categorize`),
+and no "non-JSON output is success" fallback. The template also normalizes any failure missing a
+code/category to `unhandled`/`internal`, so every agent failure is categorical by construction.
+`CapturingReply.Captured` lazily serializes the typed result when legacy text is wanted
+(`send_command` output, tests).
 
 ## How the new commands plug into the existing pattern
 
@@ -133,9 +143,9 @@ the gated agent tools registered in `ToolCatalog` (`capture`, `query`, `displays
 - **HTTP floor** — one JSON-RPC request per `POST` to `/mcp`, bound to
   `McpBindAddress` (default `127.0.0.1`) on `McpHttpPort` (default `5151`).
 
-Tool calls are translated into command invocations executed through
-`CommandInvoker` + `CapturingReply`, and the captured `CommandResult` JSON is returned
-to the caller.
+Tool calls are translated into command invocations executed against a `CapturingReply`; the
+command's typed `CommandResult` (its `Result` slot, #206) is wrapped in the #101 envelope and
+returned to the caller.
 
 ## `--mcp` headless bootstrap
 

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -160,9 +160,10 @@ Over MCP, the transport's `isError` flag mirrors the envelope (`isError = !ok`).
 
 On failure the `error` object carries a stable, fine-grained `code`, a coarse `category` from
 the closed taxonomy (`timeout`, `ambiguous-selector`, `stale-element`, `no-target`,
-`capture-blank`, `focus`, `elevation`, `foreground`, `internal`), a human-readable `detail`,
-and — when available — a `lastObservation` (the last good state before the failure, so a
-failed call is debuggable without rerunning it):
+`invalid-argument`, `capture-blank`, `focus`, `elevation`, `foreground`, `internal`), a
+human-readable `detail`, and — when available — a `lastObservation` (the last good state before
+the failure, so a failed call is debuggable without rerunning it) and a `partialResult` (the
+failing call's own partial payload, e.g. a blank capture's suspect PNG):
 
 ```json
 {
@@ -177,11 +178,13 @@ failed call is debuggable without rerunning it):
 }
 ```
 
-> **Where the shape comes from.** Internally each agent command still emits the thinner legacy
-> `CommandResult` (`{ success, command, error, data, warnings }`, in `src/Commands/CommandResult.cs`).
-> The `AgentServer` translates that into the `{ ok, result, error, … }` envelope at the MCP
-> boundary (`AgentToolResult.FromLegacy`), which is the shape an MCP client actually receives and
-> the one specified by the shared result contract in
+> **Where the shape comes from.** Internally each agent command returns a structured
+> `CommandResult` **object** (`src/Commands/CommandResult.cs`) carrying `success`/`data` plus the
+> mandatory `errorCode`/`errorCategory` taxonomy on failure (#206). The `AgentServer` builds the
+> `{ ok, result, error, … }` envelope from that object at the MCP boundary
+> (`AgentToolResult.FromCommandResult`) — no serialize/re-parse round-trip and no free-text
+> "categorization" — which is the shape an MCP client actually receives and the one specified by
+> the shared result contract in
 > [`docs/design/agent-tool-result-contract.md`](design/agent-tool-result-contract.md). A
 > couple of feature-specific refusals ride in `error.code` while `error.category` stays `internal`:
 > `emergency-stopped` (the operator engaged the [emergency stop](safety-emergency-stop-and-provisioning.md)),
@@ -228,7 +231,8 @@ unbounded region (e.g. `40000x40000` ≈ 6.4 GB of raw ARGB, before PNG encoding
 otherwise exhaust the host's memory. A region may be at most **16384 px per side** and
 **64,000,000 px total** (64 MP ≈ 256 MB raw — roughly eight 4K frames). An oversized region is
 **rejected before anything is allocated or captured** — the call fails with
-`errorCode: "region-too-large"` (`errorCategory: "no-target"`) and a detail stating the limit,
+`errorCode: "region-too-large"` (`errorCategory: "invalid-argument"`, #191: the recovery is to
+shrink the request) and a detail stating the limit,
 and the rejection is `AGENT-AUDIT:`-logged. The same caps apply to `record` regions (window
 targets need no cap: they are bounded by the window's own size). These limits are fixed, not
 settings: they are an anti-DoS bound sized well beyond real desktop geometry, not a tuning knob.
@@ -360,7 +364,8 @@ near-black dominant color is distinguished from a legitimately empty (e.g. white
 
 - A **window** capture that comes back blank is a failure (`error.category: "capture-blank"`,
   `error.code: "frame-all-black"` or `"frame-uniform"`), so it is never a *silent* bad image — an
-  agent branches on the failure rather than trusting the frame.
+  agent branches on the failure rather than trusting the frame. The suspect PNG the command
+  grabbed still rides in `error.partialResult` (#206), so the evidence is not lost.
 - A **region** capture that comes back blank is reported as a `capture-blank` **warning**, since
   a user-specified region can legitimately be empty.
 - The raw numbers are in the success payload's `blankCheck` (`blank`, `dominantFraction`, `dominantIsDark`).

--- a/docs/design/agent-tool-result-contract.md
+++ b/docs/design/agent-tool-result-contract.md
@@ -78,7 +78,8 @@ falling back to `category`.
 | `ambiguous-selector` | A selector matched more than one candidate and the tool refused to guess. | Add disambiguators (`processName`, `className`, `automationId`) and retry. |
 | `stale-element`      | A previously resolved element/handle is no longer valid (window closed, tree re-rendered). | Re-`query`/`find` to get a fresh reference, then retry. |
 | `no-target`          | A selector matched nothing (no window/element). | Broaden the selector, `query` to discover targets, or wait for the target to appear. |
-| `capture-blank`      | A screenshot was produced but detected as black/blank (composited/occluded/locked-session). | Try foreground/region capture; restore/foreground the window; surface the limitation. |
+| `invalid-argument`   | The request itself is malformed or inapplicable (#191): a client-supplied argument is invalid (unknown action, oversized region, ill-formed endpoint) or cannot apply to the target (an element that lacks the pattern an action needs). | Fix the arguments and re-issue. Do **not** retry the same call, broaden a selector, or re-find the target — the request will keep failing until it changes. |
+| `capture-blank`      | A screenshot was produced but detected as black/blank (composited/occluded/locked-session). | Try foreground/region capture; restore/foreground the window; surface the limitation. The suspect image still rides in `error.partialResult`. |
 | `focus`              | An action required input focus that could not be set. | `invoke` `setfocus` first, or foreground the window, then retry. |
 | `elevation`          | The target runs at a higher integrity level (UAC) than MCEC and cannot be driven. | Surface to the operator; the action cannot proceed without elevation. |
 | `foreground`         | An action required the target to be foreground and it could not be brought forward. | Foreground the window (subject to OS foreground-lock rules), then retry. |
@@ -96,6 +97,8 @@ not recoverable by the agent at all.
 - `ambiguous-selector` → `selector-matched-N`
 - `stale-element` → `element-stale`, `window-closed`
 - `no-target` → `window-not-found`, `element-not-found`
+- `invalid-argument` → `region-too-large`, `action-unknown`, `pattern-unsupported`, `bad-arguments`,
+  `launch-path-missing`, `recording-in-progress`, `no-recording`
 - `capture-blank` → `frame-all-black`, `frame-mostly-blank`
 - `focus` → `set-focus-failed`
 - `elevation` → `target-elevated`
@@ -123,6 +126,13 @@ result or the resolved target `WindowInfo`. It is the primary input to #87's `fa
 
 When no prior observation exists (e.g. the very first call in a session failed at selector
 resolution), `lastObservation` is omitted.
+
+## `partialResult`
+
+`error.partialResult` carries the failing call's **own** partial payload when the tool deliberately
+kept one — e.g. a `capture-blank` failure still carries the (suspect) PNG it grabbed, so the evidence
+the command paid to produce is not discarded (#206). It is distinct from `lastObservation`, which is
+the last *good* state from a *prior* call. Omitted when the failure produced nothing.
 
 ## Mapping onto the MCP tool-result transport
 

--- a/docs/design/agent-tool-result.schema.json
+++ b/docs/design/agent-tool-result.schema.json
@@ -78,6 +78,7 @@
             "ambiguous-selector",
             "stale-element",
             "no-target",
+            "invalid-argument",
             "capture-blank",
             "focus",
             "elevation",
@@ -92,6 +93,10 @@
         "lastObservation": {
           "type": ["object", "null"],
           "description": "The last good observation captured before the failure (e.g. the most recent query/capture result, or the resolved target window). Carries debugging state forward and feeds #87's failure-summary.md. Omitted when no prior observation exists."
+        },
+        "partialResult": {
+          "type": ["object", "null"],
+          "description": "The failing call's own partial payload, when the tool deliberately kept one — e.g. a capture-blank failure still carries the (suspect) PNG it grabbed. Distinct from lastObservation, which is the last good state from a prior call. Omitted when the failure produced nothing."
         }
       }
     }

--- a/src/Agent/AgentError.cs
+++ b/src/Agent/AgentError.cs
@@ -14,11 +14,12 @@ namespace MCEControl;
 /// #87's failure-summary). See <c>docs/design/agent-tool-result-contract.md</c> (#101).
 /// </summary>
 public sealed class AgentError {
-    public AgentError(string code, AgentErrorCategory category, string detail, JsonObject? lastObservation = null) {
+    public AgentError(string code, AgentErrorCategory category, string detail, JsonObject? lastObservation = null, JsonObject? partialResult = null) {
         Code = code;
         Category = category;
         Detail = detail;
         LastObservation = lastObservation;
+        PartialResult = partialResult;
     }
 
     /// <summary>Stable, fine-grained machine code (kebab-case); narrows <see cref="Category"/>.</summary>
@@ -33,12 +34,20 @@ public sealed class AgentError {
     /// <summary>The last good observation captured before the failure, or null when none exists.</summary>
     public JsonObject? LastObservation { get; }
 
+    /// <summary>
+    /// The failing call's OWN partial payload, when the command deliberately kept one — e.g. a blank
+    /// <c>capture</c> still carries the (suspect) PNG it grabbed so the evidence is not lost (#206).
+    /// Distinct from <see cref="LastObservation"/>, which is the last GOOD state from a prior call.
+    /// </summary>
+    public JsonObject? PartialResult { get; }
+
     /// <summary>The kebab-case wire string for <see cref="Category"/> that goes into <c>error.category</c>.</summary>
     public string CategoryWire => Category switch {
         AgentErrorCategory.Timeout => "timeout",
         AgentErrorCategory.AmbiguousSelector => "ambiguous-selector",
         AgentErrorCategory.StaleElement => "stale-element",
         AgentErrorCategory.NoTarget => "no-target",
+        AgentErrorCategory.InvalidArgument => "invalid-argument",
         AgentErrorCategory.CaptureBlank => "capture-blank",
         AgentErrorCategory.Focus => "focus",
         AgentErrorCategory.Elevation => "elevation",
@@ -55,6 +64,9 @@ public sealed class AgentError {
         };
         if (LastObservation is not null) {
             obj["lastObservation"] = LastObservation.DeepClone();
+        }
+        if (PartialResult is not null) {
+            obj["partialResult"] = PartialResult.DeepClone();
         }
         return obj;
     }

--- a/src/Agent/AgentErrorCategory.cs
+++ b/src/Agent/AgentErrorCategory.cs
@@ -23,6 +23,11 @@ public enum AgentErrorCategory {
     /// <summary>A selector matched nothing (no window/element).</summary>
     NoTarget,
 
+    /// <summary>The request itself was malformed or inapplicable — a client-supplied argument was
+    /// invalid (unknown action, oversized region, ill-formed endpoint) or cannot apply to the target.
+    /// Recovery is to FIX the arguments, not to retry the same call or broaden a selector (#191).</summary>
+    InvalidArgument,
+
     /// <summary>A screenshot was produced but detected as black/blank.</summary>
     CaptureBlank,
 

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -15,13 +15,14 @@ over time — a bounded one-shot (`durationMs`) or `action:start` then `action:s
 (fps/duration are capped and frames downscaled), and remember it captures whatever is on screen for the
 whole duration. Region targets (`x`/`y`/`width`/`height`) for `capture` and `record` are size-capped: max
 16384 px per side and 64000000 px total — an oversized region fails fast with `errorCode:region-too-large`
-(the detail states the limit); request a smaller region or a window target (windows are bounded by their
-own size). An open `start` auto-stops at the operator's limits (default 60 s / 600 frames); `stop`
+(category `invalid-argument`; the detail states the limit); request a smaller region or a window target
+(windows are bounded by their own size). An open `start` auto-stops at the operator's limits (default 60 s / 600 frames); `stop`
 still returns that buffered GIF — exactly once — and after an auto-stop a new recording (`start` or a
 one-shot) is allowed: it discards the unfetched GIF, carrying an `unfetched-recording-discarded` warning
 on its result, so `stop` promptly to collect your output. Check results for trouble: a `capture` with errorCategory `capture-blank` is a black/empty
 frame (minimized, cloaked, occluded, or a locked session) — restore/foreground the window and retry
-instead of trusting the image; a `capture-fallback` warning means PrintWindow was refused and the picture
+instead of trusting the image (the suspect PNG is still available in `error.partialResult` if you want to
+inspect what was grabbed); a `capture-fallback` warning means PrintWindow was refused and the picture
 may be wrong. If `query` returns `truncated:true` (a `tree-truncated` warning), the tree hit the node cap
 — raise `maxNodes` or target a deeper window so you don't reason over a partial tree. warnings are
 non-fatal; errorCategory tells you how to recover. The bounds `query`/`find` report are ABSOLUTE screen
@@ -37,7 +38,11 @@ returns promptly with `modalPending:true` — the action completes when the dial
 `query`/`capture` the new window to read it, and `invoke` its buttons to dismiss it. `invoke` does NOT
 wait for a control — it fast-fails if the element isn't present yet — so `wait-for` (or `find` with a
 timeout) the control before acting; an `invoke` that returns `error.category:no-target` means the control
-hasn't appeared yet, so `wait-for` it rather than blindly retrying. To DRAG — resize a window by its
+hasn't appeared yet, so `wait-for` it rather than blindly retrying. An `invoke` failing with
+`error.code:pattern-unsupported` (category `invalid-argument`) means the element EXISTS but cannot perform
+that action — re-finding it will never help; pick a different action or `click` its centre instead.
+`action-unknown` means the `action` string itself is wrong — fix it (invoke|toggle|setvalue|setfocus|
+expand|collapse|select). To DRAG — resize a window by its
 sizing border, move one by its title bar, drag a slider/handle, marquee-select, or reorder (there is no
 `invoke` for these) — use the `drag` tool: give a `from` and a `to`, each either an element `{ by, value }`
 in the target window (dragged from/to its centre) or an absolute screen pixel `{ x, y }`, plus optional
@@ -57,11 +62,15 @@ atomic drag in pixels and `mouse:mtp,x,y` moves the pointer to an absolute scree
 
 RESULTS: every tool returns one envelope — `{ ok, result?, warnings?, error? }`. Branch on `ok` first: on
 success read `result`; on failure read `error.category` (a closed set: timeout, ambiguous-selector,
-stale-element, no-target, capture-blank, focus, elevation, foreground, internal) to choose recovery — e.g.
-`no-target` means broaden the selector or `query` to discover targets, `ambiguous-selector` means add
-`processName`/`className`/`automationId`, `stale-element` means re-`query`/`find` for a fresh handle.
-`error.detail` is human-readable and `error.lastObservation`, when present, is the last good state before
-the failure.
+stale-element, no-target, invalid-argument, capture-blank, focus, elevation, foreground, internal) to
+choose recovery — e.g. `no-target` means broaden the selector, `query` to discover targets, or `wait-for`
+the element; `invalid-argument` means the REQUEST itself is wrong (unknown action, oversized region,
+ill-formed endpoint, an action the element can't perform) — fix the arguments, do NOT retry the same call
+or broaden a selector; `ambiguous-selector` means add `processName`/`className`/`automationId`;
+`stale-element` means re-`query`/`find` for a fresh handle; `internal` is not recoverable by you — report
+it. Branch on codes and categories, never on the wording of `error.detail` (it is human-readable and may
+change). `error.lastObservation`, when present, is the last good state before the failure, and
+`error.partialResult` is the failing call's OWN partial payload (e.g. a blank capture's suspect PNG).
 
 COMPOSE: many tasks have no single dedicated tool — build them by combining primitives creatively. Launch
 an app with the dedicated `launch` tool (`path` required, optional `arguments`/`workingDirectory`; returns the pid and the app's window handle once it appears). Fallback if `launch` is unavailable: `send_command winr` then `chars:<path>` then `enter` (the new window is foreground: `query {foreground}` for its handle). Use `invoke` with `action: "select"` for tabs/list items/radios. 

--- a/src/Agent/AgentToolResult.cs
+++ b/src/Agent/AgentToolResult.cs
@@ -125,6 +125,7 @@ public sealed class AgentToolResult {
             case "ambiguous-selector": category = AgentErrorCategory.AmbiguousSelector; return true;
             case "stale-element": category = AgentErrorCategory.StaleElement; return true;
             case "no-target": category = AgentErrorCategory.NoTarget; return true;
+            case "invalid-argument": category = AgentErrorCategory.InvalidArgument; return true;
             case "capture-blank": category = AgentErrorCategory.CaptureBlank; return true;
             case "focus": category = AgentErrorCategory.Focus; return true;
             case "elevation": category = AgentErrorCategory.Elevation; return true;

--- a/src/Agent/AgentToolResult.cs
+++ b/src/Agent/AgentToolResult.cs
@@ -18,11 +18,11 @@ namespace MCEControl;
 /// <see cref="Error"/>) <b>or</b> failure (<c>ok:false</c>, <see cref="Error"/> present, no
 /// <see cref="Result"/>) — never both. The factory methods enforce that invariant structurally.
 ///
-/// <para>Phase 1 (#86) wires this in at the <see cref="AgentServer"/> boundary by translating the
-/// legacy <see cref="CommandResult"/> each command still emits (see <see cref="FromLegacy"/>). The
-/// per-tool epics (#87–#91) will have the commands emit native categories, warnings, and
-/// <c>lastObservation</c> directly. <see cref="SessionId"/> stays null until the session store lands
-/// (Phase 2/3).</para>
+/// <para>Since #206 the envelope is built from the <see cref="CommandResult"/> OBJECT the command
+/// returned (see <see cref="FromCommandResult"/>) — no serialize → re-parse round-trip, and no
+/// free-text "categorization": every agent command emits the structured code/category itself
+/// (enforced by <see cref="AgentCommand"/>'s sealed template). <see cref="SessionId"/> stays null
+/// until the session store lands (Phase 2/3).</para>
 /// </summary>
 public sealed class AgentToolResult {
     private AgentToolResult(bool ok, JsonObject? result, AgentError? error, string? sessionId, IReadOnlyList<AgentWarning> warnings) {
@@ -61,62 +61,55 @@ public sealed class AgentToolResult {
         Failure(new AgentError(code, category, detail), sessionId);
 
     /// <summary>
-    /// Translates a legacy <see cref="CommandResult"/> JSON object
-    /// (<c>{ success, command, error, errorCode?, errorCategory?, data?, warnings? }</c>) — what each agent
-    /// command writes to its reply today — into the #101 envelope. Success carries <c>data</c> forward as
-    /// <see cref="Result"/>. On failure, the command's own structured <c>errorCategory</c>/<c>errorCode</c>
-    /// (e.g. <c>capture-blank</c>) are preserved when present; only a bare free-text error is mapped onto
-    /// the closed taxonomy via <see cref="Categorize"/> (the Phase 1 shim). Legacy <c>warnings</c> are
-    /// carried through on success or failure. When a failure has no observation of its own,
-    /// <paramref name="lastObservation"/> (the session's last good state before this call) is attached to
-    /// <c>error.lastObservation</c> so the failure is debuggable without rerunning it.
+    /// Builds the #101 envelope from the <see cref="CommandResult"/> OBJECT an agent command returned
+    /// (#206) — the object flows through; nothing is serialized and re-parsed. Success carries
+    /// <see cref="CommandResult.Data"/> forward as <see cref="Result"/> (same instance). On failure the
+    /// command's structured <see cref="CommandResult.ErrorCode"/>/<see cref="CommandResult.ErrorCategory"/>
+    /// become the error (they are mandatory — <see cref="AgentCommand"/> normalizes a missing pair to
+    /// <c>unhandled</c>/<c>internal</c>; an unknown category string maps to <c>internal</c> so
+    /// <c>error.category</c> always validates against the closed set), any failure <c>Data</c> the
+    /// command kept (e.g. a blank capture's suspect PNG) rides in <c>error.partialResult</c>, and
+    /// <paramref name="lastObservation"/> (the session's last good state before this call) is attached
+    /// to <c>error.lastObservation</c> so the failure is debuggable without rerunning it.
     ///
-    /// <para>One success is reclassified as a failure: <see cref="FindCommand"/> writes
+    /// <para>One success is reclassified as a failure: <see cref="FindCommand"/> returns
     /// <c>Ok{found:false}</c> when a <c>wait-for</c> exhausts its timeout, but an agent branches on
     /// <c>ok</c> — so a wait that never resolved must surface as a <c>timeout</c> failure, not
     /// <c>ok:true</c>. A one-shot <c>find</c> miss stays a success ("a miss is not an error").</para>
     /// </summary>
-    public static AgentToolResult FromLegacy(JsonObject legacy, string toolName, string? sessionId = null, JsonObject? lastObservation = null) {
-        IReadOnlyList<AgentWarning> warnings = ReadWarnings(legacy);
-        bool success = legacy["success"] is JsonValue sv && sv.TryGetValue(out bool b) && b;
-        if (success) {
-            JsonObject? data = (legacy["data"] as JsonObject)?.DeepClone() as JsonObject;
-            if (IsWaitForMiss(toolName, data)) {
+    public static AgentToolResult FromCommandResult(CommandResult command, string toolName, string? sessionId = null, JsonObject? lastObservation = null) {
+        if (command is null) {
+            throw new ArgumentNullException(nameof(command));
+        }
+
+        List<AgentWarning> warnings = [];
+        foreach (CommandWarning w in command.Warnings) {
+            warnings.Add(new AgentWarning(w.Code, w.Detail));
+        }
+
+        if (command.Success) {
+            if (IsWaitForMiss(toolName, command.Data)) {
                 return Failure(
                     new AgentError("wait-condition-timeout", AgentErrorCategory.Timeout,
                         "wait-for exhausted its timeout before the element appeared.", lastObservation),
                     sessionId, warnings);
             }
-            return Success(data, sessionId, warnings);
+            return Success(command.Data, sessionId, warnings);
         }
 
-        string message = LegacyString(legacy, "error") ?? "The command failed without a message.";
-
-        // Prefer the structured taxonomy the command already emitted (e.g. capture-blank / frame-all-black)
-        // over re-deriving it from free text. Only fall back to Categorize when the command wrote a bare
-        // error string with no code/category (the Phase 1 shim path).
-        AgentError error;
-        string? code = LegacyString(legacy, "errorCode");
-        if (code is not null && LegacyString(legacy, "errorCategory") is string wire && TryParseCategory(wire, out AgentErrorCategory category)) {
-            error = new AgentError(code, category, message, lastObservation);
-        }
-        else {
-            error = Categorize(toolName, message);
-            if (lastObservation is not null) {
-                error = new AgentError(error.Code, error.Category, error.Detail, lastObservation);
-            }
-        }
-        return Failure(error, sessionId, warnings);
+        string detail = command.Error ?? "The command failed without a message.";
+        string code = string.IsNullOrEmpty(command.ErrorCode) ? "unhandled" : command.ErrorCode;
+        AgentErrorCategory category =
+            command.ErrorCategory is string wire && TryParseCategory(wire, out AgentErrorCategory parsed)
+                ? parsed
+                : AgentErrorCategory.Internal;
+        return Failure(new AgentError(code, category, detail, lastObservation, command.Data), sessionId, warnings);
     }
 
     /// <summary>True when a <c>wait-for</c> returned <c>found:false</c> — i.e. it timed out.</summary>
     private static bool IsWaitForMiss(string toolName, JsonObject? data) =>
         string.Equals(toolName, "wait-for", StringComparison.OrdinalIgnoreCase)
         && data?["found"] is JsonValue fv && fv.TryGetValue(out bool found) && !found;
-
-    /// <summary>Reads a string property from a legacy result object, or null if absent/non-string.</summary>
-    private static string? LegacyString(JsonObject legacy, string key) =>
-        legacy[key] is JsonValue v && v.TryGetValue(out string? s) ? s : null;
 
     /// <summary>Maps a wire category string back onto the closed taxonomy; false for an unknown string.</summary>
     private static bool TryParseCategory(string wire, out AgentErrorCategory category) {
@@ -133,49 +126,6 @@ public sealed class AgentToolResult {
             case "internal": category = AgentErrorCategory.Internal; return true;
             default: category = AgentErrorCategory.Internal; return false;
         }
-    }
-
-    /// <summary>Carries the legacy result's <c>warnings</c> (<c>{ code, detail }</c>) into the envelope.</summary>
-    private static IReadOnlyList<AgentWarning> ReadWarnings(JsonObject legacy) {
-        if (legacy["warnings"] is not JsonArray arr || arr.Count == 0) {
-            return [];
-        }
-        List<AgentWarning> list = [];
-        foreach (JsonNode? n in arr) {
-            if (n is JsonObject w && LegacyString(w, "code") is string code && LegacyString(w, "detail") is string detail) {
-                list.Add(new AgentWarning(code, detail));
-            }
-        }
-        return list;
-    }
-
-    /// <summary>
-    /// Maps a legacy free-text command error onto the closed <see cref="AgentErrorCategory"/> taxonomy.
-    /// This is the Phase 1 translation shim: the known error strings are pinned by the command-level
-    /// tests, so the mapping is stable. Unrecognized messages fall back to <c>internal</c> (not
-    /// agent-recoverable; surface to the operator), per the contract's recovery guidance.
-    /// </summary>
-    public static AgentError Categorize(string toolName, string message) {
-        string m = message ?? "";
-
-        if (m.Contains("No matching window", StringComparison.OrdinalIgnoreCase)) {
-            return new AgentError("window-not-found", AgentErrorCategory.NoTarget, m);
-        }
-        if (m.Contains("Invoke failed", StringComparison.OrdinalIgnoreCase)) {
-            // The element was not found or its pattern is unsupported; agent recovery is to re-query/
-            // re-find a fresh target, which is exactly the no-target recovery path.
-            return new AgentError("element-not-found", AgentErrorCategory.NoTarget, m);
-        }
-        if (m.Contains("Capture failed", StringComparison.OrdinalIgnoreCase)) {
-            return new AgentError("capture-exception", AgentErrorCategory.Internal, m);
-        }
-        if (m.Contains("disabled", StringComparison.OrdinalIgnoreCase)) {
-            return new AgentError("agent-commands-disabled", AgentErrorCategory.Internal, m);
-        }
-        if (m.Contains("produced no output", StringComparison.OrdinalIgnoreCase)) {
-            return new AgentError("no-output", AgentErrorCategory.Internal, m);
-        }
-        return new AgentError("unhandled", AgentErrorCategory.Internal, m);
     }
 
     /// <summary>Serializes to the camelCase, nulls-omitted envelope object (per <see cref="AgentJson.Options"/>).</summary>

--- a/src/Agent/CapturingReply.cs
+++ b/src/Agent/CapturingReply.cs
@@ -8,12 +8,31 @@ namespace MCEControl;
 /// <summary>
 /// A <see cref="Reply"/> that accumulates everything a command writes into an in-memory buffer
 /// instead of sending it over a socket/serial transport. The MCP/HTTP façade uses this to run a
-/// command synchronously and capture its (structured JSON) output as the tool-call result.
+/// command synchronously and capture its output as the tool-call result.
+///
+/// <para>Agent commands additionally hand their structured <see cref="CommandResult"/> over as an
+/// OBJECT via <see cref="Result"/> (#206): <see cref="AgentCommand"/>'s sealed template sets it when
+/// the reply is a <see cref="CapturingReply"/> instead of serializing to text, so the MCP server
+/// consumes the result without a serialize → parse round-trip (which used to materialize a capture's
+/// base64 PNG three to four times). <see cref="Captured"/> lazily serializes the object for callers
+/// that still want the legacy JSON text (<c>send_command</c>'s output, tests), so the observable
+/// text is unchanged.</para>
 /// </summary>
 public sealed class CapturingReply : Reply {
     private readonly StringBuilder _buffer = new();
 
     public override void Write(string text) => _buffer.Append(text);
 
-    public string Captured => _buffer.ToString();
+    /// <summary>
+    /// The typed result an <see cref="AgentCommand"/> produced, or null when the executed command is
+    /// not an agent command (legacy commands write free text into the buffer instead).
+    /// </summary>
+    public CommandResult? Result { get; set; }
+
+    /// <summary>
+    /// Everything written to this reply as text. When nothing was written but a typed
+    /// <see cref="Result"/> was set, serializes it on demand — same bytes the legacy TCP/serial
+    /// transport would have carried.
+    /// </summary>
+    public string Captured => _buffer.Length > 0 ? _buffer.ToString() : Result?.ToJson() ?? "";
 }

--- a/src/Agent/UiaInvokeResult.cs
+++ b/src/Agent/UiaInvokeResult.cs
@@ -1,0 +1,33 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// The outcome of a <see cref="UiaService.Invoke"/> pattern dispatch (#206). The old bare bool
+/// conflated four distinct failures, so an agent could not tell "the element is not there yet"
+/// (re-find/wait) from "the element exists but cannot do that action" (change the action — re-finding
+/// loops forever) from "the action name is a typo" (fix the argument) from "UIA faulted" (report it).
+/// <see cref="InvokeCommand"/> maps each member to a distinct error code/category.
+/// </summary>
+public enum UiaInvokeResult {
+    /// <summary>The action was dispatched to the element's pattern successfully.</summary>
+    Ok,
+
+    /// <summary>No element matched the selector within the lookup timeout (or the window handle was
+    /// invalid). Recovery: <c>wait-for</c>/<c>find</c> the element, then retry.</summary>
+    ElementNotFound,
+
+    /// <summary>The element WAS found but does not support the UIA pattern the action needs
+    /// (e.g. <c>toggle</c> on a plain button). Recovery: choose a different action or click it —
+    /// re-finding the same element cannot help.</summary>
+    PatternUnsupported,
+
+    /// <summary>The action string is not one of the supported actions (a typo like <c>click</c> or
+    /// <c>set-value</c>). Nothing was looked up or dispatched. Recovery: fix the argument.</summary>
+    ActionUnknown,
+
+    /// <summary>UIA threw while attaching, finding, or dispatching (window closed mid-call, COM
+    /// fault). Not agent-recoverable beyond re-observing the target.</summary>
+    Faulted,
+}

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -84,30 +84,31 @@ public static class UiaService {
     /// <summary>
     /// Finds an element (a short <see cref="InvokeFindTimeoutMs"/> lookup — invoke fast-fails rather
     /// than waiting; see that constant) and dispatches <paramref name="action"/>
-    /// (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>).
-    /// Returns true on success, false if the element wasn't found or the required pattern is
-    /// unsupported. <c>expand</c> opens a collapsed menu/treeitem so its children become reachable —
+    /// (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>/<c>select</c>).
+    /// Returns a <see cref="UiaInvokeResult"/> that keeps the four failure modes distinct (#206) — the
+    /// old bare bool made an agent re-find elements that existed but lacked the pattern, i.e. loop.
+    /// <c>expand</c> opens a collapsed menu/treeitem so its children become reachable —
     /// a closed WinForms menu's sub-items are not in the UIA tree until the parent is opened. It uses
     /// the ExpandCollapse pattern, falling back to Invoke for WinForms menu items that lack it.
     /// </summary>
-    public static bool Invoke(IntPtr hwnd, string by, string value, string action, string? text) {
+    public static UiaInvokeResult Invoke(IntPtr hwnd, string by, string value, string action, string? text) {
         if (hwnd == IntPtr.Zero) {
-            return false;
+            return UiaInvokeResult.ElementNotFound;
         }
         // Reject an unknown/typo action (e.g. "click", "set-value") rather than silently activating the
         // element via the default Invoke pattern. The caller defaults a missing action to "invoke".
         if (!IsSupportedAction(action)) {
             Logger.Instance.Log4.Warn($"UiaService.Invoke: unsupported action '{action}' — rejected.");
-            return false;
+            return UiaInvokeResult.ActionUnknown;
         }
         try {
             using UIA3Automation automation = new();
             AutomationElement root = automation.FromHandle(hwnd);
             AutomationElement? el = FindElement(root, by, value, InvokeFindTimeoutMs);
             if (el is null) {
-                return false;
+                return UiaInvokeResult.ElementNotFound;
             }
-            return action.ToLowerInvariant() switch {
+            bool dispatched = action.ToLowerInvariant() switch {
                 "invoke" => InvokeDefault(el),
                 "toggle" => InvokeToggle(el),
                 "setvalue" => InvokeSetValue(el, text),
@@ -115,12 +116,14 @@ public static class UiaService {
                 "expand" => InvokeExpand(el),
                 "collapse" => InvokeCollapse(el),
                 "select" => InvokeSelect(el),
-                _ => false,
+                _ => false, // unreachable: IsSupportedAction gated above
             };
+            // The element exists; the only way a dispatcher returns false is a missing UIA pattern.
+            return dispatched ? UiaInvokeResult.Ok : UiaInvokeResult.PatternUnsupported;
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"UiaService.Invoke failed: {e.Message}");
-            return false;
+            return UiaInvokeResult.Faulted;
         }
     }
 

--- a/src/Commands/AgentCommand.cs
+++ b/src/Commands/AgentCommand.cs
@@ -10,6 +10,14 @@ namespace MCEControl;
 /// security gate STRUCTURAL: a subclass implements <see cref="ExecuteCore"/> and can only ever run
 /// after the gate has passed — forgetting the gate is impossible by construction (issue #208).
 ///
+/// RESULTS (#206): <see cref="ExecuteCore"/> returns the command's <see cref="CommandResult"/> as an
+/// OBJECT; the template emits it once per transport. Over the legacy TCP/serial pipeline it writes
+/// <c>result.ToJson()</c> to <see cref="Command.Reply"/> exactly as before; for the MCP path it hands
+/// the object to <see cref="CapturingReply.Result"/> so the server never re-parses its own output.
+/// The template also normalizes failures: a failure without a structured code/category is stamped
+/// <c>unhandled</c>/<c>internal</c>, so every agent failure envelope is categorical by construction
+/// — there is no free-text-only failure for prose-sniffing to interpret.
+///
 /// SECURITY — why the gate must live here and not (only) in the server: the MCP path checks
 /// <c>AgentCommandsEnabled</c> in <c>AgentServer</c> before dispatch, but agent commands are ordinary
 /// <see cref="Command"/>s reachable over the legacy TCP/serial pipeline too, and that pipeline has NO
@@ -21,30 +29,50 @@ namespace MCEControl;
 /// </summary>
 public abstract class AgentCommand : Command {
     /// <summary>
-    /// Sealed gate + audit + dispatch template. Order (identical to the pre-#208 hand-written
+    /// Sealed gate + audit + dispatch + emit template. Order (identical to the pre-#208 hand-written
     /// bodies): the <see cref="Command.Execute"/> per-command <c>Enabled</c> check and telemetry,
     /// then the <see cref="AgentRuntime.AgentCommandsEnabled"/> opt-in gate (fail-closed with the
     /// same structured <see cref="CommandResult"/> the commands have always emitted), then the
     /// <see cref="AgentRuntime.Audit"/> line (when <see cref="AuditDetails"/> supplies one), then
-    /// <see cref="ExecuteCore"/>.
+    /// <see cref="ExecuteCore"/>, then a single result emission (see the class remarks).
     /// </summary>
     public sealed override bool Execute() {
         if (!base.Execute()) {
             return false;
         }
 
+        CommandResult result;
         if (!AgentRuntime.AgentCommandsEnabled) {
             Logger.Instance.Log4.Warn($"{GetType().Name}: BLOCKED — agent commands are disabled. Set AgentCommandsEnabled=true to opt in.");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).").ToJson());
-            return false;
+            result = CommandResult.Fail(Cmd, "Agent commands are disabled (AgentCommandsEnabled=false).",
+                "agent-commands-disabled", "internal");
+        }
+        else {
+            string? auditDetails = AuditDetails();
+            if (auditDetails is not null) {
+                AgentRuntime.Audit(Cmd, auditDetails);
+            }
+            result = ExecuteCore();
         }
 
-        string? auditDetails = AuditDetails();
-        if (auditDetails is not null) {
-            AgentRuntime.Audit(Cmd, auditDetails);
+        // Structural guarantee (#206): every agent failure carries the closed taxonomy. A command
+        // that slipped a bare-string Fail through still produces a categorical envelope.
+        if (!result.Success) {
+            result.ErrorCode ??= "unhandled";
+            result.ErrorCategory ??= "internal";
         }
 
-        return ExecuteCore();
+        if (Reply is CapturingReply capturing) {
+            // In-process (MCP) dispatch: hand the OBJECT over; the server consumes it directly and
+            // CapturingReply.Captured serializes lazily if legacy text is ever wanted.
+            capturing.Result = result;
+        }
+        else {
+            // Legacy TCP/serial transport: the same JSON line these commands have always written.
+            Reply?.WriteLine(result.ToJson());
+        }
+
+        return result.Success;
     }
 
     /// <summary>
@@ -56,7 +84,10 @@ public abstract class AgentCommand : Command {
 
     /// <summary>
     /// The command body. Runs only when the per-command <c>Enabled</c> flag AND the
-    /// <see cref="AgentRuntime.AgentCommandsEnabled"/> opt-in are both set.
+    /// <see cref="AgentRuntime.AgentCommandsEnabled"/> opt-in are both set. Returns the command's
+    /// structured result — the template owns emitting it (never write it to <see cref="Command.Reply"/>
+    /// here). Failures should carry a structured code/category (<see
+    /// cref="CommandResult.Fail(string, string, string, string, System.Text.Json.Nodes.JsonObject?)"/>).
     /// </summary>
-    protected abstract bool ExecuteCore();
+    protected abstract CommandResult ExecuteCore();
 }

--- a/src/Commands/CaptureCommand.cs
+++ b/src/Commands/CaptureCommand.cs
@@ -68,10 +68,12 @@ public class CaptureCommand : WindowTargetingAgentCommand {
     private bool CaptureRegion() {
         // SECURITY (#158): region dimensions are agent-controlled — reject oversized
         // requests BEFORE any bitmap/PNG/base64 allocation, with a diagnosable envelope.
+        // Category invalid-argument (#191): the recovery is to SHRINK the request, not to broaden
+        // a selector — no-target's documented recovery would send the agent the wrong way.
         string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
         if (sizeError is not null) {
             AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED — {sizeError}");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, sizeError, "region-too-large", "no-target").ToJson());
+            Reply?.WriteLine(CommandResult.Fail(Cmd, sizeError, "region-too-large", "invalid-argument").ToJson());
             return false;
         }
 

--- a/src/Commands/CaptureCommand.cs
+++ b/src/Commands/CaptureCommand.cs
@@ -47,25 +47,23 @@ public class CaptureCommand : WindowTargetingAgentCommand {
     // which fails as window-not-found) does.
     protected override bool RequiresWindowTarget => !IsRegionCapture;
 
-    protected override bool OnWindowNotFound() {
+    protected override CommandResult OnWindowNotFound() {
         AgentRuntime.Audit(Cmd, "no matching window");
-        Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
-        return false;
+        return base.OnWindowNotFound();
     }
 
-    protected override bool ExecuteCore(WindowInfo? target) {
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
         try {
             return target is null ? CaptureRegion() : CaptureWindow(target);
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"{GetType().Name}: Capture failed: {e.Message}");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, $"Capture failed: {e.Message}").ToJson());
-            return false;
+            return CommandResult.Fail(Cmd, $"Capture failed: {e.Message}", "capture-exception", "internal");
         }
     }
 
     /// <summary>The explicit-region path (no window was required or resolved).</summary>
-    private bool CaptureRegion() {
+    private CommandResult CaptureRegion() {
         // SECURITY (#158): region dimensions are agent-controlled — reject oversized
         // requests BEFORE any bitmap/PNG/base64 allocation, with a diagnosable envelope.
         // Category invalid-argument (#191): the recovery is to SHRINK the request, not to broaden
@@ -73,8 +71,7 @@ public class CaptureCommand : WindowTargetingAgentCommand {
         string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
         if (sizeError is not null) {
             AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED — {sizeError}");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, sizeError, "region-too-large", "invalid-argument").ToJson());
-            return false;
+            return CommandResult.Fail(Cmd, sizeError, "region-too-large", "invalid-argument");
         }
 
         AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height}");
@@ -96,12 +93,11 @@ public class CaptureCommand : WindowTargetingAgentCommand {
         if (regionCap.Stats.IsBlank) {
             regionRes.Warn("capture-blank", "Captured region is blank (a flat fill); it may be off-screen or genuinely empty.");
         }
-        Reply?.WriteLine(regionRes.ToJson());
-        return true;
+        return regionRes;
     }
 
     /// <summary>The resolved-window path.</summary>
-    private bool CaptureWindow(WindowInfo win) {
+    private CommandResult CaptureWindow(WindowInfo win) {
         AgentRuntime.Audit(Cmd, $"window 0x{win.Handle:X} \"{win.Title}\" ({win.ProcessName})");
 
         CaptureResult cap = ScreenCapture.CaptureWindow(new IntPtr(win.Handle));
@@ -118,10 +114,9 @@ public class CaptureCommand : WindowTargetingAgentCommand {
         WriteFileIfRequested(cap.Png, data);
 
         // A blank window frame is a hard observation failure: don't return a silent bad image.
-        // The PNG stays in `data` (so the agent still sees what was grabbed and it can serve as the
-        // contract's lastObservation), but the result is flagged capture-blank so the agent branches.
+        // The PNG stays in `data` (carried into the envelope's error.partialResult, #206 — the agent
+        // still sees what was grabbed), and the result is flagged capture-blank so the agent branches.
         CommandResult res;
-        bool ok;
         if (cap.Stats.IsBlank) {
             string code = cap.Stats.DominantIsDark ? "frame-all-black" : "frame-uniform";
             string detail = cap.UsedFallback
@@ -129,17 +124,14 @@ public class CaptureCommand : WindowTargetingAgentCommand {
                 : "Captured frame is blank (a flat fill); the window may be minimized, cloaked, or rendering off-screen.";
             AgentRuntime.Audit(Cmd, $"blank frame ({code}, dominant {cap.Stats.DominantFraction:P0}, fallback={cap.UsedFallback})");
             res = CommandResult.Fail(Cmd, detail, code, "capture-blank", data);
-            ok = false;
         }
         else {
             res = CommandResult.Ok(Cmd, data);
-            ok = true;
         }
         if (cap.UsedFallback) {
             res.Warn("capture-fallback", "PrintWindow was refused; used an on-screen blit, which returns black for composited/occluded surfaces and cannot see windows behind others.");
         }
-        Reply?.WriteLine(res.ToJson());
-        return ok;
+        return res;
     }
 
     /// <summary>Serializes the blank-frame analysis so an agent can see why a capture was flagged.</summary>

--- a/src/Commands/ClickCommand.cs
+++ b/src/Commands/ClickCommand.cs
@@ -44,17 +44,11 @@ public class ClickCommand : WindowTargetingAgentCommand {
     // A window is only needed to resolve an element endpoint; a pure pixel click needs none.
     protected override bool RequiresWindowTarget => !string.IsNullOrEmpty(Value);
 
-    protected override bool OnWindowNotFound() {
-        Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
-        return false;
-    }
-
-    protected override bool ExecuteCore(WindowInfo? target) {
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr hwnd = target is null ? IntPtr.Zero : new IntPtr(target.Handle);
 
         if (!TryResolvePoint(hwnd, out (int X, int Y) point, out string? error)) {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, error!, "element-not-found", "no-target").ToJson());
-            return false;
+            return CommandResult.Fail(Cmd, error!, "element-not-found", "no-target");
         }
 
         // Clamp to the {1,2} the contract exposes and normalize the button, then dispatch and echo the
@@ -70,8 +64,7 @@ public class ClickCommand : WindowTargetingAgentCommand {
             ["button"] = button,
             ["count"] = count,
         };
-        Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
-        return true;
+        return CommandResult.Ok(Cmd, data);
     }
 
     /// <summary>

--- a/src/Commands/DisplaysCommand.cs
+++ b/src/Commands/DisplaysCommand.cs
@@ -26,7 +26,7 @@ public class DisplaysCommand : AgentCommand {
 
     protected override string? AuditDetails() => "displays";
 
-    protected override bool ExecuteCore() {
+    protected override CommandResult ExecuteCore() {
         JsonArray displays = [];
         Screen[] screens = Screen.AllScreens;
         for (int i = 0; i < screens.Length; i++) {
@@ -48,8 +48,7 @@ public class DisplaysCommand : AgentCommand {
             ["virtualBounds"] = RectJson(SystemInformation.VirtualScreen),
             ["displays"] = displays,
         };
-        Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
-        return true;
+        return CommandResult.Ok(Cmd, data);
     }
 
     /// <summary>

--- a/src/Commands/DragCommand.cs
+++ b/src/Commands/DragCommand.cs
@@ -49,16 +49,16 @@ public class DragCommand : WindowTargetingAgentCommand {
     // A window is only needed to resolve element endpoints; a pure coordinate drag needs none.
     protected override bool RequiresWindowTarget => !string.IsNullOrEmpty(FromValue) || !string.IsNullOrEmpty(ToValue);
 
-    protected override bool ExecuteCore(WindowInfo? target) {
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr hwnd = target is null ? IntPtr.Zero : new IntPtr(target.Handle);
 
+        // Endpoint misses are element lookups, so they carry the same element-not-found / no-target
+        // taxonomy as click/invoke (#206) — the recovery (wait-for/re-find the element) is identical.
         if (!TryResolvePoint(hwnd, FromBy, FromValue, FromX, FromY, out (int X, int Y) from, out string? fromError)) {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, $"Drag start: {fromError}").ToJson());
-            return false;
+            return CommandResult.Fail(Cmd, $"Drag start: {fromError}", "element-not-found", "no-target");
         }
         if (!TryResolvePoint(hwnd, ToBy, ToValue, ToX, ToY, out (int X, int Y) to, out string? toError)) {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, $"Drag end: {toError}").ToJson());
-            return false;
+            return CommandResult.Fail(Cmd, $"Drag end: {toError}", "element-not-found", "no-target");
         }
 
         List<(int X, int Y)> waypoints = [from];
@@ -73,8 +73,7 @@ public class DragCommand : WindowTargetingAgentCommand {
             ["to"] = new JsonArray { to.X, to.Y },
             ["points"] = waypoints.Count,
         };
-        Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
-        return true;
+        return CommandResult.Ok(Cmd, data);
     }
 
     /// <summary>

--- a/src/Commands/FindCommand.cs
+++ b/src/Commands/FindCommand.cs
@@ -32,7 +32,7 @@ public class FindCommand : WindowTargetingAgentCommand {
     protected override string? AuditDetails() =>
         $"find by={By} value='{Value}' timeout={EffectiveTimeout} window handle={Handle} title='{Window}' process='{Process}'";
 
-    protected override bool ExecuteCore(WindowInfo? target) {
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr h = new IntPtr(target!.Handle);
         UiaElementInfo? info = UiaService.Find(h, By, Value, EffectiveTimeout);
         bool found = info is not null;
@@ -43,7 +43,6 @@ public class FindCommand : WindowTargetingAgentCommand {
             // that establishes the current control feeds error.lastObservation for a later failing action).
             ["window"] = target.ToJsonObject(),
         };
-        Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
-        return true;
+        return CommandResult.Ok(Cmd, data);
     }
 }

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -8,9 +8,11 @@ namespace MCEControl;
 
 /// <summary>
 /// Agent actuation command: resolves a target window, finds a single UIA element, then runs a UIA
-/// pattern action against it (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>/<c>select</c>). Gated by
-/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
-/// <see cref="AgentCommand"/>). Disabled by default (security).
+/// pattern action against it (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>/<c>select</c>).
+/// Failures are categorical (#206): each <see cref="UiaInvokeResult"/> outcome maps to a distinct
+/// error code/category (see <see cref="FailureFor"/>) so an agent can tell "wait for it" from "stop
+/// re-finding and change the action". Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and
+/// audited (structurally, via <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
 public class InvokeCommand : WindowTargetingAgentCommand {
     [XmlAttribute("by")] public string By { get; set; } = "name";
@@ -27,19 +29,40 @@ public class InvokeCommand : WindowTargetingAgentCommand {
 
     protected override bool ExecuteCore(WindowInfo? target) {
         IntPtr h = new IntPtr(target!.Handle);
-        bool ok = UiaService.Invoke(h, By, Value, Action, Text);
-        if (ok) {
+        UiaInvokeResult outcome = UiaService.Invoke(h, By, Value, Action, Text);
+        if (outcome == UiaInvokeResult.Ok) {
             JsonObject data = new() {
-                ["invoked"] = ok,
+                ["invoked"] = true,
                 ["action"] = Action,
                 ["by"] = By,
                 ["value"] = Value,
             };
             Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
+            return true;
         }
-        else {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "Invoke failed (element not found or pattern unsupported)").ToJson());
-        }
-        return ok;
+        Reply?.WriteLine(FailureFor(outcome).ToJson());
+        return false;
     }
+
+    /// <summary>
+    /// Maps a failed <see cref="UiaInvokeResult"/> onto a distinct error code/category (#206). The
+    /// distinctions matter for recovery: <c>no-target</c> means wait/re-find; <c>invalid-argument</c>
+    /// means fix the call (re-finding a pattern-less element loops forever); <c>internal</c> means
+    /// report it. Internal so tests can pin the mapping without a live UIA tree.
+    /// </summary>
+    internal CommandResult FailureFor(UiaInvokeResult outcome) => outcome switch {
+        UiaInvokeResult.ElementNotFound => CommandResult.Fail(Cmd,
+            $"Element not found ({By}='{Value}') in the target window. invoke does not wait — find/wait-for the element first.",
+            "element-not-found", "no-target"),
+        UiaInvokeResult.PatternUnsupported => CommandResult.Fail(Cmd,
+            $"The element ({By}='{Value}') exists but does not support the UIA pattern the '{Action}' action needs. " +
+            "Re-finding it will not help — use a different action (or click it) instead.",
+            "pattern-unsupported", "invalid-argument"),
+        UiaInvokeResult.ActionUnknown => CommandResult.Fail(Cmd,
+            $"Unknown action '{Action}'. Use invoke, toggle, setvalue, setfocus, expand, collapse, or select.",
+            "action-unknown", "invalid-argument"),
+        _ => CommandResult.Fail(Cmd,
+            "Invoke faulted: UI Automation threw while attaching to or driving the target (it may have closed mid-call). Re-observe the window.",
+            "invoke-faulted", "internal"),
+    };
 }

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -27,7 +27,7 @@ public class InvokeCommand : WindowTargetingAgentCommand {
     protected override string? AuditDetails() =>
         $"invoke action={Action} by={By} value='{Value}' window handle={Handle} title='{Window}' process='{Process}'";
 
-    protected override bool ExecuteCore(WindowInfo? target) {
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr h = new IntPtr(target!.Handle);
         UiaInvokeResult outcome = UiaService.Invoke(h, By, Value, Action, Text);
         if (outcome == UiaInvokeResult.Ok) {
@@ -37,11 +37,9 @@ public class InvokeCommand : WindowTargetingAgentCommand {
                 ["by"] = By,
                 ["value"] = Value,
             };
-            Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
-            return true;
+            return CommandResult.Ok(Cmd, data);
         }
-        Reply?.WriteLine(FailureFor(outcome).ToJson());
-        return false;
+        return FailureFor(outcome);
     }
 
     /// <summary>

--- a/src/Commands/LaunchCommand.cs
+++ b/src/Commands/LaunchCommand.cs
@@ -31,10 +31,11 @@ public class LaunchCommand : AgentCommand {
     public LaunchCommand() { }
 
     // Audits after path validation (below), with the effective timeout — not via AuditDetails.
-    protected override bool ExecuteCore() {
+    protected override CommandResult ExecuteCore() {
         if (string.IsNullOrWhiteSpace(Path)) {
-            Reply?.WriteLine(CommandResult.Fail(Cmd, "launch requires a non-empty 'path' (executable, shell: protocol, or .lnk).").ToJson());
-            return false;
+            return CommandResult.Fail(Cmd,
+                "launch requires a non-empty 'path' (executable, shell: protocol, or .lnk).",
+                "launch-path-missing", "invalid-argument");
         }
 
         int timeout = Timeout > 0 ? Timeout : 5000;
@@ -97,13 +98,11 @@ public class LaunchCommand : AgentCommand {
                 data["note"] = "Window did not appear within timeout; use query/process or wait-for by process to locate later.";
             }
 
-            Reply?.WriteLine(CommandResult.Ok(Cmd, data).ToJson());
-            return true;
+            return CommandResult.Ok(Cmd, data);
         }
         catch (Exception ex) {
             Logger.Instance.Log4.Error($"{GetType().Name}: launch failed for '{Path}': {ex.Message}");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, $"Launch failed: {ex.Message}", "launch-failed", "internal").ToJson());
-            return false;
+            return CommandResult.Fail(Cmd, $"Launch failed: {ex.Message}", "launch-failed", "internal");
         }
     }
 

--- a/src/Commands/QueryCommand.cs
+++ b/src/Commands/QueryCommand.cs
@@ -25,12 +25,7 @@ public class QueryCommand : WindowTargetingAgentCommand {
     protected override string? AuditDetails() =>
         $"query window handle={Handle} title='{Window}' process='{Process}' class='{ClassName}' fg={Foreground} maxDepth={MaxDepth} maxNodes={MaxNodes}";
 
-    protected override bool OnWindowNotFound() {
-        Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target").ToJson());
-        return false;
-    }
-
-    protected override bool ExecuteCore(WindowInfo? target) {
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr h = new IntPtr(target!.Handle);
         UiaTreeResult tree = UiaService.DumpTree(h, MaxDepth, MaxNodes);
         JsonObject data = new() {
@@ -43,7 +38,6 @@ public class QueryCommand : WindowTargetingAgentCommand {
         if (tree.Truncated) {
             res.Warn("tree-truncated", $"UIA tree exceeded the {MaxNodes}-node cap and was clipped; raise maxNodes or narrow the target for a complete tree.");
         }
-        Reply?.WriteLine(res.ToJson());
-        return true;
+        return res;
     }
 }

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -54,7 +54,7 @@ public class RecordCommand : WindowTargetingAgentCommand {
     // the region-vs-window branch and its distinct error/audit shapes), not in the base template.
     protected override bool RequiresWindowTarget => false;
 
-    protected override bool ExecuteCore(WindowInfo? target) {
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
         // Default the action: `oneshot` when a duration is given, else `start`.
         string action = string.IsNullOrWhiteSpace(Action)
             ? (DurationMs > 0 ? "oneshot" : "start")
@@ -65,13 +65,13 @@ public class RecordCommand : WindowTargetingAgentCommand {
                 "stop" => DoStop(),
                 "start" => DoStart(oneshot: false),
                 "oneshot" => DoStart(oneshot: true),
-                _ => FailWith($"Unknown record action '{action}'. Use start, stop, or oneshot."),
+                _ => FailWith($"Unknown record action '{action}'. Use start, stop, or oneshot.",
+                    code: "record-action-unknown", category: "invalid-argument"),
             };
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"{GetType().Name}: record failed: {e.Message}");
-            Reply?.WriteLine(CommandResult.Fail(Cmd, $"Record failed: {e.Message}").ToJson());
-            return false;
+            return CommandResult.Fail(Cmd, $"Record failed: {e.Message}", "record-exception", "internal");
         }
     }
 
@@ -79,9 +79,12 @@ public class RecordCommand : WindowTargetingAgentCommand {
     private bool IsRegionTarget => Width > 0 && Height > 0 && !HasWindowTarget;
 
     /// <summary>Starts a recording; for a one-shot, also waits the duration and stops/encodes/writes.</summary>
-    private bool DoStart(bool oneshot) {
+    private CommandResult DoStart(bool oneshot) {
         if (GifRecorder.IsRecording) {
-            return FailWith("A recording is already in progress. Stop it first (action=stop).");
+            // invalid-argument: the request cannot apply in the current state — stop the active
+            // recording first; retrying the same start unchanged will keep failing.
+            return FailWith("A recording is already in progress. Stop it first (action=stop).",
+                code: "recording-in-progress", category: "invalid-argument");
         }
 
         // SECURITY (#158): an explicit record region feeds the same CaptureRegionBitmap as
@@ -101,7 +104,7 @@ public class RecordCommand : WindowTargetingAgentCommand {
         Func<Bitmap>? grab = BuildGrabber(out JsonNode? target, out string? error);
         if (grab is null) {
             AgentRuntime.Audit(Cmd, error ?? "no matching window");
-            return FailWith(error ?? "No matching window");
+            return FailWith(error ?? "No matching window", code: "window-not-found", category: "no-target");
         }
 
         AgentRuntime.Audit(Cmd, $"start {DescribeTarget(target)} fps={limits.Fps} oneshot={oneshot} durationMs={(oneshot ? limits.LoopDurationMs : 0)}");
@@ -125,8 +128,7 @@ public class RecordCommand : WindowTargetingAgentCommand {
             if (discardedUnfetched) {
                 result.Warn(DiscardedWarningCode, DiscardedWarningDetail);
             }
-            Reply?.WriteLine(result.ToJson());
-            return true;
+            return result;
         }
 
         // One-shot: wait for the bounded loop to finish (it auto-stops at loopDurationMs), with a small
@@ -209,15 +211,18 @@ public class RecordCommand : WindowTargetingAgentCommand {
     /// encodes the GIF, writes it to disk, and replies metadata. <paramref name="warnDiscardedUnfetched"/>
     /// is set by the oneshot path when its start discarded an unfetched auto-stopped GIF, so the
     /// warning surfaces on the oneshot's single (stop-produced) reply.</summary>
-    private bool DoStop(bool warnDiscardedUnfetched = false) {
+    private CommandResult DoStop(bool warnDiscardedUnfetched = false) {
         RecordingResult? result = GifRecorder.Stop();
         if (result is null) {
-            return FailWith("No recording is in progress or awaiting fetch.", warnDiscardedUnfetched);
+            // invalid-argument: there is nothing to stop/fetch — start a recording first.
+            return FailWith("No recording is in progress or awaiting fetch.", warnDiscardedUnfetched,
+                code: "no-recording", category: "invalid-argument");
         }
 
         if (result.Frames == 0 || result.Gif.Length == 0) {
             AgentRuntime.Audit(Cmd, $"stop — no output ({result.Error})");
-            return FailWith(result.Error ?? "Recording produced no frames.", warnDiscardedUnfetched);
+            return FailWith(result.Error ?? "Recording produced no frames.", warnDiscardedUnfetched,
+                code: "record-no-frames", category: "internal");
         }
 
         string path = string.IsNullOrEmpty(File)
@@ -245,7 +250,8 @@ public class RecordCommand : WindowTargetingAgentCommand {
             // is no usable output — report failure rather than success-with-fileError.
             Logger.Instance.Log4.Error($"{GetType().Name}: could not write GIF to '{path}': {e.Message}");
             AgentRuntime.Audit(Cmd, $"stop — encode ok ({result.Frames} frames) but write failed: {e.Message}");
-            return FailWith($"Recorded {result.Frames} frames but could not write GIF to '{path}': {e.Message}", warnDiscardedUnfetched);
+            return FailWith($"Recorded {result.Frames} frames but could not write GIF to '{path}': {e.Message}",
+                warnDiscardedUnfetched, code: "record-write-failed", category: "internal");
         }
 
         data["file"] = path;
@@ -254,22 +260,19 @@ public class RecordCommand : WindowTargetingAgentCommand {
         if (warnDiscardedUnfetched) {
             ok.Warn(DiscardedWarningCode, DiscardedWarningDetail);
         }
-        Reply?.WriteLine(ok.ToJson());
-        return true;
+        return ok;
     }
 
-    /// <summary>Writes a failure envelope (with the structured code/category taxonomy when given);
-    /// the discard warning still rides along when set — warnings are valid on failure too, and the
-    /// discard already happened regardless of this call's outcome.</summary>
-    private bool FailWith(string error, bool warnDiscardedUnfetched = false, string? code = null, string? category = null) {
-        CommandResult result = code is not null && category is not null
-            ? CommandResult.Fail(Cmd, error, code, category)
-            : CommandResult.Fail(Cmd, error);
+    /// <summary>Builds a failure result carrying the structured code/category taxonomy (#206 —
+    /// mandatory for every record failure); the discard warning still rides along when set —
+    /// warnings are valid on failure too, and the discard already happened regardless of this
+    /// call's outcome.</summary>
+    private CommandResult FailWith(string error, bool warnDiscardedUnfetched = false, string? code = null, string? category = null) {
+        CommandResult result = CommandResult.Fail(Cmd, error, code ?? "unhandled", category ?? "internal");
         if (warnDiscardedUnfetched) {
             result.Warn(DiscardedWarningCode, DiscardedWarningDetail);
         }
-        Reply?.WriteLine(result.ToJson());
-        return false;
+        return result;
     }
 
     private static int Clamp(int value, int min, int max) => Math.Max(min, Math.Min(max, value));

--- a/src/Commands/RecordCommand.cs
+++ b/src/Commands/RecordCommand.cs
@@ -91,7 +91,8 @@ public class RecordCommand : WindowTargetingAgentCommand {
             string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
             if (sizeError is not null) {
                 AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED — {sizeError}");
-                return FailWith(sizeError, code: "region-too-large", category: "no-target");
+                // invalid-argument (#191): the recovery is to shrink the request, not broaden a selector.
+                return FailWith(sizeError, code: "region-too-large", category: "invalid-argument");
             }
         }
 

--- a/src/Commands/WindowTargetingAgentCommand.cs
+++ b/src/Commands/WindowTargetingAgentCommand.cs
@@ -16,8 +16,9 @@ namespace MCEControl;
 /// Not every command resolves unconditionally: <c>click</c>/<c>drag</c> only need a window for
 /// element endpoints, <c>capture</c> supports a window-less region grab, and <c>record</c> resolves
 /// inside its (test-overridable) grabber factory — those override <see cref="RequiresWindowTarget"/>
-/// and receive <c>null</c>. When resolution fails, <see cref="OnWindowNotFound"/> emits each
-/// command's historical failure envelope (they differ — result unification is #206).
+/// and receive <c>null</c>. When resolution fails, <see cref="OnWindowNotFound"/> returns the ONE
+/// structured window-not-found failure (#206 unified the per-command shapes); a command overrides it
+/// only to add behavior (e.g. <c>capture</c> audits the miss).
 /// </summary>
 public abstract class WindowTargetingAgentCommand : AgentCommand {
     // NOTE: attribute names MUST be all-lowercase. SerializedCommands.Deserialize runs an XSLT that
@@ -49,16 +50,15 @@ public abstract class WindowTargetingAgentCommand : AgentCommand {
         WindowResolver.Resolve(Handle > 0 ? Handle : (long?)null, Window, Process, ClassName, Foreground);
 
     /// <summary>
-    /// Emits the command's window-not-found failure and returns false. The base emission is the
-    /// historical majority shape; commands that emit a coded envelope (or audit the miss) override.
+    /// Builds the command's window-not-found failure: one structured shape for every window-targeting
+    /// command (#206) — code <c>window-not-found</c>, category <c>no-target</c>. Commands override
+    /// only to ADD behavior (e.g. <c>capture</c> audits the miss), not to change the envelope.
     /// </summary>
-    protected virtual bool OnWindowNotFound() {
-        Reply?.WriteLine(CommandResult.Fail(Cmd, "No matching window").ToJson());
-        return false;
-    }
+    protected virtual CommandResult OnWindowNotFound() =>
+        CommandResult.Fail(Cmd, "No matching window", "window-not-found", "no-target");
 
     /// <summary>Resolve-once template: resolve (when required), fail via <see cref="OnWindowNotFound"/>, dispatch.</summary>
-    protected sealed override bool ExecuteCore() {
+    protected sealed override CommandResult ExecuteCore() {
         if (!RequiresWindowTarget) {
             return ExecuteCore(null);
         }
@@ -73,9 +73,10 @@ public abstract class WindowTargetingAgentCommand : AgentCommand {
 
     /// <summary>
     /// The command body. <paramref name="target"/> is the resolved window, or <c>null</c> only when
-    /// <see cref="RequiresWindowTarget"/> returned false for this invocation.
+    /// <see cref="RequiresWindowTarget"/> returned false for this invocation. Returns the structured
+    /// result; the <see cref="AgentCommand"/> template owns emitting it.
     /// </summary>
-    protected abstract bool ExecuteCore(WindowInfo? target);
+    protected abstract CommandResult ExecuteCore(WindowInfo? target);
 
     // No Clone override: the shared selectors are value/string-typed, so the base
     // MemberwiseClone-based Command.Clone (#207) copies them by construction.

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -266,10 +266,10 @@ public static class AgentServer {
             // otherwise default to 0 and actuate at a bogus coordinate. Reject an ill-formed endpoint up
             // front rather than actuating it.
             if (name == "drag" && DragArgsError(args) is string dragError) {
-                return ToolError(dragError, "bad-arguments");
+                return ToolError(dragError, "bad-arguments", AgentErrorCategory.InvalidArgument);
             }
             if (name == "click" && ClickArgsError(args) is string clickError) {
-                return ToolError(clickError, "bad-arguments");
+                return ToolError(clickError, "bad-arguments", AgentErrorCategory.InvalidArgument);
             }
             return RunAgentCommand(name, args);
         }
@@ -377,21 +377,18 @@ public static class AgentServer {
             cmd.Execute();
         }
 
-        // Translate the legacy CommandResult the command wrote into its reply into the #101 envelope.
-        string captured = reply.Captured.Trim();
-        if (string.IsNullOrEmpty(captured)) {
-            AgentError noOutput = new("no-output", AgentErrorCategory.Internal, $"The '{name}' command produced no output.", priorObservation);
+        // Consume the CommandResult OBJECT the command handed to the CapturingReply (#206) — no
+        // serialize → JsonNode.Parse round-trip of our own output (which used to materialize a
+        // capture's base64 PNG three to four times), and no "non-JSON output is success" fallback:
+        // an agent command that produced no typed result is a structured internal failure.
+        if (reply.Result is not CommandResult commandResult) {
+            AgentError noOutput = new("no-output", AgentErrorCategory.Internal,
+                $"The '{name}' command produced no structured result.", priorObservation);
             session.RecordError(noOutput.ToJsonObject());
             return McpResult(AgentToolResult.Failure(noOutput, session.SessionId));
         }
 
-        if (TryParse(captured) is not JsonObject legacy) {
-            // An agent command always emits CommandResult JSON; a non-JSON reply is unexpected. Carry the
-            // raw text forward rather than fabricating a structured error.
-            return McpResult(AgentToolResult.Success(new JsonObject { ["output"] = captured }, session.SessionId));
-        }
-
-        AgentToolResult env = AgentToolResult.FromLegacy(legacy, name, session.SessionId, priorObservation);
+        AgentToolResult env = AgentToolResult.FromCommandResult(commandResult, name, session.SessionId, priorObservation);
 
         // For capture, additionally surface the PNG as an MCP image content block so image-aware clients
         // render it. The base64 stays in the envelope's result so text-only agents (which do not consume
@@ -462,7 +459,7 @@ public static class AgentServer {
     private static JsonObject RunSendCommand(JsonObject args) {
         string command = args["command"]?.GetValue<string>() ?? "";
         if (string.IsNullOrWhiteSpace(command)) {
-            return ToolError("send_command requires a non-empty 'command' argument.", "bad-arguments");
+            return ToolError("send_command requires a non-empty 'command' argument.", "bad-arguments", AgentErrorCategory.InvalidArgument);
         }
 
         CommandInvoker? invoker = AgentRuntime.Invoker;
@@ -512,7 +509,8 @@ public static class AgentServer {
         }
 
         // The legacy command path returns opaque text, not a CommandResult; carry it forward as the
-        // success payload. (A richer send_command success/failure taxonomy is #206.)
+        // success payload. (An agent command routed through send_command hands over a typed result
+        // instead — CapturingReply.Captured lazily serializes it, so the output is unchanged.)
         string captured = reply.Captured.Trim();
         JsonObject result = new() { ["output"] = string.IsNullOrEmpty(captured) ? "ok" : captured };
         CommandEventHub.Publish(new CommandEvent("send_command", CommandTersifier.ForRawCommand(command), CommandOutcome.Ok, session.SessionId));
@@ -550,7 +548,7 @@ public static class AgentServer {
     private static JsonObject RunEndSession(JsonObject args) {
         string? sessionId = Str(args, "sessionId");
         if (string.IsNullOrWhiteSpace(sessionId)) {
-            return ToolError("end-session requires a non-empty 'sessionId' argument.", "bad-arguments");
+            return ToolError("end-session requires a non-empty 'sessionId' argument.", "bad-arguments", AgentErrorCategory.InvalidArgument);
         }
         bool removed = SessionProvisioner.Teardown(sessionId);
         JsonObject result = new() {
@@ -1081,27 +1079,20 @@ public static class AgentServer {
     }
 
     /// <summary>
-    /// A tool-level failure (a security gate or a bad request) reported as the #101 envelope. These are
-    /// MCEC-side refusals the agent cannot recover from on its own, so they map to the <c>internal</c>
-    /// category; <paramref name="code"/> distinguishes the specific cause. The ambient session's id is
-    /// attached so even a refused call tells the agent which session it belonged to.
+    /// A tool-level failure (a security gate or a bad request) reported as the #101 envelope. Security/
+    /// policy refusals the agent cannot recover from on its own map to the default <c>internal</c>
+    /// category; argument-validation refusals pass <see cref="AgentErrorCategory.InvalidArgument"/>
+    /// (#191 — the recovery is to fix the request, not report a bug). <paramref name="code"/>
+    /// distinguishes the specific cause. The ambient session's id is attached so even a refused call
+    /// tells the agent which session it belonged to.
     /// </summary>
-    private static JsonObject ToolError(string message, string code = "internal-error") =>
-        McpResult(AgentToolResult.Failure(new AgentError(code, AgentErrorCategory.Internal, message), AgentRuntime.Session.SessionId));
+    private static JsonObject ToolError(string message, string code = "internal-error", AgentErrorCategory category = AgentErrorCategory.Internal) =>
+        McpResult(AgentToolResult.Failure(new AgentError(code, category, message), AgentRuntime.Session.SessionId));
 
     private static JsonObject TextContent(string text) => new() {
         ["type"] = "text",
         ["text"] = text,
     };
-
-    private static JsonNode? TryParse(string json) {
-        try {
-            return JsonNode.Parse(json);
-        }
-        catch (JsonException) {
-            return null;
-        }
-    }
 
     private static string AsString(JsonNode? node) =>
         node is JsonValue v && v.TryGetValue(out string? s) ? s : "";

--- a/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
@@ -144,54 +144,29 @@ public class AgentToolResultTests {
         Assert.Contains(wire, CategoryEnum);
     }
 
-    [Theory]
-    [InlineData("No matching window", "no-target", "window-not-found")]
-    [InlineData("Invoke failed (element not found or pattern unsupported)", "no-target", "element-not-found")]
-    [InlineData("Capture failed: boom", "internal", "capture-exception")]
-    [InlineData("Agent commands are disabled (AgentCommandsEnabled=false).", "internal", "agent-commands-disabled")]
-    [InlineData("command produced no output", "internal", "no-output")]
-    [InlineData("something nobody mapped", "internal", "unhandled")]
-    public void Categorize_MapsKnownErrorStrings(string message, string category, string code) {
-        AgentError error = AgentToolResult.Categorize("invoke", message);
+    // #206: the prose-sniffing Categorize shim is GONE. The envelope is built from the CommandResult
+    // OBJECT the command returned; the tests below pin codes/categories — never error-message text.
 
-        Assert.Equal(category, error.CategoryWire);
-        Assert.Equal(code, error.Code);
-        Assert.Equal(message, error.Detail);
+    [Fact]
+    public void FromCommandResult_Success_MapsDataToResult_SameInstance() {
+        // The object flows through: result IS the command's Data (no serialize → parse → clone chain,
+        // which used to materialize a capture's base64 PNG three to four times).
+        JsonObject data = new() { ["tree"] = "x" };
+        CommandResult command = CommandResult.Ok("query", data);
+
+        AgentToolResult env = AgentToolResult.FromCommandResult(command, "query");
+
+        Assert.True(env.Ok);
+        Assert.Same(data, env.Result);
+        AssertValidEnvelope(env.ToJsonObject());
     }
 
     [Fact]
-    public void FromLegacy_Success_MapsDataToResult() {
-        JsonObject legacy = CommandResult.Ok("query", new JsonObject { ["tree"] = "x" }).ToJsonObject();
+    public void FromCommandResult_Failure_CarriesStructuredCodeAndCategory() {
+        CommandResult command = CommandResult
+            .Fail("capture", "Captured frame is blank (a flat fill).", "frame-all-black", "capture-blank");
 
-        JsonObject env = AgentToolResult.FromLegacy(legacy, "query").ToJsonObject();
-
-        AssertValidEnvelope(env);
-        Assert.True(env["ok"]!.GetValue<bool>());
-        Assert.Equal("x", env["result"]!["tree"]!.GetValue<string>());
-    }
-
-    [Fact]
-    public void FromLegacy_Failure_MapsErrorViaTaxonomy() {
-        JsonObject legacy = CommandResult.Fail("capture", "No matching window").ToJsonObject();
-
-        JsonObject env = AgentToolResult.FromLegacy(legacy, "capture").ToJsonObject();
-
-        AssertValidEnvelope(env);
-        Assert.False(env["ok"]!.GetValue<bool>());
-        Assert.Equal("no-target", env["error"]!["category"]!.GetValue<string>());
-        Assert.Equal("window-not-found", env["error"]!["code"]!.GetValue<string>());
-    }
-
-    [Fact]
-    public void FromLegacy_Failure_PrefersStructuredCategoryAndCode() {
-        // A blank window capture writes a structured Fail (code + category), not a bare string. The
-        // translator must preserve those so an agent takes the documented capture-blank recovery path
-        // rather than seeing internal/unhandled (Codex P2 on #171).
-        JsonObject legacy = CommandResult
-            .Fail("capture", "Captured frame is blank (a flat fill).", "frame-all-black", "capture-blank")
-            .ToJsonObject();
-
-        JsonObject env = AgentToolResult.FromLegacy(legacy, "capture").ToJsonObject();
+        JsonObject env = AgentToolResult.FromCommandResult(command, "capture").ToJsonObject();
 
         AssertValidEnvelope(env);
         Assert.False(env["ok"]!.GetValue<bool>());
@@ -200,43 +175,70 @@ public class AgentToolResultTests {
     }
 
     [Fact]
-    public void FromLegacy_Failure_UnknownStructuredCategory_FallsBackToTaxonomy() {
-        // If a command ever emits a category outside the closed set, don't propagate it — fall back to
-        // free-text categorization so error.category always validates against the schema enum.
-        JsonObject legacy = CommandResult
-            .Fail("capture", "No matching window", "weird-code", "not-a-category")
-            .ToJsonObject();
+    public void FromCommandResult_Failure_KeptData_RidesInPartialResult() {
+        // A blank capture deliberately keeps the (suspect) PNG in its failure Data — the envelope must
+        // carry it in error.partialResult rather than discarding the image the command paid to keep.
+        JsonObject kept = new() { ["base64"] = "iVBORw0K", ["encoding"] = "png" };
+        CommandResult command = CommandResult
+            .Fail("capture", "Captured frame is blank.", "frame-all-black", "capture-blank", kept);
 
-        JsonObject env = AgentToolResult.FromLegacy(legacy, "capture").ToJsonObject();
+        JsonObject env = AgentToolResult.FromCommandResult(command, "capture").ToJsonObject();
 
         AssertValidEnvelope(env);
-        Assert.Equal("no-target", env["error"]!["category"]!.GetValue<string>());
-        Assert.Equal("window-not-found", env["error"]!["code"]!.GetValue<string>());
+        Assert.False(env.ContainsKey("result"));
+        Assert.Equal("iVBORw0K", env["error"]!["partialResult"]!["base64"]!.GetValue<string>());
     }
 
     [Fact]
-    public void FromLegacy_CarriesWarnings_OnSuccessAndFailure() {
-        JsonObject okLegacy = CommandResult.Ok("query", new JsonObject { ["truncated"] = true })
-            .Warn("tree-truncated", "hit the node cap").ToJsonObject();
-        JsonObject okEnv = AgentToolResult.FromLegacy(okLegacy, "query").ToJsonObject();
+    public void FromCommandResult_Failure_WithoutCode_FallsBackToUnhandledInternal() {
+        // A bare-string Fail (which AgentCommand's template also normalizes) must still yield a
+        // categorical envelope — never a prose-derived one.
+        CommandResult command = CommandResult.Fail("capture", "something nobody coded");
+
+        JsonObject env = AgentToolResult.FromCommandResult(command, "capture").ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.Equal("unhandled", env["error"]!["code"]!.GetValue<string>());
+        Assert.Equal("internal", env["error"]!["category"]!.GetValue<string>());
+        Assert.Equal("something nobody coded", env["error"]!["detail"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void FromCommandResult_Failure_UnknownCategory_FallsBackToInternal_KeepsCode() {
+        // If a command ever emits a category outside the closed set, don't propagate it —
+        // error.category must always validate against the schema enum. The (open-set) code survives.
+        CommandResult command = CommandResult.Fail("capture", "No matching window", "weird-code", "not-a-category");
+
+        JsonObject env = AgentToolResult.FromCommandResult(command, "capture").ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.Equal("internal", env["error"]!["category"]!.GetValue<string>());
+        Assert.Equal("weird-code", env["error"]!["code"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void FromCommandResult_CarriesWarnings_OnSuccessAndFailure() {
+        CommandResult okCommand = CommandResult.Ok("query", new JsonObject { ["truncated"] = true })
+            .Warn("tree-truncated", "hit the node cap");
+        JsonObject okEnv = AgentToolResult.FromCommandResult(okCommand, "query").ToJsonObject();
         AssertValidEnvelope(okEnv);
         Assert.Equal("tree-truncated", okEnv["warnings"]![0]!["code"]!.GetValue<string>());
 
-        JsonObject failLegacy = CommandResult
+        CommandResult failCommand = CommandResult
             .Fail("capture", "Captured frame is blank.", "frame-uniform", "capture-blank")
-            .Warn("capture-fallback", "PrintWindow refused; used an on-screen blit").ToJsonObject();
-        JsonObject failEnv = AgentToolResult.FromLegacy(failLegacy, "capture").ToJsonObject();
+            .Warn("capture-fallback", "PrintWindow refused; used an on-screen blit");
+        JsonObject failEnv = AgentToolResult.FromCommandResult(failCommand, "capture").ToJsonObject();
         AssertValidEnvelope(failEnv);
         Assert.Equal("capture-fallback", failEnv["warnings"]![0]!["code"]!.GetValue<string>());
     }
 
     [Fact]
-    public void FromLegacy_WaitForMiss_BecomesTimeoutFailure() {
-        // FindCommand writes Ok{found:false} when a wait-for exhausts its timeout. An agent branches on
+    public void FromCommandResult_WaitForMiss_BecomesTimeoutFailure() {
+        // FindCommand returns Ok{found:false} when a wait-for exhausts its timeout. An agent branches on
         // `ok`, so that must surface as a timeout failure, not ok:true (Codex P2 on #115).
-        JsonObject legacy = CommandResult.Ok("wait-for", new JsonObject { ["found"] = false, ["element"] = null }).ToJsonObject();
+        CommandResult command = CommandResult.Ok("wait-for", new JsonObject { ["found"] = false, ["element"] = null });
 
-        JsonObject env = AgentToolResult.FromLegacy(legacy, "wait-for").ToJsonObject();
+        JsonObject env = AgentToolResult.FromCommandResult(command, "wait-for").ToJsonObject();
 
         AssertValidEnvelope(env);
         Assert.False(env["ok"]!.GetValue<bool>());
@@ -245,11 +247,11 @@ public class AgentToolResultTests {
     }
 
     [Fact]
-    public void FromLegacy_WaitForHit_StaysSuccess() {
-        JsonObject legacy = CommandResult.Ok("wait-for",
-            new JsonObject { ["found"] = true, ["element"] = new JsonObject { ["name"] = "OK" } }).ToJsonObject();
+    public void FromCommandResult_WaitForHit_StaysSuccess() {
+        CommandResult command = CommandResult.Ok("wait-for",
+            new JsonObject { ["found"] = true, ["element"] = new JsonObject { ["name"] = "OK" } });
 
-        JsonObject env = AgentToolResult.FromLegacy(legacy, "wait-for").ToJsonObject();
+        JsonObject env = AgentToolResult.FromCommandResult(command, "wait-for").ToJsonObject();
 
         AssertValidEnvelope(env);
         Assert.True(env["ok"]!.GetValue<bool>());
@@ -257,11 +259,11 @@ public class AgentToolResultTests {
     }
 
     [Fact]
-    public void FromLegacy_FindMiss_StaysSuccess() {
+    public void FromCommandResult_FindMiss_StaysSuccess() {
         // A one-shot `find` miss is not an error ("a miss is not an error"); only a timed-out wait-for is.
-        JsonObject legacy = CommandResult.Ok("find", new JsonObject { ["found"] = false }).ToJsonObject();
+        CommandResult command = CommandResult.Ok("find", new JsonObject { ["found"] = false });
 
-        JsonObject env = AgentToolResult.FromLegacy(legacy, "find").ToJsonObject();
+        JsonObject env = AgentToolResult.FromCommandResult(command, "find").ToJsonObject();
 
         AssertValidEnvelope(env);
         Assert.True(env["ok"]!.GetValue<bool>());
@@ -269,11 +271,11 @@ public class AgentToolResultTests {
     }
 
     [Fact]
-    public void FromLegacy_Failure_AttachesSessionIdAndPriorObservation() {
-        JsonObject legacy = CommandResult.Fail("invoke", "No matching window").ToJsonObject();
+    public void FromCommandResult_Failure_AttachesSessionIdAndPriorObservation() {
+        CommandResult command = CommandResult.Fail("invoke", "No matching window", "window-not-found", "no-target");
         JsonObject prior = new() { ["window"] = "About" };
 
-        JsonObject env = AgentToolResult.FromLegacy(legacy, "invoke", "s-1234", prior).ToJsonObject();
+        JsonObject env = AgentToolResult.FromCommandResult(command, "invoke", "s-1234", prior).ToJsonObject();
 
         AssertValidEnvelope(env);
         Assert.Equal("s-1234", env["sessionId"]!.GetValue<string>());

--- a/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
@@ -18,7 +18,7 @@ namespace MCEControl.xUnit.Agent;
 /// </summary>
 public class AgentToolResultTests {
     private static readonly HashSet<string> CategoryEnum = [
-        "timeout", "ambiguous-selector", "stale-element", "no-target",
+        "timeout", "ambiguous-selector", "stale-element", "no-target", "invalid-argument",
         "capture-blank", "focus", "elevation", "foreground", "internal",
     ];
 
@@ -81,6 +81,22 @@ public class AgentToolResultTests {
     }
 
     [Fact]
+    public void Failure_WithPartialResult_IncludesIt_DistinctFromLastObservation() {
+        // #206: a blank capture's own (suspect) payload rides in error.partialResult — the image the
+        // command paid to keep must not be discarded — while error.lastObservation stays the last
+        // GOOD state from a prior call.
+        JsonObject prior = new() { ["window"] = "About" };
+        JsonObject partial = new() { ["base64"] = "iVBORw0K", ["encoding"] = "png" };
+        JsonObject env = AgentToolResult
+            .Failure(new AgentError("frame-all-black", AgentErrorCategory.CaptureBlank, "blank frame", prior, partial))
+            .ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.Equal("About", env["error"]!["lastObservation"]!["window"]!.GetValue<string>());
+        Assert.Equal("iVBORw0K", env["error"]!["partialResult"]!["base64"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void Failure_WithLastObservation_IncludesIt() {
         JsonObject obs = new() { ["window"] = "About" };
         JsonObject env = AgentToolResult
@@ -116,6 +132,7 @@ public class AgentToolResultTests {
     [InlineData(AgentErrorCategory.AmbiguousSelector, "ambiguous-selector")]
     [InlineData(AgentErrorCategory.StaleElement, "stale-element")]
     [InlineData(AgentErrorCategory.NoTarget, "no-target")]
+    [InlineData(AgentErrorCategory.InvalidArgument, "invalid-argument")]
     [InlineData(AgentErrorCategory.CaptureBlank, "capture-blank")]
     [InlineData(AgentErrorCategory.Focus, "focus")]
     [InlineData(AgentErrorCategory.Elevation, "elevation")]

--- a/tests/MCEControl.xUnit/Agent/CapturingReplyTests.cs
+++ b/tests/MCEControl.xUnit/Agent/CapturingReplyTests.cs
@@ -1,0 +1,53 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Pins the #206 typed-result handoff: an agent command hands its <see cref="CommandResult"/> to
+/// <see cref="CapturingReply.Result"/> as an OBJECT; <see cref="CapturingReply.Captured"/> serializes
+/// it lazily only when legacy text is actually wanted (send_command output, tests), so the observable
+/// wire text is unchanged while the MCP path never re-parses its own output.
+/// </summary>
+public class CapturingReplyTests {
+    [Fact]
+    public void Captured_Empty_WhenNothingWrittenAndNoResult() {
+        CapturingReply reply = new();
+
+        Assert.Equal("", reply.Captured);
+        Assert.Null(reply.Result);
+    }
+
+    [Fact]
+    public void Captured_ReturnsBufferedText_ForLegacyWrites() {
+        CapturingReply reply = new();
+        reply.WriteLine("plain text output");
+
+        Assert.Equal("plain text output", reply.Captured.Trim());
+    }
+
+    [Fact]
+    public void Captured_LazilySerializesTypedResult_WhenNothingWasWritten() {
+        CapturingReply reply = new() {
+            Result = CommandResult.Ok("displays", new JsonObject { ["count"] = 2 }),
+        };
+
+        JsonObject json = JsonNode.Parse(reply.Captured)!.AsObject();
+        Assert.True(json["success"]!.GetValue<bool>());
+        Assert.Equal(2, json["data"]!["count"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void Captured_BufferedText_TakesPrecedenceOverTypedResult() {
+        // A command that wrote text AND set a typed result (not a shape agent commands produce, but
+        // the contract must be deterministic): the buffered text wins — Result is the typed side-channel.
+        CapturingReply reply = new() { Result = CommandResult.Ok("x") };
+        reply.Write("buffered");
+
+        Assert.Equal("buffered", reply.Captured);
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
+++ b/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
@@ -28,6 +28,26 @@ public class UiaServiceTests {
     }
 
     [Fact]
+    public void Invoke_ZeroHandle_ReturnsElementNotFound() {
+        // #206: the guard paths return distinct categorical outcomes, not a conflating bool.
+        UiaInvokeResult result = UiaService.Invoke(IntPtr.Zero, "name", "OK", "invoke", null);
+
+        Assert.Equal(UiaInvokeResult.ElementNotFound, result);
+    }
+
+    [Theory]
+    [InlineData("click")]
+    [InlineData("set-value")]
+    [InlineData("")]
+    public void Invoke_UnknownAction_ReturnsActionUnknown_WithoutTouchingUia(string action) {
+        // An unsupported action is rejected before any UIA attach — even a bogus handle never gets
+        // that far — and reports ActionUnknown (fix the argument), not a not-found/pattern failure.
+        UiaInvokeResult result = UiaService.Invoke(new IntPtr(0x1), "name", "OK", action, null);
+
+        Assert.Equal(UiaInvokeResult.ActionUnknown, result);
+    }
+
+    [Fact]
     public void DumpTree_ZeroHandle_ReturnsEmptyUntruncatedResult() {
         // The guard path must return a well-formed result (null root, no nodes, not truncated) rather
         // than null, so query can always read nodeCount/truncated.

--- a/tests/MCEControl.xUnit/Commands/AgentCommandResultPipelineTests.cs
+++ b/tests/MCEControl.xUnit/Commands/AgentCommandResultPipelineTests.cs
@@ -1,0 +1,157 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Pins the #206 object pipeline in <see cref="AgentCommand"/>'s sealed Execute template: the
+/// <see cref="CommandResult"/> flows to <see cref="CapturingReply.Result"/> as the SAME instance (no
+/// serialize → re-parse), the legacy TCP/serial transport still receives the JSON line, and every
+/// failure is normalized onto the closed taxonomy (no free-text-only failures left to prose-sniff).
+/// </summary>
+[Collection("AgentSerial")]
+public class AgentCommandResultPipelineTests {
+    [Fact]
+    public void Execute_HandsTheResultObjectToCapturingReply_SameInstance() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CommandResult produced = CommandResult.Ok("stub", new JsonObject { ["x"] = 1 });
+            CapturingReply reply = new();
+            StubResultAgentCommand cmd = new() { Cmd = "stub", Enabled = true, Reply = reply, Producer = () => produced };
+
+            bool ok = cmd.Execute();
+
+            Assert.True(ok);
+            // Identity, not equality: the object the command built IS what the MCP server consumes —
+            // the seam that proves no intermediate serialize/parse copies exist on this path.
+            Assert.Same(produced, reply.Result);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_WritesTheJsonLine_ToALegacyReply() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            RecordingReply reply = new();
+            StubResultAgentCommand cmd = new() {
+                Cmd = "stub", Enabled = true, Reply = reply,
+                Producer = () => CommandResult.Ok("stub", new JsonObject { ["x"] = 1 }),
+            };
+
+            cmd.Execute();
+
+            // The legacy TCP/serial transport still gets the same single JSON line as before #206.
+            Assert.EndsWith(Environment.NewLine, reply.Text, StringComparison.Ordinal);
+            JsonObject json = JsonNode.Parse(reply.Text.Trim())!.AsObject();
+            Assert.True(json["success"]!.GetValue<bool>());
+            Assert.Equal(1, json["data"]!["x"]!.GetValue<int>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_NormalizesABareStringFailure_OntoTheClosedTaxonomy() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            StubResultAgentCommand cmd = new() {
+                Cmd = "stub", Enabled = true, Reply = reply,
+                Producer = () => CommandResult.Fail("stub", "bare prose only"),
+            };
+
+            bool ok = cmd.Execute();
+
+            // Structural guarantee: no agent failure leaves the template without a code/category.
+            Assert.False(ok);
+            Assert.Equal("unhandled", reply.Result!.ErrorCode);
+            Assert.Equal("internal", reply.Result.ErrorCategory);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_WhenAgentDisabled_FailureIsCategorical() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = null; // agent commands disabled
+        try {
+            CapturingReply reply = new();
+            StubResultAgentCommand cmd = new() {
+                Cmd = "stub", Enabled = true, Reply = reply,
+                Producer = () => throw new InvalidOperationException("gate must block before the body"),
+            };
+
+            bool ok = cmd.Execute();
+
+            Assert.False(ok);
+            Assert.Equal("agent-commands-disabled", reply.Result!.ErrorCode);
+            Assert.Equal("internal", reply.Result.ErrorCategory);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Find_WindowNotFound_CarriesStructuredCode() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            // A selector that cannot match anything on any desktop: find used to fail with the bare
+            // string "No matching window" (prose the deleted Categorize shim had to sniff).
+            CapturingReply reply = new();
+            FindCommand cmd = new() {
+                Cmd = "find", Enabled = true, Reply = reply,
+                Window = $"no-such-window-{Guid.NewGuid():N}", Value = "OK",
+            };
+
+            bool ok = cmd.Execute();
+
+            Assert.False(ok);
+            Assert.Equal("window-not-found", reply.Result!.ErrorCode);
+            Assert.Equal("no-target", reply.Result.ErrorCategory);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Drag_ElementEndpointWithNoMatchingWindow_CarriesStructuredCode() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            // An element endpoint forces window resolution; a selector that matches nothing used to
+            // produce the bare "No matching window" string. No input is ever synthesized.
+            CapturingReply reply = new();
+            DragCommand cmd = new() {
+                Cmd = "drag", Enabled = true, Reply = reply,
+                Window = $"no-such-window-{Guid.NewGuid():N}",
+                FromValue = "Slider", ToX = 10, ToY = 10,
+            };
+
+            bool ok = cmd.Execute();
+
+            Assert.False(ok);
+            Assert.Equal("window-not-found", reply.Result!.ErrorCode);
+            Assert.Equal("no-target", reply.Result.ErrorCategory);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/CaptureCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CaptureCommandTests.cs
@@ -83,7 +83,9 @@ public class CaptureCommandTests {
             JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
             Assert.False(json["success"]!.GetValue<bool>());
             Assert.Equal("region-too-large", json["errorCode"]!.GetValue<string>());
-            Assert.Equal("no-target", json["errorCategory"]!.GetValue<string>());
+            // #191: an oversized region is a malformed request — the recovery is to shrink it,
+            // so the category is invalid-argument, not no-target.
+            Assert.Equal("invalid-argument", json["errorCategory"]!.GetValue<string>());
             // The detail must tell the agent what the limits are so the failure is recoverable.
             Assert.Contains(ScreenCapture.MaxRegionDimension.ToString(), json["error"]!.GetValue<string>());
             // Rejected before capture: no image payload may be present.

--- a/tests/MCEControl.xUnit/Commands/InvokeCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/InvokeCommandTests.cs
@@ -68,6 +68,25 @@ public class InvokeCommandTests {
         }
     }
 
+    [Theory]
+    // #206: each UiaInvokeResult failure maps to a DISTINCT code/category so agent recovery differs:
+    // no-target => wait/re-find; invalid-argument => fix the call (re-finding cannot help); internal
+    // => report. The old bare bool collapsed all four into one prose string.
+    [InlineData(UiaInvokeResult.ElementNotFound, "element-not-found", "no-target")]
+    [InlineData(UiaInvokeResult.PatternUnsupported, "pattern-unsupported", "invalid-argument")]
+    [InlineData(UiaInvokeResult.ActionUnknown, "action-unknown", "invalid-argument")]
+    [InlineData(UiaInvokeResult.Faulted, "invoke-faulted", "internal")]
+    public void FailureFor_MapsEachOutcomeToADistinctCodeAndCategory(UiaInvokeResult outcome, string code, string category) {
+        InvokeCommand cmd = new() { Cmd = "invoke", By = "name", Value = "OK", Action = "toggle" };
+
+        CommandResult result = cmd.FailureFor(outcome);
+
+        Assert.False(result.Success);
+        Assert.Equal(code, result.ErrorCode);
+        Assert.Equal(category, result.ErrorCategory);
+        Assert.False(string.IsNullOrEmpty(result.Error));
+    }
+
     [Fact]
     public void IsSupportedAction_IncludesSelect() {
         Assert.True(UiaService.IsSupportedAction("select"));

--- a/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/RecordCommandTests.cs
@@ -132,7 +132,8 @@ public class RecordCommandTests {
             JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
             Assert.False(json["success"]!.GetValue<bool>());
             Assert.Equal("region-too-large", json["errorCode"]!.GetValue<string>());
-            Assert.Equal("no-target", json["errorCategory"]!.GetValue<string>());
+            // #191: an oversized region is a malformed request — invalid-argument, not no-target.
+            Assert.Equal("invalid-argument", json["errorCategory"]!.GetValue<string>());
             Assert.Contains(ScreenCapture.MaxRegionDimension.ToString(), json["error"]!.GetValue<string>());
         }
         finally {

--- a/tests/MCEControl.xUnit/Commands/RecordingReply.cs
+++ b/tests/MCEControl.xUnit/Commands/RecordingReply.cs
@@ -1,0 +1,16 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Text;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>A <see cref="Reply"/> that records what a legacy (TCP/serial) transport would receive.</summary>
+internal sealed class RecordingReply : Reply {
+    private readonly StringBuilder _text = new();
+
+    public string Text => _text.ToString();
+
+    public override void Write(string text) => _text.Append(text);
+}

--- a/tests/MCEControl.xUnit/Commands/StubResultAgentCommand.cs
+++ b/tests/MCEControl.xUnit/Commands/StubResultAgentCommand.cs
@@ -1,0 +1,18 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Test-only <see cref="AgentCommand"/> whose body returns whatever <see cref="Producer"/> supplies,
+/// so tests can drive the sealed Execute template (#208/#206) — gate, normalization, and result
+/// emission — without touching the desktop.
+/// </summary>
+internal sealed class StubResultAgentCommand : AgentCommand {
+    public Func<CommandResult> Producer { get; set; } = null!;
+
+    protected override CommandResult ExecuteCore() => Producer();
+}

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -528,6 +528,52 @@ public class AgentServerTests {
         }
     }
 
+    // --- #206: RunAgentCommand consumes the CommandResult OBJECT the command handed to its
+    // CapturingReply — no JsonNode.Parse of its own output, and no "non-JSON output is success"
+    // fallback. `displays` is the one agent tool that runs headlessly end-to-end.
+
+    [Fact]
+    public void RunAgentCommand_Displays_FlowsTheTypedResultIntoTheEnvelope() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.Invoker = new CommandInvoker { ["displays"] = new DisplaysCommand { Cmd = "displays", Enabled = true } };
+        try {
+            JsonObject resp = AgentServer.RunAgentCommand("displays", []);
+
+            Assert.False(resp["isError"]!.GetValue<bool>());
+            JsonObject envelope = JsonNode.Parse(FirstTextBlock(resp))!.AsObject();
+            Assert.True(envelope["ok"]!.GetValue<bool>());
+            // The command's Data payload IS the envelope's result — the object pipeline end-to-end.
+            Assert.True(envelope["result"]!.AsObject().ContainsKey("displays"));
+            Assert.True(envelope["result"]!["count"]!.GetValue<int>() > 0);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.Invoker = null;
+        }
+    }
+
+    [Fact]
+    public void RunAgentCommand_WindowNotFound_ReportsStructuredCode_NotProse() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.Invoker = new CommandInvoker { ["query"] = new QueryCommand { Cmd = "query", Enabled = true } };
+        try {
+            JsonObject resp = AgentServer.RunAgentCommand("query",
+                new JsonObject { ["window"] = $"no-such-window-{Guid.NewGuid():N}" });
+
+            Assert.True(resp["isError"]!.GetValue<bool>());
+            JsonObject error = JsonNode.Parse(FirstTextBlock(resp))!.AsObject()["error"]!.AsObject();
+            // Pinned by CODE and CATEGORY — never by the human-readable message (#206).
+            Assert.Equal("window-not-found", error["code"]!.GetValue<string>());
+            Assert.Equal("no-target", error["category"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.Invoker = null;
+        }
+    }
+
     [Fact]
     public void BuildCommand_UnknownName_ReturnsNull_NeverADefaultCommand() {
         // The old default arm meant an unmapped name became an InvokeCommand. Now it maps to null,


### PR DESCRIPTION
Fixes #206
Fixes #191

## What changed

### 1. Object pipeline (no re-parsed strings)
`AgentCommand.ExecuteCore()` — and `WindowTargetingAgentCommand.ExecuteCore(WindowInfo?)` — now **return** their `CommandResult`. The sealed #208 template emits it once per transport:

- **Legacy TCP/serial**: the same single `Reply.WriteLine(result.ToJson())` line as before (wire format preserved).
- **MCP (in-process)**: `CapturingReply` gains a typed `Result` slot; the server consumes the **object** directly via the new `AgentToolResult.FromCommandResult(...)`. The old `CommandResult → ToJson() → JsonNode.Parse → FromLegacy → ToJson()` chain is gone — a capture's base64 PNG is no longer materialized 3–4×. `CapturingReply.Captured` lazily serializes the typed result, so `send_command`-routed agent commands and tests see unchanged text.
- The **"non-JSON output = success" fallback is deleted**: an agent command that produced no typed result is a structured `no-output`/`internal` failure. Nothing else routes through `RunAgentCommand`, so the fallback was dead once the pipeline was typed.
- Tests assert the result **object identity** flows through the template (`Assert.Same`) and end-to-end through `RunAgentCommand` (`displays`, the one headless tool).

### 2. Categorical failures — prose-sniffing deleted
`AgentToolResult.Categorize` and `FromLegacy` are **deleted**. The sealed template normalizes any failure missing a code/category to `unhandled`/`internal`, making `Fail(code, category)` structurally mandatory for agent commands. `UiaService.Invoke` returns a new `UiaInvokeResult` enum (`Ok | ElementNotFound | PatternUnsupported | ActionUnknown | Faulted`) instead of a conflating bool — agents no longer loop re-finding elements that exist but lack the pattern.

### 3. Partial data
A blank window capture's failure `Data` (the suspect PNG the command deliberately kept) now rides in the envelope's new **`error.partialResult`** instead of being silently dropped by the failure branch. Distinct from `error.lastObservation` (the last *good* state from a *prior* call). Schema + contract updated. (No #215 lastObservation-compaction here.)

## Taxonomy delta (all agent-observable changes)

**New category** (closed set grows 9 → 10; schema + contract + instructions updated):
| category | meaning | recovery |
|---|---|---|
| `invalid-argument` | the request itself is malformed/inapplicable (#191) | fix the arguments; never retry unchanged or broaden a selector |

**New envelope field**: `error.partialResult` (failing call's own partial payload).

**Code / category changes:**
| where | before | after |
|---|---|---|
| `capture`/`record` oversized region | `region-too-large` / `no-target` | `region-too-large` / **`invalid-argument`** (#191) |
| `invoke` element miss | bare `"Invoke failed (element not found or pattern unsupported)"` → prose-sniffed `element-not-found`/`no-target` | `element-not-found` / `no-target` (emitted structurally) |
| `invoke` element exists, pattern missing | same conflated prose | **`pattern-unsupported` / `invalid-argument`** (new) |
| `invoke` bad `action` string | same conflated prose | **`action-unknown` / `invalid-argument`** (new) |
| `invoke` UIA fault | same conflated prose | **`invoke-faulted` / `internal`** (new) |
| `find`/`wait-for`/`drag`/`record` window miss | bare `"No matching window"` → prose-sniffed | `window-not-found` / `no-target` (one shape for every window-targeting command, via the base class) |
| `drag` endpoint element miss | bare `"Drag start/end: element not found…"` | `element-not-found` / `no-target` (matches `click`) |
| `capture` exception | bare `"Capture failed: …"` → prose-sniffed `capture-exception`/`internal` | `capture-exception` / `internal` (emitted structurally) |
| `launch` empty path | bare string | **`launch-path-missing` / `invalid-argument`** |
| `record` unknown action | bare string | **`record-action-unknown` / `invalid-argument`** |
| `record` start while recording | bare string | **`recording-in-progress` / `invalid-argument`** |
| `record` stop with nothing to fetch | bare string | **`no-recording` / `invalid-argument`** |
| `record` zero frames / write failure / exception | bare strings | **`record-no-frames`**, **`record-write-failed`**, **`record-exception`** — all `internal` |
| agent gate refusal (in-command) | bare `"Agent commands are disabled…"` → prose-sniffed | `agent-commands-disabled` / `internal` (emitted structurally) |
| server arg validation (`drag`/`click` endpoints, empty `send_command`, `end-session` sessionId) | `bad-arguments` / `internal` | `bad-arguments` / **`invalid-argument`** |
| any structurally missing code/category | prose-sniffed or `unhandled`/`internal` | `unhandled` / `internal` (normalized in the sealed template) |
| `no-output` | `internal`, "produced no output" (empty-text check) | `no-output` / `internal`, "produced no structured result" (typed check) |

**Unchanged (scope guards honored):** `send_command`'s #195 semantics (`unknown-command`/`command-dropped`/`send-command-timeout`/`emergency-stopped` codes), tool schemas/catalog (#205), blank-capture codes (`frame-all-black`/`frame-uniform` / `capture-blank`), `wait-for` miss → `wait-condition-timeout`/`timeout`, security-refusal codes (`emergency-stopped`, `command-disabled`, `unknown-tool`, `agent-commands-disabled`, provisioning codes) staying category `internal`, and the legacy TCP/serial emission path (`Reply.WriteLine(json)`).

## Docs & guidance (standing rule)
- `src/Agent/AgentInstructions.md` (embedded connect-time playbook): invalid-argument recovery, invoke's pattern-unsupported/action-unknown guidance, partialResult, region-too-large category, and "branch on codes, never on `error.detail` wording".
- `docs/design/agent-tool-result-contract.md` + `agent-tool-result.schema.json`: category enum, example codes, `partialResult`.
- `docs/agent-server.md`, `docs/agent-server-architecture.md`: envelope provenance rewritten for the object pipeline.

## Tests
`dotnet build` (Debug + Release) and full `dotnet test` green locally: **735 passed, 0 failed, 22 skipped** (the skips are the opt-in desktop E2E/input suites). Prose-pinned tests now pin codes/categories; new coverage: `UiaInvokeResult` mapping per outcome, find/drag/query structured failure envelopes, blank-capture `partialResult`, `CapturingReply` typed slot + lazy `Captured`, template normalization, and result-object identity through `RunAgentCommand`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm