### PR TITLE
fix: produce ambiguous-selector, stale-element, and elevation errors; mark focus/foreground reserved

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -171,7 +171,8 @@ Over MCP, the transport's `isError` flag mirrors the envelope (`isError = !ok`).
 
 On failure the `error` object carries a stable, fine-grained `code`, a coarse `category` from
 the closed taxonomy (`timeout`, `ambiguous-selector`, `stale-element`, `no-target`,
-`invalid-argument`, `capture-blank`, `focus`, `elevation`, `foreground`, `internal`), a
+`invalid-argument`, `capture-blank`, `focus`, `elevation`, `foreground`, `internal`; `focus`
+and `foreground` are reserved for future detection and are not currently produced), a
 human-readable `detail`, and (when available) a `lastObservation` (the last good state before
 the failure, so a failed call is debuggable without rerunning it) and a `partialResult` (the
 failing call's own partial payload, e.g. a blank capture's suspect PNG):
@@ -403,9 +404,10 @@ Known limits:
   the desktop cannot be rendered and captures are blank. This is detected (blank frame) but cannot
   be worked around from user space.
 - **Elevation (UAC):** MCEC running at medium integrity cannot read the UIA tree of, drive, or
-  reliably capture a window owned by an elevated (high-integrity) process. Such targets surface as
-  empty/failed observations; run MCEC elevated only if you explicitly need to automate elevated
-  apps, and understand the security trade-off.
+  reliably capture a window owned by an elevated (high-integrity) process. When UI Automation
+  reports access denied for such a target, the tool fails with `error.category: elevation`
+  (`code: target-elevated`) so an agent knows to stop rather than retry; run MCEC elevated only
+  if you explicitly need to automate elevated apps, and understand the security trade-off.
 
 ### UIA tree size & stability
 

--- a/docs/design/agent-tool-result-contract.md
+++ b/docs/design/agent-tool-result-contract.md
@@ -75,35 +75,36 @@ falling back to `category`.
 | `category`           | When it applies | Typical recovery for an agent |
 |----------------------|-----------------|-------------------------------|
 | `timeout`            | A wait/poll (e.g. `wait-for`) expired before its condition held. | Re-observe; extend the timeout; or abandon the step. |
-| `ambiguous-selector` | A selector matched more than one candidate and the tool refused to guess. | Add disambiguators (`processName`, `className`, `automationId`) and retry. |
+| `ambiguous-selector` | A selector matched more than one candidate and the tool refused to guess. | Narrow the element selector (prefer `automationId`, else `className` or a more specific name) and retry. |
 | `stale-element`      | A previously resolved element/handle is no longer valid (window closed, tree re-rendered). | Re-`query`/`find` to get a fresh reference, then retry. |
 | `no-target`          | A selector matched nothing (no window/element). | Broaden the selector, `query` to discover targets, or wait for the target to appear. |
 | `invalid-argument`   | The request itself is malformed or inapplicable (#191): a client-supplied argument is invalid (unknown action, oversized region, ill-formed endpoint) or cannot apply to the target (an element that lacks the pattern an action needs). | Fix the arguments and re-issue. Do **not** retry the same call, broaden a selector, or re-find the target; the request will keep failing until it changes. |
 | `capture-blank`      | A screenshot was produced but detected as black/blank (composited/occluded/locked-session). | Try foreground/region capture; restore/foreground the window; surface the limitation. The suspect image still rides in `error.partialResult`. |
-| `focus`              | An action required input focus that could not be set. | `invoke` `setfocus` first, or foreground the window, then retry. |
-| `elevation`          | The target runs at a higher integrity level (UAC) than MCEC and cannot be driven. | Surface to the operator; the action cannot proceed without elevation. |
-| `foreground`         | An action required the target to be foreground and it could not be brought forward. | Foreground the window (subject to OS foreground-lock rules), then retry. |
+| `focus`              | **Reserved** (#261): an action required input focus that could not be set. No code path produces it yet (`setfocus` dispatch is fire-and-forget); it stays in the closed set for wire compatibility and future detection. | Treat like `internal` until a producer exists. |
+| `elevation`          | The target runs at a higher integrity level (UAC) than MCEC and cannot be driven. Produced (#261) when a UIA attach/read/dispatch on a valid window fails with E_ACCESSDENIED (UIPI). | Surface to the operator; the action cannot proceed without elevation. |
+| `foreground`         | **Reserved** (#261): an action required the target to be foreground and it could not be brought forward. No agent command checks a SetForegroundWindow result yet; kept for wire compatibility and future detection. | Treat like `internal` until a producer exists. |
 | `internal`           | An unexpected MCEC-side fault (bug, unhandled exception). | Not agent-recoverable; report with `lastObservation` for a bug bundle (#87). |
 
 `focus`, `elevation`, and `foreground` are kept distinct (rather than one "input" bucket) because
 the recoveries differ: focus is retryable, foreground is OS-policy-constrained, and elevation is
-not recoverable by the agent at all.
+not recoverable by the agent at all. In-product guidance (`AgentInstructions.md`) documents recovery
+only for categories that can actually occur; reserved categories must not be taught to agents (#261).
 
 ### Example error codes per category
 
 `code` values are stable strings but the list is open; these are illustrative, not exhaustive:
 
 - `timeout` → `wait-condition-timeout`
-- `ambiguous-selector` → `selector-matched-N`
+- `ambiguous-selector` → `selector-matched-N` (N is the literal match count, e.g. `selector-matched-3`)
 - `stale-element` → `element-stale`, `window-closed`
 - `no-target` → `window-not-found`, `element-not-found`
 - `invalid-argument` → `region-too-large`, `action-unknown`, `pattern-unsupported`, `bad-arguments`,
   `launch-path-missing`, `recording-in-progress`, `no-recording`
 - `capture-blank` → `frame-all-black`, `frame-mostly-blank`
-- `focus` → `set-focus-failed`
+- `focus` → `set-focus-failed` (reserved; no producer yet)
 - `elevation` → `target-elevated`
-- `foreground` → `set-foreground-denied`
-- `internal` → `unhandled-exception`
+- `foreground` → `set-foreground-denied` (reserved; no producer yet)
+- `internal` → `unhandled-exception`, `uia-faulted`, `invoke-faulted`
 
 ## Warning model
 

--- a/src/Agent/AgentErrorCategory.cs
+++ b/src/Agent/AgentErrorCategory.cs
@@ -31,13 +31,21 @@ public enum AgentErrorCategory {
     /// <summary>A screenshot was produced but detected as black/blank.</summary>
     CaptureBlank,
 
-    /// <summary>An action required input focus that could not be set.</summary>
+    /// <summary>An action required input focus that could not be set. RESERVED (#261): part of the
+    /// closed wire contract but not yet produced by any code path; <c>setfocus</c> dispatch is
+    /// fire-and-forget and no command verifies focus landed. Do not document recovery guidance for it
+    /// until a producer exists.</summary>
     Focus,
 
-    /// <summary>The target runs at a higher integrity level (UAC) than MCEC and cannot be driven.</summary>
+    /// <summary>The target runs at a higher integrity level (UAC) than MCEC and cannot be driven.
+    /// Produced (#261) when a UIA attach/read/dispatch on a valid window fails with E_ACCESSDENIED
+    /// (UIPI); see <see cref="UiaService.ClassifyUiaFailure"/>.</summary>
     Elevation,
 
-    /// <summary>An action required the target to be foreground and it could not be brought forward.</summary>
+    /// <summary>An action required the target to be foreground and it could not be brought forward.
+    /// RESERVED (#261): part of the closed wire contract but not yet produced by any code path; no
+    /// agent command checks a SetForegroundWindow result. Do not document recovery guidance for it
+    /// until a producer exists.</summary>
     Foreground,
 
     /// <summary>An unexpected MCEC-side fault (bug, unhandled exception) or a policy refusal the agent

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -66,10 +66,15 @@ stale-element, no-target, invalid-argument, capture-blank, focus, elevation, for
 choose recovery; e.g. `no-target` means broaden the selector, `query` to discover targets, or `wait-for`
 the element; `invalid-argument` means the REQUEST itself is wrong (unknown action, oversized region,
 ill-formed endpoint, an action the element can't perform); fix the arguments, do NOT retry the same call
-or broaden a selector; `ambiguous-selector` means add `processName`/`className`/`automationId`;
-`stale-element` means re-`query`/`find` for a fresh handle; `internal` is not recoverable by you; report
-it. Branch on codes and categories, never on the wording of `error.detail` (it is human-readable and may
-change). `error.lastObservation`, when present, is the last good state before the failure, and
+or broaden a selector; `ambiguous-selector` means the element selector matched more than one element and
+the tool refused to guess (the match count rides in the code, `selector-matched-N`); NARROW the selector
+(prefer `automationId`, else `className` or a more specific name); retrying it unchanged cannot help;
+`stale-element` means the window/element went away mid-call (closed or re-rendered); re-`query`/`find`
+for a fresh handle, then retry; `elevation` means the target runs elevated (UAC) at a higher integrity
+level than MCEC and cannot be observed or driven; report it to the user, do not retry; `internal` is not
+recoverable by you; report it. `focus` and `foreground` are reserved for future detection and are never
+produced today; treat them like `internal` if one ever appears. Branch on codes and categories, never on
+the wording of `error.detail` (it is human-readable and may change). `error.lastObservation`, when present, is the last good state before the failure, and
 `error.partialResult` is the failing call's OWN partial payload (e.g. a blank capture's suspect PNG).
 When the last good observation was a `capture`, `lastObservation` is a compact summary; the window
 descriptor, dimensions, blankCheck verdict, and byte count, with `kind:"capture-summary"`; plus an

--- a/src/Agent/UiaFailureKind.cs
+++ b/src/Agent/UiaFailureKind.cs
@@ -1,0 +1,28 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// How a UIA attach/read/dispatch failed, classified from the exception it threw (#261). Produced by
+/// <see cref="UiaService.ClassifyUiaFailure"/> and carried on <see cref="UiaFindOutcome"/> and
+/// <see cref="UiaTreeResult"/> so commands can map real UIA failure modes onto the closed
+/// <see cref="AgentErrorCategory"/> taxonomy (stale-element, elevation) instead of collapsing
+/// everything into a null result that reads as "not found".
+/// </summary>
+public enum UiaFailureKind {
+    /// <summary>No failure.</summary>
+    None = 0,
+
+    /// <summary>The window or element is no longer available (closed, torn down, re-rendered);
+    /// UIA_E_ELEMENTNOTAVAILABLE or FlaUI's ElementNotAvailableException. Maps to <c>stale-element</c>.</summary>
+    WindowGone,
+
+    /// <summary>UIA was denied access to the target (E_ACCESSDENIED), which for a valid window almost
+    /// always means the target process runs at a higher integrity level (UAC) than MCEC (UIPI blocks
+    /// the client). Maps to <c>elevation</c>.</summary>
+    AccessDenied,
+
+    /// <summary>Any other UIA fault. Maps to <c>internal</c>.</summary>
+    Faulted,
+}

--- a/src/Agent/UiaFindOutcome.cs
+++ b/src/Agent/UiaFindOutcome.cs
@@ -1,0 +1,22 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// The outcome of a <see cref="UiaService.Find"/> element lookup (#261). The old bare
+/// <c>UiaElementInfo?</c> conflated four distinct outcomes into null; not found, ambiguous selector,
+/// window gone, and access denied all looked identical to a caller; so an agent was told
+/// <c>no-target</c> (broaden the selector!) for failures whose correct recovery is the opposite.
+/// </summary>
+/// <param name="Element">The single matching element, or null when none/ambiguous/failed.</param>
+/// <param name="MatchCount">How many elements matched the selector on the deciding attempt; &gt; 1
+/// means the selector was ambiguous and the lookup refused to guess.</param>
+/// <param name="Failure">How the lookup failed, when it failed exceptionally.</param>
+public sealed record UiaFindOutcome(UiaElementInfo? Element, int MatchCount, UiaFailureKind Failure) {
+    /// <summary>A clean miss: nothing matched, no fault.</summary>
+    public static readonly UiaFindOutcome NotFound = new(null, 0, UiaFailureKind.None);
+
+    /// <summary>True when the selector matched more than one element and the lookup refused to guess.</summary>
+    public bool Ambiguous => MatchCount > 1;
+}

--- a/src/Agent/UiaInvokeResult.cs
+++ b/src/Agent/UiaInvokeResult.cs
@@ -27,7 +27,22 @@ public enum UiaInvokeResult {
     /// <c>set-value</c>). Nothing was looked up or dispatched. Recovery: fix the argument.</summary>
     ActionUnknown,
 
-    /// <summary>UIA threw while attaching, finding, or dispatching (window closed mid-call, COM
-    /// fault). Not agent-recoverable beyond re-observing the target.</summary>
+    /// <summary>The selector matched MORE than one element and the lookup refused to guess (#261).
+    /// Nothing was dispatched. Recovery: narrow the selector (automationId/className or a more
+    /// specific name); retrying the same selector cannot help.</summary>
+    ElementAmbiguous,
+
+    /// <summary>The element or its window went away between lookup and dispatch, or the window handle
+    /// no longer resolves (UIA_E_ELEMENTNOTAVAILABLE, #261). Recovery: re-<c>query</c>/<c>find</c> for
+    /// a fresh target, then retry.</summary>
+    ElementStale,
+
+    /// <summary>UIA was denied access to the target (E_ACCESSDENIED, #261): for a valid window this
+    /// means the target runs at a higher integrity level (UAC) than MCEC and cannot be driven.
+    /// Not agent-recoverable; surface it to the operator.</summary>
+    TargetElevated,
+
+    /// <summary>UIA threw while attaching, finding, or dispatching (COM fault not classified as stale
+    /// or elevation). Not agent-recoverable beyond re-observing the target.</summary>
     Faulted,
 }

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -82,29 +82,36 @@ public static class UiaService {
         }
         catch (Exception e) {
             // FromHandle/UIA can throw COMException or FlaUI-specific exceptions on a window that
-            // closes mid-call; never let it escape the command's Execute().
+            // closes mid-call; never let it escape the command's Execute(). Classify the fault (#261)
+            // so query reports stale-element/elevation instead of a healthy-looking empty tree.
             Logger.Instance.Log4.Error($"UiaService.DumpTree failed: {e.Message}");
-            return new UiaTreeResult(null, 0, false);
+            return new UiaTreeResult(null, 0, false, ClassifyUiaFailure(e));
         }
     }
 
     /// <summary>
-    /// Finds the first descendant of <paramref name="hwnd"/> matching <paramref name="value"/> by the
+    /// Finds the single descendant of <paramref name="hwnd"/> matching <paramref name="value"/> by the
     /// given strategy (<c>name</c>/<c>automationid</c>/<c>classname</c>, case-insensitive). When
-    /// <paramref name="timeoutMs"/> &gt; 0 it retries until found or the timeout elapses. Returns a
-    /// single node (no children) or null.
+    /// <paramref name="timeoutMs"/> &gt; 0 it retries until found or the timeout elapses. A selector
+    /// matching MORE than one element fails fast as ambiguous (#261; waiting cannot disambiguate, and
+    /// silently acting on "the first match" is the worst agent failure mode: it succeeds on the wrong
+    /// control); exceptional failures are classified (<see cref="UiaFailureKind"/>) rather than
+    /// collapsed into "not found".
     /// </summary>
-    public static UiaElementInfo? Find(IntPtr hwnd, string by, string value, int timeoutMs) {
+    public static UiaFindOutcome Find(IntPtr hwnd, string by, string value, int timeoutMs) {
         if (hwnd == IntPtr.Zero) {
-            return null;
+            return UiaFindOutcome.NotFound;
         }
         try {
-            AutomationElement? el = FindWithPolling(hwnd, by, value, timeoutMs);
-            return el is null ? null : RunOnWorker(_ => Describe(el));
+            (AutomationElement? el, int matchCount) = FindWithPolling(hwnd, by, value, timeoutMs);
+            if (matchCount > 1) {
+                return new UiaFindOutcome(null, matchCount, UiaFailureKind.None);
+            }
+            return el is null ? UiaFindOutcome.NotFound : new UiaFindOutcome(RunOnWorker(_ => Describe(el)), 1, UiaFailureKind.None);
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"UiaService.Find failed: {e.Message}");
-            return null;
+            return new UiaFindOutcome(null, 0, ClassifyUiaFailure(e));
         }
     }
 
@@ -118,7 +125,14 @@ public static class UiaService {
     /// a closed WinForms menu's sub-items are not in the UIA tree until the parent is opened. It uses
     /// the ExpandCollapse pattern, falling back to Invoke for WinForms menu items that lack it.
     /// </summary>
-    public static UiaInvokeResult Invoke(IntPtr hwnd, string by, string value, string action, string? text) {
+    public static UiaInvokeResult Invoke(IntPtr hwnd, string by, string value, string action, string? text) =>
+        Invoke(hwnd, by, value, action, text, out _);
+
+    /// <inheritdoc cref="Invoke(IntPtr, string, string, string, string?)"/>
+    /// <param name="matchCount">How many elements matched the selector; &gt; 1 accompanies
+    /// <see cref="UiaInvokeResult.ElementAmbiguous"/> so the failure can report the count.</param>
+    public static UiaInvokeResult Invoke(IntPtr hwnd, string by, string value, string action, string? text, out int matchCount) {
+        matchCount = 0;
         if (hwnd == IntPtr.Zero) {
             return UiaInvokeResult.ElementNotFound;
         }
@@ -130,7 +144,11 @@ public static class UiaService {
         }
         try {
             // The lookup runs (poll-by-poll) on the shared UIA worker like every other tree access...
-            AutomationElement? el = FindWithPolling(hwnd, by, value, InvokeFindTimeoutMs);
+            (AutomationElement? el, matchCount) = FindWithPolling(hwnd, by, value, InvokeFindTimeoutMs);
+            if (matchCount > 1) {
+                // Acting on "the first of N matches" silently drives the wrong control (#261).
+                return UiaInvokeResult.ElementAmbiguous;
+            }
             if (el is null) {
                 return UiaInvokeResult.ElementNotFound;
             }
@@ -156,8 +174,39 @@ public static class UiaService {
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"UiaService.Invoke failed: {e.Message}");
-            return UiaInvokeResult.Faulted;
+            // Classify the fault (#261): an element torn down between lookup and dispatch is the
+            // canonical stale-element; access denied on a valid window is the elevation (UIPI) case.
+            return ClassifyUiaFailure(e) switch {
+                UiaFailureKind.WindowGone => UiaInvokeResult.ElementStale,
+                UiaFailureKind.AccessDenied => UiaInvokeResult.TargetElevated,
+                _ => UiaInvokeResult.Faulted,
+            };
         }
+    }
+
+    /// <summary>UIA_E_ELEMENTNOTAVAILABLE: the element/window backing a UIA object is gone.</summary>
+    private const int UiaElementNotAvailableHResult = unchecked((int)0x80040201);
+
+    /// <summary>E_ACCESSDENIED: UIA refused access; for a valid window this is the UIPI/elevation case.</summary>
+    private const int AccessDeniedHResult = unchecked((int)0x80070005);
+
+    /// <summary>
+    /// Classifies a UIA exception into a <see cref="UiaFailureKind"/> (#261), walking inner exceptions
+    /// because FlaUI sometimes wraps the underlying COMException. Matched by HRESULT (and FlaUI's
+    /// typed ElementNotAvailableException) rather than by exception type alone, so both the raw COM
+    /// error and the wrapped form classify identically. Internal so tests can pin the mapping without
+    /// a live UIA tree.
+    /// </summary>
+    internal static UiaFailureKind ClassifyUiaFailure(Exception e) {
+        for (Exception? cur = e; cur is not null; cur = cur.InnerException) {
+            if (cur is FlaUI.Core.Exceptions.ElementNotAvailableException || cur.HResult == UiaElementNotAvailableHResult) {
+                return UiaFailureKind.WindowGone;
+            }
+            if (cur.HResult == AccessDeniedHResult) {
+                return UiaFailureKind.AccessDenied;
+            }
+        }
+        return UiaFailureKind.Faulted;
     }
 
     /// <summary>True if <paramref name="action"/> is one of the supported invoke actions
@@ -277,21 +326,26 @@ public static class UiaService {
     /// <see cref="FindPollIntervalMs"/>, sleeping on the CALLING thread between attempts so a long
     /// wait never monopolizes the worker. <paramref name="timeoutMs"/> &lt;= 0 means a single attempt.
     /// The root is re-resolved from <paramref name="hwnd"/> each attempt, so a window that re-renders
-    /// mid-wait cannot leave the poll holding a stale subtree.
+    /// mid-wait cannot leave the poll holding a stale subtree. Each attempt enumerates ALL matches
+    /// (FindAll, not FindFirst; the cost of ambiguity detection, #261; the scan is bounded by the
+    /// target window's own tree): more than one match returns immediately with the count and a null
+    /// element; waiting cannot disambiguate a selector, and returning "the first" acts on the wrong
+    /// control. Exceptions propagate to the caller for classification.
     /// </summary>
-    private static AutomationElement? FindWithPolling(IntPtr hwnd, string by, string value, int timeoutMs) {
+    private static (AutomationElement? Element, int MatchCount) FindWithPolling(IntPtr hwnd, string by, string value, int timeoutMs) {
         Stopwatch sw = Stopwatch.StartNew();
         while (true) {
-            AutomationElement? el = RunOnWorker(automation => {
+            (AutomationElement? el, int count) = RunOnWorker(automation => {
                 AutomationElement root = automation.FromHandle(hwnd);
-                return root.FindFirstDescendant(BuildCondition(by, value));
+                AutomationElement[] matches = root.FindAllDescendants(BuildCondition(by, value));
+                return (matches.Length == 1 ? matches[0] : null, matches.Length);
             });
-            if (el is not null || timeoutMs <= 0) {
-                return el;
+            if (count > 0 || timeoutMs <= 0) {
+                return (el, count);
             }
             long remaining = timeoutMs - sw.ElapsedMilliseconds;
             if (remaining <= 0) {
-                return null;
+                return (null, 0);
             }
             Thread.Sleep((int)Math.Min(FindPollIntervalMs, remaining));
         }

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -42,6 +42,14 @@ public static class UiaService {
     /// missing element must fail fast (no-target) rather than be misreported as a pending modal (#107).
     /// Agents are instructed to <c>wait-for</c>/<c>find</c> a control before acting on it, so invoke does
     /// not need a long implicit wait of its own.
+    ///
+    /// <para>#262 review (Codex P2): the lookup enumerates matches with <c>FindAllDescendants</c> to
+    /// detect an ambiguous selector, so a found lookup no longer early-exits on the first match. The
+    /// exposure is bounded: the poll loop returns the instant a scan finds any match, so the found
+    /// (and found-ambiguous) case is a SINGLE scan; the not-found case polls, but <c>FindFirst</c>
+    /// already had to walk the whole subtree to conclude "none," so its worst-case latency is
+    /// unchanged. The grace must clear this timeout by more than one scan can take on a large tree;
+    /// the margin is pinned by <c>InvokeFindTimeout_StaysBelowModalGrace...</c>.</para>
     /// </summary>
     public const int InvokeFindTimeoutMs = 500;
 

--- a/src/Agent/UiaTreeResult.cs
+++ b/src/Agent/UiaTreeResult.cs
@@ -7,6 +7,9 @@ namespace MCEControl;
 /// The result of a UIA tree snapshot (<see cref="UiaService.DumpTree"/>): the (possibly null) root
 /// node, the total <see cref="NodeCount"/> captured, and whether the node cap clipped the walk
 /// (<see cref="Truncated"/>). Carrying the count and truncation flag lets <c>query</c> surface a
-/// <c>tree-truncated</c> warning instead of returning a silently clipped tree.
+/// <c>tree-truncated</c> warning instead of returning a silently clipped tree. <see cref="Failure"/>
+/// classifies an attach-level fault (#261) so <c>query</c> can report <c>stale-element</c>/<c>elevation</c>
+/// instead of an empty tree that reads as a healthy-but-blank observation.
 /// </summary>
-public sealed record UiaTreeResult(UiaElementInfo? Root, int NodeCount, bool Truncated);
+public sealed record UiaTreeResult(UiaElementInfo? Root, int NodeCount, bool Truncated,
+    UiaFailureKind Failure = UiaFailureKind.None);

--- a/src/Commands/ClickCommand.cs
+++ b/src/Commands/ClickCommand.cs
@@ -47,8 +47,8 @@ public class ClickCommand : WindowTargetingAgentCommand {
     protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr hwnd = target is null ? IntPtr.Zero : new IntPtr(target.Handle);
 
-        if (!TryResolvePoint(hwnd, out (int X, int Y) point, out string? error)) {
-            return CommandResult.Fail(Cmd, error!, "element-not-found", "no-target");
+        if (!TryResolvePoint(hwnd, out (int X, int Y) point, out CommandResult? failure)) {
+            return failure!;
         }
 
         // Clamp to the {1,2} the contract exposes and normalize the button, then dispatch and echo the
@@ -70,21 +70,27 @@ public class ClickCommand : WindowTargetingAgentCommand {
     /// <summary>
     /// Resolves the click point to an absolute screen pixel: the centre of an element (<see cref="By"/>/
     /// <see cref="Value"/>) when <see cref="Value"/> is set, else the literal (<see cref="X"/>,
-    /// <see cref="Y"/>). Returns false with <paramref name="error"/> when the element can't be found.
+    /// <see cref="Y"/>). Returns false with a structured <paramref name="failure"/> when the element
+    /// can't be resolved (not found, ambiguous, stale window, elevated target; #261).
     /// </summary>
-    private bool TryResolvePoint(IntPtr hwnd, out (int X, int Y) point, out string? error) {
-        error = null;
+    private bool TryResolvePoint(IntPtr hwnd, out (int X, int Y) point, out CommandResult? failure) {
+        failure = null;
         if (string.IsNullOrEmpty(Value)) {
             point = (X, Y);
             return true;
         }
+        string by = string.IsNullOrEmpty(By) ? "name" : By;
         // hwnd is guaranteed non-zero here: the base resolves the window whenever Value is set.
-        UiaElementInfo? el = UiaService.Find(hwnd, string.IsNullOrEmpty(By) ? "name" : By, Value, FindTimeoutMs);
-        if (el is null) {
+        UiaFindOutcome outcome = UiaService.Find(hwnd, by, Value, FindTimeoutMs);
+        failure = UiaFindFailureFor(Cmd, by, Value, outcome);
+        if (failure is null && outcome.Element is null) {
+            failure = CommandResult.Fail(Cmd, $"element not found ({by}='{Value}')", "element-not-found", "no-target");
+        }
+        if (failure is not null) {
             point = default;
-            error = $"element not found ({(string.IsNullOrEmpty(By) ? "name" : By)}='{Value}')";
             return false;
         }
+        UiaElementInfo el = outcome.Element!;
         point = (el.X + (el.Width / 2), el.Y + (el.Height / 2));
         return true;
     }

--- a/src/Commands/DragCommand.cs
+++ b/src/Commands/DragCommand.cs
@@ -81,7 +81,9 @@ public class DragCommand : WindowTargetingAgentCommand {
     /// bounds) when <paramref name="value"/> is set, else the literal (<paramref name="x"/>,
     /// <paramref name="y"/>). Returns false with a structured <paramref name="failure"/> when an
     /// element endpoint has no window or can't be resolved (not found, ambiguous, stale window,
-    /// elevated target; #261); <paramref name="endpoint"/> names which end failed in the detail.
+    /// elevated target; #261). <paramref name="endpoint"/> ("Drag start"/"Drag end") is prefixed onto
+    /// the detail of EVERY failure category (via <see cref="LabelEndpoint"/>) so a two-endpoint drag
+    /// always says which end failed (#262 review).
     /// </summary>
     private static bool TryResolvePoint(IntPtr hwnd, string by, string value, int x, int y, string endpoint, string cmd, out (int X, int Y) point, out CommandResult? failure) {
         failure = null;
@@ -91,23 +93,34 @@ public class DragCommand : WindowTargetingAgentCommand {
         }
         if (hwnd == IntPtr.Zero) {
             point = default;
-            failure = CommandResult.Fail(cmd, $"{endpoint}: element endpoint requires a target window", "element-not-found", "no-target");
+            failure = LabelEndpoint(endpoint, CommandResult.Fail(cmd, "element endpoint requires a target window", "element-not-found", "no-target"));
             return false;
         }
         string effectiveBy = string.IsNullOrEmpty(by) ? "name" : by;
         UiaFindOutcome outcome = UiaService.Find(hwnd, effectiveBy, value, FindTimeoutMs);
-        failure = UiaFindFailureFor(cmd, effectiveBy, value, outcome);
-        if (failure is null && outcome.Element is null) {
-            failure = CommandResult.Fail(cmd, $"{endpoint}: element not found ({effectiveBy}='{value}')", "element-not-found", "no-target");
-        }
-        if (failure is not null) {
+        CommandResult? raw = UiaFindFailureFor(cmd, effectiveBy, value, outcome)
+            ?? (outcome.Element is null
+                ? CommandResult.Fail(cmd, $"element not found ({effectiveBy}='{value}')", "element-not-found", "no-target")
+                : null);
+        if (raw is not null) {
             point = default;
+            failure = LabelEndpoint(endpoint, raw);
             return false;
         }
         UiaElementInfo el = outcome.Element!;
         point = (el.X + (el.Width / 2), el.Y + (el.Height / 2));
         return true;
     }
+
+    /// <summary>
+    /// Prefixes an endpoint label ("Drag start"/"Drag end") onto a resolution failure's detail so a
+    /// two-endpoint drag reports WHICH end failed, uniformly across every failure category (#262
+    /// review). Rebuilds the result because <see cref="CommandResult.Error"/> is init-only; code,
+    /// category, and any carried data are preserved. Internal so the mapping is unit-testable without
+    /// a live UIA tree.
+    /// </summary>
+    internal static CommandResult LabelEndpoint(string endpoint, CommandResult failure) =>
+        CommandResult.Fail(failure.Command!, $"{endpoint}: {failure.Error}", failure.ErrorCode!, failure.ErrorCategory!, failure.Data);
 
     /// <summary>Parses <c>x,y;x,y;...</c> intermediate waypoints; skips malformed pairs.</summary>
     private static List<(int X, int Y)> ParsePath(string? spec) {

--- a/src/Commands/DragCommand.cs
+++ b/src/Commands/DragCommand.cs
@@ -52,13 +52,13 @@ public class DragCommand : WindowTargetingAgentCommand {
     protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr hwnd = target is null ? IntPtr.Zero : new IntPtr(target.Handle);
 
-        // Endpoint misses are element lookups, so they carry the same element-not-found / no-target
-        // taxonomy as click/invoke (#206); the recovery (wait-for/re-find the element) is identical.
-        if (!TryResolvePoint(hwnd, FromBy, FromValue, FromX, FromY, out (int X, int Y) from, out string? fromError)) {
-            return CommandResult.Fail(Cmd, $"Drag start: {fromError}", "element-not-found", "no-target");
+        // Endpoint misses are element lookups, so they carry the same taxonomy as click/invoke
+        // (#206, #261: no-target, ambiguous-selector, stale-element, elevation); the recoveries match.
+        if (!TryResolvePoint(hwnd, FromBy, FromValue, FromX, FromY, "Drag start", Cmd, out (int X, int Y) from, out CommandResult? fromFailure)) {
+            return fromFailure!;
         }
-        if (!TryResolvePoint(hwnd, ToBy, ToValue, ToX, ToY, out (int X, int Y) to, out string? toError)) {
-            return CommandResult.Fail(Cmd, $"Drag end: {toError}", "element-not-found", "no-target");
+        if (!TryResolvePoint(hwnd, ToBy, ToValue, ToX, ToY, "Drag end", Cmd, out (int X, int Y) to, out CommandResult? toFailure)) {
+            return toFailure!;
         }
 
         List<(int X, int Y)> waypoints = [from];
@@ -79,26 +79,32 @@ public class DragCommand : WindowTargetingAgentCommand {
     /// <summary>
     /// Resolves one drag endpoint to an absolute screen pixel: an element (by/value, centre of its
     /// bounds) when <paramref name="value"/> is set, else the literal (<paramref name="x"/>,
-    /// <paramref name="y"/>). Returns false with <paramref name="error"/> when an element endpoint has
-    /// no window or the element can't be found.
+    /// <paramref name="y"/>). Returns false with a structured <paramref name="failure"/> when an
+    /// element endpoint has no window or can't be resolved (not found, ambiguous, stale window,
+    /// elevated target; #261); <paramref name="endpoint"/> names which end failed in the detail.
     /// </summary>
-    private static bool TryResolvePoint(IntPtr hwnd, string by, string value, int x, int y, out (int X, int Y) point, out string? error) {
-        error = null;
+    private static bool TryResolvePoint(IntPtr hwnd, string by, string value, int x, int y, string endpoint, string cmd, out (int X, int Y) point, out CommandResult? failure) {
+        failure = null;
         if (string.IsNullOrEmpty(value)) {
             point = (x, y);
             return true;
         }
         if (hwnd == IntPtr.Zero) {
             point = default;
-            error = "element endpoint requires a target window";
+            failure = CommandResult.Fail(cmd, $"{endpoint}: element endpoint requires a target window", "element-not-found", "no-target");
             return false;
         }
-        UiaElementInfo? el = UiaService.Find(hwnd, string.IsNullOrEmpty(by) ? "name" : by, value, FindTimeoutMs);
-        if (el is null) {
+        string effectiveBy = string.IsNullOrEmpty(by) ? "name" : by;
+        UiaFindOutcome outcome = UiaService.Find(hwnd, effectiveBy, value, FindTimeoutMs);
+        failure = UiaFindFailureFor(cmd, effectiveBy, value, outcome);
+        if (failure is null && outcome.Element is null) {
+            failure = CommandResult.Fail(cmd, $"{endpoint}: element not found ({effectiveBy}='{value}')", "element-not-found", "no-target");
+        }
+        if (failure is not null) {
             point = default;
-            error = $"element not found ({(string.IsNullOrEmpty(by) ? "name" : by)}='{value}')";
             return false;
         }
+        UiaElementInfo el = outcome.Element!;
         point = (el.X + (el.Width / 2), el.Y + (el.Height / 2));
         return true;
     }

--- a/src/Commands/FindCommand.cs
+++ b/src/Commands/FindCommand.cs
@@ -9,8 +9,10 @@ namespace MCEControl;
 /// <summary>
 /// Agent observation command handling both <c>find</c> (one-shot) and <c>wait-for</c> (polls until a
 /// timeout). Resolves a target window, then locates a single UIA element by name/automationid/
-/// classname. Always replies success with a <c>found</c> flag (a miss is not an error). Gated by
-/// <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
+/// classname. A clean miss replies success with <c>found:false</c> (a miss is not an error;
+/// <see cref="AgentToolResult"/> reclassifies a <c>wait-for</c> miss as <c>timeout</c>); an ambiguous
+/// selector or a classified UIA fault (stale window, elevated target, #261) is a structured failure.
+/// Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
 /// <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
 public class FindCommand : WindowTargetingAgentCommand {
@@ -34,11 +36,14 @@ public class FindCommand : WindowTargetingAgentCommand {
 
     protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr h = new IntPtr(target!.Handle);
-        UiaElementInfo? info = UiaService.Find(h, By, Value, EffectiveTimeout);
-        bool found = info is not null;
+        UiaFindOutcome outcome = UiaService.Find(h, By, Value, EffectiveTimeout);
+        if (UiaFindFailureFor(Cmd, By, Value, outcome) is { } failure) {
+            return failure;
+        }
+        bool found = outcome.Element is not null;
         JsonObject data = new() {
             ["found"] = found,
-            ["element"] = info?.ToJsonObject(),
+            ["element"] = outcome.Element?.ToJsonObject(),
             // Echo the resolved window so the session can record it as the active target (a find/wait-for
             // that establishes the current control feeds error.lastObservation for a later failing action).
             ["window"] = target.ToJsonObject(),

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -29,7 +29,7 @@ public class InvokeCommand : WindowTargetingAgentCommand {
 
     protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr h = new IntPtr(target!.Handle);
-        UiaInvokeResult outcome = UiaService.Invoke(h, By, Value, Action, Text);
+        UiaInvokeResult outcome = UiaService.Invoke(h, By, Value, Action, Text, out int matchCount);
         if (outcome == UiaInvokeResult.Ok) {
             JsonObject data = new() {
                 ["invoked"] = true,
@@ -39,16 +39,18 @@ public class InvokeCommand : WindowTargetingAgentCommand {
             };
             return CommandResult.Ok(Cmd, data);
         }
-        return FailureFor(outcome);
+        return FailureFor(outcome, matchCount);
     }
 
     /// <summary>
-    /// Maps a failed <see cref="UiaInvokeResult"/> onto a distinct error code/category (#206). The
-    /// distinctions matter for recovery: <c>no-target</c> means wait/re-find; <c>invalid-argument</c>
-    /// means fix the call (re-finding a pattern-less element loops forever); <c>internal</c> means
-    /// report it. Internal so tests can pin the mapping without a live UIA tree.
+    /// Maps a failed <see cref="UiaInvokeResult"/> onto a distinct error code/category (#206, #261).
+    /// The distinctions matter for recovery: <c>no-target</c> means wait/re-find; <c>invalid-argument</c>
+    /// means fix the call (re-finding a pattern-less element loops forever); <c>ambiguous-selector</c>
+    /// means narrow the selector; <c>stale-element</c> means re-observe for a fresh target;
+    /// <c>elevation</c> and <c>internal</c> mean report it. Internal so tests can pin the mapping
+    /// without a live UIA tree.
     /// </summary>
-    internal CommandResult FailureFor(UiaInvokeResult outcome) => outcome switch {
+    internal CommandResult FailureFor(UiaInvokeResult outcome, int matchCount = 0) => outcome switch {
         UiaInvokeResult.ElementNotFound => CommandResult.Fail(Cmd,
             $"Element not found ({By}='{Value}') in the target window. invoke does not wait; find/wait-for the element first.",
             "element-not-found", "no-target"),
@@ -59,6 +61,18 @@ public class InvokeCommand : WindowTargetingAgentCommand {
         UiaInvokeResult.ActionUnknown => CommandResult.Fail(Cmd,
             $"Unknown action '{Action}'. Use invoke, toggle, setvalue, setfocus, expand, collapse, or select.",
             "action-unknown", "invalid-argument"),
+        UiaInvokeResult.ElementAmbiguous => CommandResult.Fail(Cmd,
+            $"The selector ({By}='{Value}') matched {matchCount} elements; refusing to guess which to act on. " +
+            "Narrow it: prefer automationId, or add className or a more specific name.",
+            $"selector-matched-{matchCount}", "ambiguous-selector"),
+        UiaInvokeResult.ElementStale => CommandResult.Fail(Cmd,
+            $"The element ({By}='{Value}') or its window went away mid-call (closed or re-rendered). " +
+            "Re-query/find for a fresh target, then retry.",
+            "element-stale", "stale-element"),
+        UiaInvokeResult.TargetElevated => CommandResult.Fail(Cmd,
+            "UI Automation was denied access to the target; it runs at a higher integrity level (UAC) than MCEC " +
+            "and cannot be driven. Surface this to the operator; do not retry.",
+            "target-elevated", "elevation"),
         _ => CommandResult.Fail(Cmd,
             "Invoke faulted: UI Automation threw while attaching to or driving the target (it may have closed mid-call). Re-observe the window.",
             "invoke-faulted", "internal"),

--- a/src/Commands/QueryCommand.cs
+++ b/src/Commands/QueryCommand.cs
@@ -28,6 +28,12 @@ public class QueryCommand : WindowTargetingAgentCommand {
     protected override CommandResult ExecuteCore(WindowInfo? target) {
         IntPtr h = new IntPtr(target!.Handle);
         UiaTreeResult tree = UiaService.DumpTree(h, MaxDepth, MaxNodes);
+        // An attach-level fault is a classified failure (#261: window-closed/stale-element,
+        // target-elevated/elevation, uia-faulted/internal), not an ok result with a null tree an
+        // agent would read as a healthy-but-empty window.
+        if (UiaFailureFor(Cmd, tree.Failure) is { } failure) {
+            return failure;
+        }
         JsonObject data = new() {
             ["window"] = target.ToJsonObject(),
             ["nodeCount"] = tree.NodeCount,

--- a/src/Commands/WindowTargetingAgentCommand.cs
+++ b/src/Commands/WindowTargetingAgentCommand.cs
@@ -78,6 +78,43 @@ public abstract class WindowTargetingAgentCommand : AgentCommand {
     /// </summary>
     protected abstract CommandResult ExecuteCore(WindowInfo? target);
 
+    /// <summary>
+    /// Maps a non-miss <see cref="UiaFindOutcome"/> failure onto the ONE structured shape every
+    /// element-resolving command shares (#261): ambiguous selector, then the classified UIA faults
+    /// (<see cref="UiaFailureFor"/>). Returns null when the lookup did not fail this way (found, or a
+    /// clean miss); a miss stays per-command because the commands disagree about it (<c>find</c>
+    /// reports <c>found:false</c> success, <c>click</c>/<c>drag</c>/<c>invoke</c> fail with
+    /// <c>no-target</c>).
+    /// </summary>
+    protected static CommandResult? UiaFindFailureFor(string cmd, string by, string value, UiaFindOutcome outcome) =>
+        outcome.Ambiguous
+            ? CommandResult.Fail(cmd,
+                $"The selector ({by}='{value}') matched {outcome.MatchCount} elements; refusing to guess which one. " +
+                "Narrow it: prefer automationId, or add className or a more specific name.",
+                $"selector-matched-{outcome.MatchCount}", "ambiguous-selector")
+            : UiaFailureFor(cmd, outcome.Failure);
+
+    /// <summary>
+    /// Maps a classified UIA fault (#261) onto the shared structured failure: window gone maps to
+    /// <c>window-closed</c>/<c>stale-element</c>, access denied to <c>target-elevated</c>/<c>elevation</c>
+    /// (for a valid window, UIA's E_ACCESSDENIED means UIPI blocked a lower-integrity client), and
+    /// anything else to <c>uia-faulted</c>/<c>internal</c>. Null when there was no fault.
+    /// </summary>
+    protected static CommandResult? UiaFailureFor(string cmd, UiaFailureKind failure) => failure switch {
+        UiaFailureKind.WindowGone => CommandResult.Fail(cmd,
+            "The target window or element went away mid-call (closed or re-rendered). " +
+            "Re-query for a fresh window handle, then retry.",
+            "window-closed", "stale-element"),
+        UiaFailureKind.AccessDenied => CommandResult.Fail(cmd,
+            "UI Automation was denied access to the target; it runs at a higher integrity level (UAC) than MCEC " +
+            "and cannot be observed or driven. Surface this to the operator; do not retry.",
+            "target-elevated", "elevation"),
+        UiaFailureKind.Faulted => CommandResult.Fail(cmd,
+            "UI Automation faulted while attaching to or reading the target. Re-observe the window.",
+            "uia-faulted", "internal"),
+        _ => null,
+    };
+
     // No Clone override: the shared selectors are value/string-typed, so the base
     // MemberwiseClone-based Command.Clone (#207) copies them by construction.
 }

--- a/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
+++ b/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
@@ -55,14 +55,69 @@ public class UiaServiceTests {
 
     [Fact]
     public void DumpTree_ZeroHandle_ReturnsEmptyUntruncatedResult() {
-        // The guard path must return a well-formed result (null root, no nodes, not truncated) rather
-        // than null, so query can always read nodeCount/truncated.
+        // The guard path must return a well-formed result (null root, no nodes, not truncated, no
+        // classified failure) rather than null, so query can always read nodeCount/truncated.
         UiaTreeResult result = UiaService.DumpTree(IntPtr.Zero, maxDepth: 6, maxNodes: 1000);
 
         Assert.NotNull(result);
         Assert.Null(result.Root);
         Assert.Equal(0, result.NodeCount);
         Assert.False(result.Truncated);
+        Assert.Equal(UiaFailureKind.None, result.Failure);
+    }
+
+    [Fact]
+    public void Find_ZeroHandle_ReturnsCleanMiss() {
+        // #261: the guard path is a clean miss (no match, no fault), never a classified failure.
+        UiaFindOutcome outcome = UiaService.Find(IntPtr.Zero, "name", "OK", timeoutMs: 0);
+
+        Assert.Null(outcome.Element);
+        Assert.Equal(0, outcome.MatchCount);
+        Assert.False(outcome.Ambiguous);
+        Assert.Equal(UiaFailureKind.None, outcome.Failure);
+    }
+
+    // --- #261: UIA exception classification onto the closed error taxonomy.
+
+    [Fact]
+    public void ClassifyUiaFailure_ElementNotAvailableHResult_IsWindowGone() {
+        // UIA_E_ELEMENTNOTAVAILABLE: the window/element backing a UIA object is gone -> stale-element.
+        var e = new System.Runtime.InteropServices.COMException("gone", unchecked((int)0x80040201));
+
+        Assert.Equal(UiaFailureKind.WindowGone, UiaService.ClassifyUiaFailure(e));
+    }
+
+    [Fact]
+    public void ClassifyUiaFailure_FlaUIElementNotAvailable_IsWindowGone() {
+        // FlaUI wraps the COM error in a typed exception on some paths; both forms classify the same.
+        var e = new FlaUI.Core.Exceptions.ElementNotAvailableException("gone");
+
+        Assert.Equal(UiaFailureKind.WindowGone, UiaService.ClassifyUiaFailure(e));
+    }
+
+    [Fact]
+    public void ClassifyUiaFailure_AccessDenied_IsElevationCase() {
+        // E_ACCESSDENIED on a valid window is the UIPI/elevation case, via COMException or the
+        // UnauthorizedAccessException COM interop sometimes surfaces instead.
+        var com = new System.Runtime.InteropServices.COMException("denied", unchecked((int)0x80070005));
+        var uae = new UnauthorizedAccessException("denied");
+
+        Assert.Equal(UiaFailureKind.AccessDenied, UiaService.ClassifyUiaFailure(com));
+        Assert.Equal(UiaFailureKind.AccessDenied, UiaService.ClassifyUiaFailure(uae));
+    }
+
+    [Fact]
+    public void ClassifyUiaFailure_WalksInnerExceptions() {
+        // A classified COM error wrapped by an outer exception must still classify.
+        var inner = new System.Runtime.InteropServices.COMException("gone", unchecked((int)0x80040201));
+        var outer = new InvalidOperationException("wrapper", inner);
+
+        Assert.Equal(UiaFailureKind.WindowGone, UiaService.ClassifyUiaFailure(outer));
+    }
+
+    [Fact]
+    public void ClassifyUiaFailure_UnrecognizedException_IsFaulted() {
+        Assert.Equal(UiaFailureKind.Faulted, UiaService.ClassifyUiaFailure(new InvalidOperationException("boom")));
     }
 
     // --- #215: all UIA work funnels through ONE dedicated MTA worker with one cached UIA3Automation.

--- a/tests/MCEControl.xUnit/Commands/DragCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/DragCommandTests.cs
@@ -66,4 +66,41 @@ public class DragCommandTests {
             AgentRuntime.Settings = null;
         }
     }
+
+    // #262 review (Copilot): a two-endpoint drag must name WHICH end failed in the detail for EVERY
+    // failure category, not only the not-found path. Before the fix, ambiguous/stale/elevation
+    // failures came straight from the shared UiaFindFailureFor mapper with no "Drag start"/"Drag end"
+    // prefix, contradicting TryResolvePoint's doc comment. LabelEndpoint is the shared prefixing step.
+
+    [Theory]
+    [InlineData("Drag start")]
+    [InlineData("Drag end")]
+    public void LabelEndpoint_PrefixesDetail_WhilePreservingCodeAndCategory(string endpoint) {
+        CommandResult raw = CommandResult.Fail(
+            "drag", "The selector (name='OK') matched 3 elements; refusing to guess which one.",
+            "selector-matched-3", "ambiguous-selector");
+
+        CommandResult labeled = DragCommand.LabelEndpoint(endpoint, raw);
+
+        Assert.False(labeled.Success);
+        Assert.StartsWith(endpoint + ":", labeled.Error);
+        Assert.Contains("matched 3 elements", labeled.Error);      // original detail retained
+        Assert.Equal("selector-matched-3", labeled.ErrorCode);     // code/category untouched
+        Assert.Equal("ambiguous-selector", labeled.ErrorCategory);
+    }
+
+    [Theory]
+    // Every classified endpoint failure keeps its taxonomy AND gains the endpoint label.
+    [InlineData("window-closed", "stale-element")]
+    [InlineData("target-elevated", "elevation")]
+    [InlineData("element-not-found", "no-target")]
+    public void LabelEndpoint_AppliesToEveryCategory(string code, string category) {
+        CommandResult raw = CommandResult.Fail("drag", "detail text", code, category);
+
+        CommandResult labeled = DragCommand.LabelEndpoint("Drag end", raw);
+
+        Assert.StartsWith("Drag end:", labeled.Error);
+        Assert.Equal(code, labeled.ErrorCode);
+        Assert.Equal(category, labeled.ErrorCategory);
+    }
 }

--- a/tests/MCEControl.xUnit/Commands/InvokeCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/InvokeCommandTests.cs
@@ -69,12 +69,15 @@ public class InvokeCommandTests {
     }
 
     [Theory]
-    // #206: each UiaInvokeResult failure maps to a DISTINCT code/category so agent recovery differs:
-    // no-target => wait/re-find; invalid-argument => fix the call (re-finding cannot help); internal
-    // => report. The old bare bool collapsed all four into one prose string.
+    // #206/#261: each UiaInvokeResult failure maps to a DISTINCT code/category so agent recovery
+    // differs: no-target => wait/re-find; invalid-argument => fix the call (re-finding cannot help);
+    // ambiguous-selector => narrow the selector; stale-element => re-observe; elevation/internal =>
+    // report. The old bare bool collapsed everything into one prose string.
     [InlineData(UiaInvokeResult.ElementNotFound, "element-not-found", "no-target")]
     [InlineData(UiaInvokeResult.PatternUnsupported, "pattern-unsupported", "invalid-argument")]
     [InlineData(UiaInvokeResult.ActionUnknown, "action-unknown", "invalid-argument")]
+    [InlineData(UiaInvokeResult.ElementStale, "element-stale", "stale-element")]
+    [InlineData(UiaInvokeResult.TargetElevated, "target-elevated", "elevation")]
     [InlineData(UiaInvokeResult.Faulted, "invoke-faulted", "internal")]
     public void FailureFor_MapsEachOutcomeToADistinctCodeAndCategory(UiaInvokeResult outcome, string code, string category) {
         InvokeCommand cmd = new() { Cmd = "invoke", By = "name", Value = "OK", Action = "toggle" };
@@ -85,6 +88,20 @@ public class InvokeCommandTests {
         Assert.Equal(code, result.ErrorCode);
         Assert.Equal(category, result.ErrorCategory);
         Assert.False(string.IsNullOrEmpty(result.Error));
+    }
+
+    [Fact]
+    public void FailureFor_AmbiguousSelector_CarriesTheMatchCountInTheCode() {
+        // #261: the contract's ambiguous-selector code is selector-matched-N with the literal count,
+        // so the agent (and the audit log) can see how bad the collision is.
+        InvokeCommand cmd = new() { Cmd = "invoke", By = "name", Value = "OK", Action = "invoke" };
+
+        CommandResult result = cmd.FailureFor(UiaInvokeResult.ElementAmbiguous, matchCount: 3);
+
+        Assert.False(result.Success);
+        Assert.Equal("selector-matched-3", result.ErrorCode);
+        Assert.Equal("ambiguous-selector", result.ErrorCategory);
+        Assert.Contains("3", result.Error);
     }
 
     [Fact]

--- a/tests/MCEControl.xUnit/Commands/UiaFailureProbeCommand.cs
+++ b/tests/MCEControl.xUnit/Commands/UiaFailureProbeCommand.cs
@@ -1,0 +1,20 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Concrete <see cref="WindowTargetingAgentCommand"/> exposing the protected static #261 UIA-failure
+/// mappers so <see cref="WindowTargetingAgentCommandTests"/> can pin them without a live UIA tree.
+/// </summary>
+public sealed class UiaFailureProbeCommand : WindowTargetingAgentCommand {
+    protected override string AuditDetails() => "probe";
+    protected override CommandResult ExecuteCore(WindowInfo? target) => CommandResult.Ok(Cmd, null);
+
+    public static CommandResult? FindFailure(string cmd, string by, string value, UiaFindOutcome outcome) =>
+        UiaFindFailureFor(cmd, by, value, outcome);
+
+    public static CommandResult? Failure(string cmd, UiaFailureKind kind) => UiaFailureFor(cmd, kind);
+}

--- a/tests/MCEControl.xUnit/Commands/WindowTargetingAgentCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/WindowTargetingAgentCommandTests.cs
@@ -1,0 +1,56 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>
+/// Pins the shared #261 UIA-failure mapping every element-resolving command routes through:
+/// classified UIA faults and ambiguous selectors map onto the closed taxonomy with stable codes,
+/// and healthy outcomes map to null (no failure).
+/// </summary>
+public class WindowTargetingAgentCommandTests {
+    [Theory]
+    [InlineData(UiaFailureKind.WindowGone, "window-closed", "stale-element")]
+    [InlineData(UiaFailureKind.AccessDenied, "target-elevated", "elevation")]
+    [InlineData(UiaFailureKind.Faulted, "uia-faulted", "internal")]
+    public void UiaFailureFor_MapsEachKindToADistinctCodeAndCategory(UiaFailureKind kind, string code, string category) {
+        CommandResult? result = UiaFailureProbeCommand.Failure("query", kind);
+
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal(code, result.ErrorCode);
+        Assert.Equal(category, result.ErrorCategory);
+        Assert.False(string.IsNullOrEmpty(result.Error));
+    }
+
+    [Fact]
+    public void UiaFailureFor_None_IsNoFailure() {
+        Assert.Null(UiaFailureProbeCommand.Failure("query", UiaFailureKind.None));
+    }
+
+    [Fact]
+    public void UiaFindFailureFor_AmbiguousSelector_CarriesTheMatchCountInTheCode() {
+        UiaFindOutcome outcome = new(null, MatchCount: 4, UiaFailureKind.None);
+
+        CommandResult? result = UiaFailureProbeCommand.FindFailure("find", "name", "OK", outcome);
+
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal("selector-matched-4", result.ErrorCode);
+        Assert.Equal("ambiguous-selector", result.ErrorCategory);
+        Assert.Contains("OK", result.Error);
+    }
+
+    [Fact]
+    public void UiaFindFailureFor_FoundOrCleanMiss_IsNoFailure() {
+        // A found element and a clean miss are NOT failures here; a miss stays per-command (find
+        // reports found:false success, click/drag/invoke fail with no-target).
+        UiaFindOutcome found = new(new UiaElementInfo(), MatchCount: 1, UiaFailureKind.None);
+
+        Assert.Null(UiaFailureProbeCommand.FindFailure("find", "name", "OK", found));
+        Assert.Null(UiaFailureProbeCommand.FindFailure("find", "name", "OK", UiaFindOutcome.NotFound));
+    }
+}

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -389,9 +389,18 @@ public class AgentServerTests {
         // element lookup could take longer than the grace, an ordinary lookup miss (misspelled name, menu
         // not expanded) would be misreported as a pending modal success. The find must resolve within the
         // grace, so a worker still running afterward can only be a genuinely blocking action.
+        //
+        // #262 review (Codex P2): the invoke lookup enumerates matches (FindAllDescendants) to detect an
+        // ambiguous selector. The poll loop never STARTS an attempt past InvokeFindTimeoutMs, so the
+        // worst-case overshoot is a single in-flight scan; the grace must clear the find timeout by more
+        // than that scan can take, or a slow scan on a large tree gets misreported as a pending modal.
+        // Pin a minimum headroom so the two constants can never drift close together.
+        const int MinScanHeadroomMs = 200;
         Assert.True(
-            UiaService.InvokeFindTimeoutMs < AgentServer.InvokeModalGraceMs,
-            $"invoke find timeout ({UiaService.InvokeFindTimeoutMs}ms) must be < modal grace ({AgentServer.InvokeModalGraceMs}ms)");
+            AgentServer.InvokeModalGraceMs - UiaService.InvokeFindTimeoutMs >= MinScanHeadroomMs,
+            $"modal grace ({AgentServer.InvokeModalGraceMs}ms) must exceed the invoke find timeout " +
+            $"({UiaService.InvokeFindTimeoutMs}ms) by >= {MinScanHeadroomMs}ms so one in-flight " +
+            "FindAll scan cannot outlast the grace and be misreported as a pending modal (#262).");
     }
 
     // --- #74: MCP tools honor the per-command Enabled gate in mcec.commands (a SECOND gate, independent


### PR DESCRIPTION
Fixes #261.

## Direction

The issue offered two directions: implement detection, or narrow the guidance. This PR takes a hybrid, weighted by whether a real failure site exists today:

**Implemented (3 of 5):**

- **`ambiguous-selector`** (the priority case): element lookups in `find`/`wait-for`/`invoke`/`click`/`drag` now enumerate all matches instead of taking the first, and refuse to guess when a selector matches more than one element. Silently driving "the first of N matches" is the worst agent failure mode; it *succeeds* on the wrong control. Fails fast (waiting cannot disambiguate) with `selector-matched-N` carrying the literal count.
- **`stale-element`**: `UIA_E_ELEMENTNOTAVAILABLE` (raw COM or FlaUI's typed wrapper, walked through inner exceptions) now classifies as `window-closed`/`element-stale` instead of falling through to `no-target` or `internal`. An element torn down between lookup and dispatch is the canonical case.
- **`elevation`**: `E_ACCESSDENIED` from a UIA attach/read/dispatch (the UIPI symptom for an elevated target) classifies as `target-elevated`. `query` on an elevated window now fails structurally instead of returning a healthy-looking null tree, which converts the documented architectural limitation into the classified error the taxonomy always promised.

**Narrowed (2 of 5):**

- **`focus`/`foreground`**: no code path can currently attempt-and-fail these distinctly (`setfocus` dispatch is fire-and-forget; no agent command checks a `SetForegroundWindow` result). Building focus verification would be flaky by design, so these are marked RESERVED in the enum doc comments and the contract doc, and `AgentInstructions.md` now tells agents they are never produced today (treat like `internal` if ever seen). They stay in the closed wire set for compatibility and future detection.

## Mechanics

- `UiaService.Find` returns a `UiaFindOutcome` (element, match count, classified failure) instead of a bare nullable; the old shape conflated four distinct outcomes into null, which is the root cause the issue identified.
- Classification is centralized in `UiaService.ClassifyUiaFailure` (HRESULT-based, inner-exception walking) and mapped once in `WindowTargetingAgentCommand`, so all five consumers emit one structured shape.
- `UiaInvokeResult` gains `ElementAmbiguous`/`ElementStale`/`TargetElevated`; `InvokeCommand.FailureFor` maps each to its distinct code/category.
- In-product guidance (`AgentInstructions.md`), the contract doc, and `docs/agent-server.md` updated to match reality.

## Behavior change to be aware of

A selector that previously "worked" by silently matching the first of several elements now fails with `ambiguous-selector`. That is deliberate contract enforcement, and the connect-time guidance has always told agents how to recover (narrow the selector). Lookup cost per poll goes from FindFirst to FindAll, bounded by the target window's own tree.

## Tests

875 passed, 0 failed. New coverage: exception classification (HRESULT, typed, wrapped, unrecognized), the shared failure mapping (codes/categories per `UiaFailureKind`), ambiguous match-count in the error code, and the new `FailureFor` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QhTmY6fdbarGeef3iyCPm