### PR TITLE
test: fix McpStdioTransport backpressure flake on low-core CI runners

### DIFF
--- a/tests/MCEControl.xUnit/Services/McpStdioTransportTests.cs
+++ b/tests/MCEControl.xUnit/Services/McpStdioTransportTests.cs
@@ -19,6 +19,20 @@ namespace MCEControl.xUnit.Services;
 /// stops consuming until a slot frees), mirroring the HTTP fan-out bound (#151).
 /// </summary>
 public class McpStdioTransportTests {
+    static McpStdioTransportTests() {
+        // These tests deliberately PARK a full cap's worth (16) of dispatches on blocking waits.
+        // On a 2-core hosted CI runner the thread pool starts near the core count and injects
+        // roughly one thread per second, so reaching 16 simultaneously-blocked workers takes
+        // ~14s — losing the race against the tests' 15s timeouts (the post-merge CI flake on
+        // #243). Guarantee the pool can field the whole cap (plus the overflow request and the
+        // loop's own work) without waiting on thread injection.
+        ThreadPool.GetMinThreads(out int workers, out int iocp);
+        int needed = McpStdioTransport.MaxConcurrentStdioRequests + 8;
+        if (workers < needed) {
+            ThreadPool.SetMinThreads(needed, iocp);
+        }
+    }
+
     private static string Request(int id) => $"{{\"jsonrpc\":\"2.0\",\"id\":{id},\"method\":\"x\"}}";
 
     private static JsonObject Ok(JsonObject req) =>


### PR DESCRIPTION
Fixes the develop CI failure introduced by #243's merge: `Run_CapsInFlightDispatches_ByBackpressure` parks 16 dispatches on blocking waits, and on a 2-core hosted runner thread-pool injection latency (~1 thread/s) makes the 15s wait lose the race. `ThreadPool.SetMinThreads(cap+8)` in the fixture's static ctor removes the injection latency from what the test measures.

Verified: 4 consecutive local runs green; the change is test-only.

Process note: #243 was merged while its final check was still pending (the watch tripped on a pending status and the merge wasn't gated on the result) — this PR restores the green develop that gate should have ensured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm