### PR TITLE
docs: fix two stale/inaccurate claims found while triaging issues #24, #37

### DIFF
--- a/docs/home-automation.md
+++ b/docs/home-automation.md
@@ -155,8 +155,9 @@ By default **all** commands are disabled, to reduce the surface area MCEC expose
 
 ![Commands](commands_enable.png "Commands")
 
-Clicking **Save mcec.commands file** saves changes immediately. The `.commands` file is also saved
-automatically whenever MCEC exits.
+Clicking **Save mcec.commands file** saves changes immediately. The `.commands` file is **not** saved
+automatically on exit; MCEC only writes it in response to that explicit action, so a crash or power loss
+can never corrupt it mid-write on the way out.
 
 ## Testing MCEC
 
@@ -246,6 +247,11 @@ VK_F1
 
 A full list of virtual key codes is on
 [this MSDN page](http://msdn.microsoft.com/en-us/library/dd375731.aspx).
+
+> Since Windows 10, `VK_MEDIA_*` keys (play/pause, next/prev track, volume) are only delivered to the
+> **foreground** application; this is a Windows platform behavior, not something MCEC controls. If a media
+> key seems to do nothing, bring the target app to the foreground first (e.g. with `SetForegroundWindow` or
+> a launch sequence), then send the key.
 
 Sending `chars:` plus text simulates typing that text. `chars:3` types `3`; `chars:Hello` types the
 letters H-e-l-l-o (including the shift for the capital). The text after `chars:` can include *character


### PR DESCRIPTION
Two small doc corrections found during a full open-issue triage pass:

1. **home-automation.md said `.commands` auto-saves on exit.** It hasn't since the fix for #24 removed the exit-time save call (`MainWindow.cs`, commented out with a `BUGBUG` note referencing that issue) — that unattended write racing a shutdown was the likely corruption cause. Corrected to state save-on-explicit-action only.
2. **Added a foreground-only caveat to the `VK_MEDIA_*` example**, per the root cause identified closing #37: Windows 10+ only delivers media virtual keys to the foreground app, a platform behavior, not an MCEC bug.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)