### PR TITLE
fix(ui): status bar truncates a long version instead of pushing out the indicators

### DIFF
--- a/src/Helpers/EllipsizedText.cs
+++ b/src/Helpers/EllipsizedText.cs
@@ -1,0 +1,56 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace MCEControl;
+
+/// <summary>
+/// Fits a string into a pixel width by trimming it to the longest prefix that fits with a
+/// trailing ellipsis. Used by the main window's status bar: the status label holds the full
+/// informational version (e.g. a long prerelease "x.y.z-branch.n+sha" string), and
+/// <c>ToolStripStatusLabel</c> has no <c>AutoEllipsis</c>, so without this a long status pushes
+/// the Client/Server/Serial indicators out of the strip. Pure (no control state); unit-tested
+/// directly.
+/// </summary>
+internal static class EllipsizedText {
+    public const string Ellipsis = "…";
+
+    /// <summary>
+    /// Returns <paramref name="text"/> unchanged when it renders within <paramref name="maxWidth"/>
+    /// pixels in <paramref name="font"/>; otherwise the longest prefix that fits with a trailing
+    /// ellipsis. A width too small for even the ellipsis yields an empty string; a non-positive
+    /// width yields an empty string.
+    /// </summary>
+    public static string Fit(string text, int maxWidth, Font font) {
+        if (string.IsNullOrEmpty(text)) {
+            return string.Empty;
+        }
+        if (maxWidth <= 0) {
+            return string.Empty;
+        }
+        if (Measure(text, font) <= maxWidth) {
+            return text;
+        }
+
+        // Binary-search the longest prefix whose "prefix…" rendering fits.
+        int lo = 0, hi = text.Length - 1;
+        while (lo < hi) {
+            int mid = (lo + hi + 1) / 2;
+            if (Measure(text[..mid] + Ellipsis, font) <= maxWidth) {
+                lo = mid;
+            }
+            else {
+                hi = mid - 1;
+            }
+        }
+
+        if (lo == 0) {
+            return Measure(Ellipsis, font) <= maxWidth ? Ellipsis : string.Empty;
+        }
+        return text[..lo] + Ellipsis;
+    }
+
+    private static int Measure(string s, Font font) => TextRenderer.MeasureText(s, font).Width;
+}

--- a/src/MainWindow.Designer.cs
+++ b/src/MainWindow.Designer.cs
@@ -139,7 +139,7 @@ namespace MCEControl
             this.statusStripClient,
             this.statusStripServer,
             this.statusStripSerial});
-            this.statusStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
+            this.statusStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Table;
             this.statusStrip.Location = new System.Drawing.Point(0, 237);
             this.statusStrip.Name = "statusStrip";
             this.statusStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional;
@@ -156,6 +156,7 @@ namespace MCEControl
             this.statusStripStatus.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.statusStripStatus.Name = "statusStripStatus";
             this.statusStripStatus.Size = new System.Drawing.Size(123, 19);
+            this.statusStripStatus.Spring = true;
             this.statusStripStatus.Text = "MCEC Status";
             this.statusStripStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.statusStripStatus.Click += new System.EventHandler(this.statusStripStatus_Click);

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -86,6 +86,10 @@ public partial class MainWindow : Form, IAppHost {
 
         InitializeServiceControllers();
 
+        // The status label is a Spring item; its width changes with the window, so re-fit the
+        // (possibly ellipsized) status text whenever the strip is resized.
+        statusStrip.SizeChanged += (s, e) => ApplyStatusText();
+
         SetStatus("");
         sendAwakeMenuItem.Enabled = false;
         installLatestVersionMenuItem.Enabled = false;
@@ -696,16 +700,41 @@ public partial class MainWindow : Form, IAppHost {
         }
     }
 
+    // The full, untruncated status text. The status label is a Spring item (it takes only the
+    // space the Client/Server/Serial indicators leave over), so the displayed text is re-fitted
+    // to that width on every set and on strip resize; the full text lives in the tooltip.
+    private string _statusText = string.Empty;
+
     private void SetStatus(string text) {
         if (statusStrip.InvokeRequired) {
             statusStrip.BeginInvoke((Action)(() => { SetStatus(text); }));
         }
         else {
-            statusStripStatus.Text = text;
+            _statusText = text ?? string.Empty;
+            ApplyStatusText();
             // NotifyIcon.Text throws if longer than 127 chars. Status text can include the full
             // informational version (e.g. a long prerelease "x.y.z-branch.n+sha" string), so cap it.
-            notifyIcon.Text = text.Length > 127 ? text[..124] + "..." : text;
+            notifyIcon.Text = _statusText.Length > 127 ? _statusText[..124] + "..." : _statusText;
         }
+    }
+
+    /// <summary>
+    /// Fits <see cref="_statusText"/> into the status label's current (Spring-allocated) width
+    /// with a trailing ellipsis, so an arbitrarily long status (e.g. the full informational
+    /// version) can never push the Client/Server/Serial indicators out of the strip. The full
+    /// text is kept reachable as the label's tooltip when truncated. Called on every status set
+    /// and on strip resize (the Spring width changes with the window).
+    /// </summary>
+    private void ApplyStatusText() {
+        int width = statusStripStatus.ContentRectangle.Width;
+        if (width <= 0) {
+            // Not laid out yet (constructor-time SetStatus); the SizeChanged hook re-fits later.
+            statusStripStatus.Text = _statusText;
+            return;
+        }
+        string fitted = EllipsizedText.Fit(_statusText, width, statusStripStatus.Font);
+        statusStripStatus.Text = fitted;
+        statusStripStatus.ToolTipText = fitted == _statusText ? string.Empty : _statusText;
     }
 
     // ----------------------------------------

--- a/tests/MCEControl.xUnit/Helpers/EllipsizedTextTests.cs
+++ b/tests/MCEControl.xUnit/Helpers/EllipsizedTextTests.cs
@@ -1,0 +1,86 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Drawing;
+using System.Windows.Forms;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Helpers;
+
+/// <summary>
+/// Pins the status-bar text fitter: a status longer than the label's Spring-allocated width must
+/// come back ellipsized and within the width, so a long informational version string can never
+/// push the Client/Server/Serial indicators out of the status strip.
+/// </summary>
+public class EllipsizedTextTests {
+    private static readonly Font TestFont = new("Segoe UI", 9f);
+
+    private static int Measure(string s) => TextRenderer.MeasureText(s, TestFont).Width;
+
+    [Fact]
+    public void ShortText_ReturnedUnchanged() {
+        const string text = "Version: 3.0.11";
+        int width = Measure(text) + 20;
+
+        Assert.Equal(text, EllipsizedText.Fit(text, width, TestFont));
+    }
+
+    [Fact]
+    public void ExactFit_ReturnedUnchanged() {
+        const string text = "Version: 3.0.11";
+        int width = Measure(text);
+
+        Assert.Equal(text, EllipsizedText.Fit(text, width, TestFont));
+    }
+
+    [Fact]
+    public void LongText_IsEllipsizedAndFits() {
+        // The real-world case: a full informational version with branch + sha.
+        const string text = "Version: 3.0.12-claude-issue-123-super-long-branch-name.47+Branch.claude-issue-123.Sha.0123456789abcdef0123456789abcdef01234567";
+        int width = Measure("Version: 3.0.12-clau"); // deliberately much narrower than the text
+
+        string fitted = EllipsizedText.Fit(text, width, TestFont);
+
+        Assert.EndsWith(EllipsizedText.Ellipsis, fitted);
+        Assert.True(Measure(fitted) <= width, $"fitted '{fitted}' measures {Measure(fitted)}px > {width}px");
+        Assert.True(fitted.Length < text.Length);
+        Assert.StartsWith(fitted[..^1], text); // prefix of the original, plus the ellipsis
+    }
+
+    [Fact]
+    public void LongText_KeepsTheLongestPrefixThatFits() {
+        const string text = "Version: 3.0.12-develop.5+Branch.develop.Sha.abcdef";
+        int width = Measure(text) - 10; // just barely too narrow
+
+        string fitted = EllipsizedText.Fit(text, width, TestFont);
+
+        Assert.EndsWith(EllipsizedText.Ellipsis, fitted);
+        Assert.True(Measure(fitted) <= width);
+        // One more character must NOT fit; otherwise the search stopped early.
+        string oneMore = text[..(fitted.Length)] + EllipsizedText.Ellipsis;
+        Assert.True(Measure(oneMore) > width, "a longer prefix would still have fit");
+    }
+
+    [Fact]
+    public void TinyWidth_DegradesToEllipsisThenEmpty() {
+        const string text = "Version: 3.0.11";
+
+        string atEllipsisWidth = EllipsizedText.Fit(text, Measure(EllipsizedText.Ellipsis), TestFont);
+        Assert.Equal(EllipsizedText.Ellipsis, atEllipsisWidth);
+
+        Assert.Equal(string.Empty, EllipsizedText.Fit(text, 1, TestFont));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void NonPositiveWidth_ReturnsEmpty(int width) {
+        Assert.Equal(string.Empty, EllipsizedText.Fit("anything", width, TestFont));
+    }
+
+    [Fact]
+    public void EmptyText_ReturnsEmpty() {
+        Assert.Equal(string.Empty, EllipsizedText.Fit("", 100, TestFont));
+    }
+}


### PR DESCRIPTION
The status strip used `HorizontalStackWithOverflow` with an autosizing status label first, so a long informational version (`x.y.z-branch.n+sha`) grew the label and pushed the Client/Server/Serial indicators off the strip.

## Fix
- The strip now uses **Table layout with `statusStripStatus.Spring = true`**: the label takes only the space the indicators leave over, so they can never be displaced regardless of text length.
- `SetStatus` keeps the full text and fits the displayed text to the label's current width with a trailing ellipsis (new pure `EllipsizedText.Fit` helper; binary-searches the longest prefix that renders within the width via `TextRenderer.MeasureText`). The full text stays reachable as the label's **tooltip** (`ShowItemToolTips` already enabled), and the fit re-runs on strip resize since the Spring width tracks the window.

## Tests
8 new unit tests pin the fitter: unchanged short/exact-fit text, ellipsized long text within budget, longest-prefix maximality (one more char must not fit), and tiny-width degradations (ellipsis alone, then empty). Full suite: 845/845 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)