### PR TITLE
docs(site): @tigkindel handle; responsive doc menu with new pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-By Tig Kindel ([@ckindel on Twitter](http://www.twitter.com/ckindel)) - Copyright © [Kindel](http://www.kindel.com), LLC.
+By Tig Kindel ([@tigkindel on Twitter](https://twitter.com/tigkindel)) - Copyright © [Kindel](http://www.kindel.com), LLC.
 
 ![mcec](docs/hero.gif "MCEC: one agent driving another; launch, File ▸ Settings (every tab), mouse-resize, drag the title bar in circles, Help ▸ About; recorded with MCEC's own agent tools")
 

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,0 +1,26 @@
+# Docs-site menu. One entry per button, rendered by _layouts/default.html.
+# class: download | github | document (drives the existing Dinky button styling)
+- title: Install
+  url: https://github.com/tig/mcec/releases
+  class: download
+- title: View On GitHub
+  url: https://github.com/tig/mcec
+  class: github
+- title: Overview
+  url: index.html
+  class: document
+- title: Documentation
+  url: documentation.html
+  class: document
+- title: Agent Server
+  url: agent-server.html
+  class: document
+- title: Agent Safety
+  url: safety-emergency-stop-and-provisioning.html
+  class: document
+- title: Home Automation
+  url: home-automation.html
+  class: document
+- title: Examples
+  url: example_commands.html
+  class: document

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -28,7 +28,7 @@
           <li><a class="buttons document" href="example_commands.html">Examples</a></li>
         </ul>
         <p class="header">By <a class="header name" href="{{ site.github.owner_url }}">Tigger Kindel</a><br>
-          <a class="header name" href ="http://www.twitter.com/ckindel">@ckindel on Twitter</a></p>
+          <a class="header name" href="https://twitter.com/tigkindel">@tigkindel on Twitter</a></p>
       </header>
 
       <section>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -7,7 +7,7 @@
 {% seo %}
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <script src="{{ '/assets/js/scale.fix.js' | relative_url }}"></script>
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="{{ '/assets/favicon.png' | relative_url }}" />
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -21,11 +21,9 @@
         <p class="header">{{ site.description | default: site.github.project_tagline }}</p>
 
         <ul>
-          <li><a class="buttons download" href="{{ site.github.install_url }}">Install</a></li>
-          <li><a class="buttons github" href="{{ site.github.repository_url }}">View On GitHub</a></li>
-          <li><a class="buttons document" href="index.html">Overview</a></li>
-          <li><a class="buttons document" href="documentation.html">Documentation</a></li>
-          <li><a class="buttons document" href="example_commands.html">Examples</a></li>
+          {% for item in site.data.nav %}
+          <li class="{{ item.class }}"><a class="buttons {{ item.class }}" href="{{ item.url }}">{{ item.title }}</a></li>
+          {% endfor %}
         </ul>
         <p class="header">By <a class="header name" href="{{ site.github.owner_url }}">Tigger Kindel</a><br>
           <a class="header name" href="https://twitter.com/tigkindel">@tigkindel on Twitter</a></p>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -68,6 +68,57 @@ header img{
    border: none;
 }
 
+/* ----------------------------------------------------------------------------
+   Responsive doc menu. Layout only; colors, fonts, and content styling are
+   untouched. Desktop (>960px) keeps the fixed Dinky sidebar exactly as-is
+   (just allowed to scroll if the menu outgrows a short viewport). Below 960px
+   the header becomes a normal top block and the buttons flow as a wrapping
+   row; nothing is absolutely positioned and nothing is ever hidden.
+---------------------------------------------------------------------------- */
+
+@media screen and (min-width: 961px) {
+  header {
+    max-height: calc(100vh - 40px);
+    overflow-y: auto;
+  }
+}
+
+@media print, screen and (max-width: 960px) {
+  header {
+    position: static;
+    float: none;
+    width: auto;
+    margin: 0;
+    padding: 20px 30px;
+    border-radius: 0 0 4px 4px;
+  }
+
+  header ul {
+    position: static;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 12px 0 0;
+  }
+
+  header li {
+    width: auto;
+    height: auto;
+    margin-bottom: 0;
+  }
+
+  header li a.buttons {
+    white-space: nowrap;
+  }
+}
+
+@media print, screen and (max-width: 480px) {
+  /* The stock theme hides the Install button here; keep it visible. */
+  header ul li.download {
+    display: list-item;
+  }
+}
+
 
 
 


### PR DESCRIPTION
Two docs-site fixes:

**Twitter handle** — README byline and the site header now link https://twitter.com/tigkindel (was @ckindel).

**Responsive doc menu** — the Dinky sidebar's small-screen behavior was broken: below 960px the menu was absolutely positioned over the title, and the stock theme hid the Install button below 480px. Redone with layout-only CSS (colors, fonts, and content styling untouched):

- Desktop (>960px): the fixed sidebar is unchanged, just allowed to scroll if the menu outgrows a short viewport.
- Below 960px: the header becomes a normal top block and the red buttons flow as a wrapping row; nothing is absolutely positioned or hidden at any width.
- The nav is now data-driven (`docs/_data/nav.yml`) and includes **Agent Server**, **Agent Safety**, and **Home Automation** alongside the original five entries; future pages are one-line additions.
- Viewport meta drops `user-scalable=no` (accessibility).

GitHub Pages builds the site on merge; CI here covers the app build/tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)