### PR TITLE
fix: a missing mcec.commands file is not an error

### DIFF
--- a/src/Commands/SerializedCommands.cs
+++ b/src/Commands/SerializedCommands.cs
@@ -103,7 +103,10 @@ public class SerializedCommands {
             }
         }
         catch (FileNotFoundException) {
-            Logger.Instance.Log4.Error($"SerializedCommands: {userCommandsFile} was not found");
+            // Expected, not an error: fresh installs and provisioned/demo subject copies have no
+            // user commands file, and MCEC runs fine on built-ins alone. Only a present-but-unreadable
+            // file (the catch below) is a real problem.
+            Logger.Instance.Log4.Info($"SerializedCommands: No user commands file ({userCommandsFile}); using built-in commands only. Create it to add your own commands.");
         }
         catch (Exception ex) {
             string msg = $"No commands loaded. Error reading {userCommandsFile} - {ex.Message}.\n\nSee log file for details: {Logger.Instance.LogFile}\n\nFor help, open an issue at github.com/tig/mcec";


### PR DESCRIPTION
A missing user commands file is an expected state (fresh installs; provisioned/demo subject copies never have one) and the app runs fully on built-ins. `LoadCommands` logged the caught `FileNotFoundException` at Error level; this downgrades it to Info with a friendlier message pointing at how to add user commands. A present-but-unreadable file still logs at Error via the general catch.

Surfaced while regenerating `docs/hero.gif`: the red ERROR line has been visible in the shipped hero GIF's log window all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm