### PR TITLE
feat: create the default mcec.commands file on first run

### DIFF
--- a/src/Commands/SerializedCommands.cs
+++ b/src/Commands/SerializedCommands.cs
@@ -69,6 +69,15 @@ public class SerializedCommands {
     static public SerializedCommands LoadCommands(string userCommandsFile, string currentVersion) {
         SerializedCommands? cmds = null;
         FileStream? fs = null;
+
+        // First run (and provisioned/demo subject copies): create the default commands file, the
+        // same way SettingsStore creates a default mcec.settings — the full built-in catalog with
+        // every command Enabled="false" (nothing enabled, so no actuation surface changes), per the
+        // long-documented contract in docs/home-automation.md.
+        if (!File.Exists(userCommandsFile)) {
+            TryCreateDefaultCommandsFile(userCommandsFile, currentVersion);
+        }
+
         try {
             Logger.Instance.Log4.Info($"SerializedCommands: Loading user-defined commands from {userCommandsFile}");
             fs = new FileStream(userCommandsFile, FileMode.Open, FileAccess.Read);
@@ -103,10 +112,9 @@ public class SerializedCommands {
             }
         }
         catch (FileNotFoundException) {
-            // Expected, not an error: fresh installs and provisioned/demo subject copies have no
-            // user commands file, and MCEC runs fine on built-ins alone. Only a present-but-unreadable
-            // file (the catch below) is a real problem.
-            Logger.Instance.Log4.Info($"SerializedCommands: No user commands file ({userCommandsFile}); using built-in commands only. Create it to add your own commands.");
+            // Only reachable when TryCreateDefaultCommandsFile above could not write (e.g. a
+            // read-only location). Not an error: MCEC runs fully on built-ins without the file.
+            Logger.Instance.Log4.Info($"SerializedCommands: No user commands file ({userCommandsFile}); using built-in commands only.");
         }
         catch (Exception ex) {
             string msg = $"No commands loaded. Error reading {userCommandsFile} - {ex.Message}.\n\nSee log file for details: {Logger.Instance.LogFile}\n\nFor help, open an issue at github.com/tig/mcec";
@@ -158,6 +166,39 @@ public class SerializedCommands {
             if (ucFS != null) {
                 ucFS.Close();
             }
+        }
+    }
+
+    /// <summary>
+    /// Creates the default commands file on first run: every built-in command from
+    /// <see cref="CommandRegistry"/>, all with <c>Enabled="false"</c>, version-stamped, and carrying
+    /// the standard guidance comments. This is the contract docs/home-automation.md has always
+    /// described ("containing all built-in commands with Enabled=false") and it is what makes the
+    /// security model's enable-a-command workflow real: the user flips Enabled on an existing entry
+    /// instead of authoring XML from scratch. Nothing enabled → the actuation surface is unchanged.
+    /// Mirrors SettingsStore's create-default-settings behavior. Quiet on failure (Info/Warn logs
+    /// only, never a dialog): a location we cannot write to just means MCEC keeps running on
+    /// built-ins, and LoadCommands' FileNotFoundException fallback reports that.
+    /// Internal so tests can exercise the failure path directly (InternalsVisibleTo MCEControl.xUnit).
+    /// </summary>
+    internal static void TryCreateDefaultCommandsFile(string userCommandsFile, string currentVersion) {
+        try {
+            SerializedCommands defaults = new() {
+                Version = currentVersion,
+                // The registry's built-in factories produce Enabled=false instances
+                // (pinned by CommandRegistryTests) — serialize them as-is.
+                commandArray = [.. CommandRegistry.Entries.SelectMany(e => e.BuiltIns())],
+            };
+            // CreateNew: if another instance raced us to it, theirs wins and our load proceeds.
+            using FileStream fs = new(userCommandsFile, FileMode.CreateNew, FileAccess.Write);
+            Serializer.Serialize(fs, defaults);
+            Logger.Instance.Log4.Info($"SerializedCommands: Created default commands file ({defaults.Count} built-in commands, all disabled): {userCommandsFile}");
+        }
+        catch (IOException e) {
+            Logger.Instance.Log4.Warn($"SerializedCommands: Could not create default commands file ({userCommandsFile}): {e.Message}");
+        }
+        catch (UnauthorizedAccessException e) {
+            Logger.Instance.Log4.Warn($"SerializedCommands: Could not create default commands file ({userCommandsFile}): {e.Message}");
         }
     }
 

--- a/tests/MCEControl.xUnit/Commands/DefaultCommandsFileTests.cs
+++ b/tests/MCEControl.xUnit/Commands/DefaultCommandsFileTests.cs
@@ -1,0 +1,99 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.IO;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// First-run behavior: a missing mcec.commands is not an error — LoadCommands creates the default
+/// file (the full built-in catalog, every command Enabled="false", version-stamped, guidance
+/// comments) the same way SettingsStore creates a default mcec.settings, then loads it. This is the
+/// contract docs/home-automation.md documents. Creation is quiet on failure; MCEC runs on built-ins
+/// alone.
+/// </summary>
+public class DefaultCommandsFileTests {
+    private static string TempCommandsPath() =>
+        Path.Combine(Path.GetTempPath(), $"mcec-test-{Guid.NewGuid():N}", "mcec.commands");
+
+    [Fact]
+    public void LoadCommands_MissingFile_CreatesDefaultAndLoadsIt() {
+        string path = TempCommandsPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        try {
+            SerializedCommands cmds = SerializedCommands.LoadCommands(path, "3.0.0");
+
+            Assert.True(File.Exists(path), "default commands file was not created");
+            Assert.NotNull(cmds);
+            // The full built-in catalog, with NOTHING enabled — the actuation surface must not
+            // change just because the file now exists (the security model's default-deny).
+            Assert.True(cmds.Count > 100, $"expected the built-in catalog, got {cmds.Count} commands");
+            Assert.All(cmds.commandArray, c => Assert.False(c.Enabled, $"'{c.Cmd}' must not be enabled in the default file"));
+            Assert.Equal("3.0.0", cmds.Version);
+
+            // The template carries the standard guidance comments for the user to edit.
+            string content = File.ReadAllText(path);
+            Assert.Contains("<!--", content, StringComparison.Ordinal);
+
+            // A second load round-trips the created file cleanly.
+            SerializedCommands again = SerializedCommands.LoadCommands(path, "3.0.0");
+            Assert.NotNull(again);
+            Assert.Equal(cmds.Count, again.Count);
+        }
+        finally {
+            Directory.Delete(Path.GetDirectoryName(path)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadCommands_ExistingFile_IsNotOverwritten() {
+        string path = TempCommandsPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        try {
+            var existing = new SerializedCommands {
+                commandArray = [new PauseCommand { Cmd = "userpause", Args = "50", Enabled = true }],
+            };
+            // Same version as the load below so the upgrade-rewrite path stays out of the way.
+            SerializedCommands.SaveCommands(path, existing, "3.0.0");
+            byte[] before = File.ReadAllBytes(path);
+
+            SerializedCommands cmds = SerializedCommands.LoadCommands(path, "3.0.0");
+
+            Assert.Equal(before, File.ReadAllBytes(path));
+            Assert.Equal(1, cmds.Count);
+            Assert.Equal("userpause", cmds.commandArray[0].Cmd);
+        }
+        finally {
+            Directory.Delete(Path.GetDirectoryName(path)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryCreateDefaultCommandsFile_UnwritableLocation_DoesNotThrow() {
+        // Nonexistent directory → DirectoryNotFoundException (an IOException) inside the helper.
+        string path = Path.Combine(Path.GetTempPath(), $"mcec-test-{Guid.NewGuid():N}", "nope", "mcec.commands");
+
+        Exception? ex = Record.Exception(() => SerializedCommands.TryCreateDefaultCommandsFile(path, "3.0.0"));
+
+        Assert.Null(ex);
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void CommandInvoker_Create_MissingFile_CreatesDefaultAndRegistersBuiltIns() {
+        string path = TempCommandsPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        try {
+            CommandInvoker invoker = CommandInvoker.Create(path, "3.0.0", disableInternalCommands: false);
+
+            Assert.True(File.Exists(path), "default commands file was not created");
+            Assert.True(invoker.Count > 0, "built-in commands were not registered");
+        }
+        finally {
+            Directory.Delete(Path.GetDirectoryName(path)!, recursive: true);
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/SerializedCommandsTests.cs
+++ b/tests/MCEControl.xUnit/Commands/SerializedCommandsTests.cs
@@ -327,14 +327,20 @@ public class SerializedCommandsTests
     }
 
     [Fact]
-    public void LoadCommands_NonExistentFile_ReturnsNull()
+    public void LoadCommands_NonExistentFile_CreatesDefaultCatalog()
     {
+        // A missing file is first-run, not an error: LoadCommands creates the default file (the
+        // built-in catalog, all Enabled=false) and loads it. See DefaultCommandsFileTests.
         string tempFile = Path.GetTempFileName();
         File.Delete(tempFile);
 
         var loaded = SerializedCommands.LoadCommands(tempFile, "1.0.0.0");
 
-        Assert.Null(loaded);
+        Assert.NotNull(loaded);
+        Assert.True(loaded.Count > 0);
+        Assert.All(loaded.commandArray, c => Assert.False(c.Enabled));
+        Assert.True(File.Exists(tempFile));
+        File.Delete(tempFile);
     }
 
     [Fact]


### PR DESCRIPTION
Implements the behavior `docs/home-automation.md` has documented all along: first run creates `mcec.commands` containing the full built-in catalog with every command `Enabled="false"` (sourced from the #204 `CommandRegistry`, whose factories are pinned disabled-by-default).

- Actuation surface unchanged: nothing in the default file is enabled; default-deny holds.
- The enable-a-command security workflow becomes real: users flip `Enabled` on an existing entry instead of authoring XML from scratch.
- Creation is quiet-on-failure (Warn, never a dialog) so a read-only location can't dialog-spam startup; the Info fallback from the prior commit covers that case.
- Provisioned sessions are unaffected (SessionProvisioner writes its own `.commands` before launch).
- Tests: new `DefaultCommandsFileTests` (creates catalog + all-disabled + comments + round-trip, existing file untouched, unwritable location doesn't throw, `CommandInvoker.Create` end-to-end); the one test pinning the old return-null behavior updated to pin the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm