### PR TITLE
feat: session lifecycle tools + per-call sessionId routing (#86 Phase 3)

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -166,7 +166,8 @@ success it reads `result`, on failure it reads `error`:
 
 A result is **either** a success (`ok: true`, `result` present, no `error`) **or** a failure
 (`ok: false`, `error` present, no `result`); never both. `warnings` (non-fatal conditions)
-may appear on either. `sessionId` is present when the call ran inside a mounted session.
+may appear on either. `sessionId` names the [session](#agent-sessions) the call ran in (the
+implicit default session unless the call routed itself with a `sessionId` argument).
 Over MCP, the transport's `isError` flag mirrors the envelope (`isError = !ok`).
 
 On failure the `error` object carries a stable, fine-grained `code`, a coarse `category` from
@@ -201,6 +202,44 @@ failing call's own partial payload, e.g. a blank capture's suspect PNG):
 > `emergency-stopped` (the operator engaged the [emergency stop](safety-emergency-stop-and-provisioning.md)),
 > `provisioning-not-authorized` (`AllowSessionProvisioning` is off), and `command-disabled` (the
 > per-command `Enabled` gate).
+
+### Agent sessions
+
+Every result carries a `sessionId`; the **session** it ran in. A session is the server's
+memory of one task: its active target window, last observation, last action, last error, and a
+per-session artifact directory (where a `capture`'s bytes are spilled so a later
+`error.lastObservation` never re-embeds megabytes of screenshot). This lets a multi-step task be
+one durable, debuggable record instead of a string of stateless calls.
+
+For a single linear task you never touch sessions: omit `sessionId` and every call shares one
+**implicit default session**, so state simply accumulates (and stdio "just works" with one ambient
+session). To run **independent** tasks that must not share a target or history, use the lifecycle
+tools:
+
+- **`session-start`** creates a fresh session and returns its `sessionId` (plus its initial
+  status). Echo that `sessionId` on later tool calls; each such call runs in that session and is
+  echoed back on the result.
+- **`session-status`** returns a session's remembered state (active target, last
+  observation/action/error, artifact dir, any emergency stop). Pass `sessionId` to inspect a
+  specific session, or omit it for the default.
+- **`session-end`** frees a session's server-side state. It is idempotent (ending an unknown or
+  already-ended id reports `ended: false` rather than erroring). Afterward a tool call that still
+  echoes that id is refused with `error.code: unknown-session` (category `invalid-argument`); start
+  a new one or omit `sessionId` to fall back to the default.
+
+> **Identity is carried in-band, not bound to the connection.** Both stdio and the HTTP floor
+> funnel into one stateless dispatch; the store is keyed by id, not by socket, so the same
+> `sessionId` addresses the same session across either transport. The lifecycle tools are part of
+> the agent surface and honor the same `AgentCommandsEnabled` opt-in and emergency-stop latch as
+> every other tool.
+>
+> **Not the same as `provision-session`.** These sessions are in-process runtime state. A
+> [provisioned session](safety-emergency-stop-and-provisioning.md) is a whole disposable MCEC
+> *install* on disk (`#138`); a different concept with its own `sessionId`/`token`.
+>
+> **Tool names are hyphenated** (`session-start`, not `session/start`) because MCP/Anthropic tool
+> names must match `^[a-zA-Z0-9_-]{1,64}$`, and to match the existing `wait-for`/`end-session`
+> convention.
 
 ### `capture` result example
 
@@ -495,6 +534,12 @@ When connected, the server advertises these tools:
 | `click`        | The `click` command (atomic click at an element centre or pixel). |
 | `record`       | The `record` command (window/region → animated GIF over time). |
 | `send_command` | Generic raw-command passthrough; send any MCEC command line.  |
+| `session-start`  | Start a new [agent session](#agent-sessions) and return its `sessionId`. |
+| `session-status` | Report a session's state (active target, last observation/action/error, artifact dir). |
+| `session-end`    | End an agent session, freeing its server-side state. |
+
+Every observation/actuation tool and `send_command` also accept an optional `sessionId`
+argument (from `session-start`) to [route the call into that session](#agent-sessions).
 
 ---
 

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -76,6 +76,20 @@ descriptor, dimensions, blankCheck verdict, and byte count, with `kind:"capture-
 `artifact` path where the PNG was saved on the host; it never carries the image bytes inline, so
 re-`capture` if you need to SEE the prior state rather than reason about its metadata.
 
+SESSIONS: every result carries a `sessionId`; the session it ran in. A session is the runtime's memory of
+one task: its active target window, last observation, last action, last error, and a per-session artifact
+directory (where a `capture`'s bytes are spilled). You do NOT need to manage sessions for a single linear
+task: omit `sessionId` and every call shares one implicit default session, so state just accumulates. To
+run INDEPENDENT tasks that must not share state, call `session-start` to get a fresh `sessionId`, then pass
+that `sessionId` on each call to route it into that session; two sessions keep separate targets and
+histories. `session-status` (optional `sessionId`, else the default) returns a session's remembered state
+for debugging or replay; `session-end` (required `sessionId`) frees a session's state. After you end a
+session, a call that still echoes its id is refused with `error.code:unknown-session` (category
+`invalid-argument`); start a new one or omit `sessionId` to fall back to the default. An id you never
+started is refused the same way. (Note the hyphen: the tools are `session-start`/`session-status`/
+`session-end`.) This is separate from `provision-session`, which hands you a whole disposable MCEC INSTALL
+(see PROVISION), not an in-process session.
+
 COMPOSE: many tasks have no single dedicated tool; build them by combining primitives creatively. Launch
 an app with the dedicated `launch` tool (`path` required, optional `arguments`/`workingDirectory`; returns the pid and the app's window handle once it appears). Fallback if `launch` is unavailable: `send_command winr` then `chars:<path>` then `enter` (the new window is foreground: `query {foreground}` for its handle). Use `invoke` with `action: "select"` for tabs/list items/radios. 
 Drag/resize/move with the `drag` tool (`from`/`to`, optional `path` waypoints). Switch a tab/list item by `invoke` `select` (preferred) or `click` its centre. Record a window by
@@ -137,7 +151,8 @@ session from any window. If ANY tool returns `error.code:emergency-stopped` (the
 `error.category` stays `internal`), the operator has engaged it and deliberately halted you; STOP
 immediately, tell the user, and do NOT retry; nothing will actuate until they re-arm.
 
-SECURITY: the agent tools (capture/query/displays/find/wait-for/invoke/record/launch/drag/click) only work when the operator has set
+SECURITY: the agent tools (capture/query/displays/find/wait-for/invoke/record/launch/drag/click, and the
+session-start/session-status/session-end lifecycle) only work when the operator has set
 AgentCommandsEnabled=true; otherwise they return an error; surface that to the user rather than retrying.
 `send_command` is also gated by AgentCommandsEnabled when you are connected over the HTTP transport (it is
 refused with `error.code:agent-commands-disabled` if the agent surface is not opted in); over the local

--- a/src/Agent/AgentRuntime.cs
+++ b/src/Agent/AgentRuntime.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace MCEControl;
@@ -216,13 +217,17 @@ public static class AgentRuntime {
     /// <paramref name="session"/> null when a non-empty id names no live session, so the caller can refuse
     /// the call rather than silently forking a new session's state under a stale id.
     /// </summary>
-    public static bool TryResolveSession(string? sessionId, out AgentSession session) {
+    public static bool TryResolveSession(string? sessionId, [MaybeNullWhen(false)] out AgentSession session) {
         lock (_sessionGate) {
-            if (string.IsNullOrWhiteSpace(sessionId)) {
+            // Only an absent/empty id means "default"; a whitespace-only id is non-empty content, so it is
+            // NOT treated as missing (it will simply match no live session and be refused). Otherwise a
+            // stray " " would silently route into the default session and fork the state an explicit
+            // session was meant to isolate.
+            if (string.IsNullOrEmpty(sessionId)) {
                 session = _defaultSession ??= CreateAndRegister();
                 return true;
             }
-            return _sessions.TryGetValue(sessionId.Trim(), out session!);
+            return _sessions.TryGetValue(sessionId.Trim(), out session);
         }
     }
 

--- a/src/Agent/AgentRuntime.cs
+++ b/src/Agent/AgentRuntime.cs
@@ -2,6 +2,7 @@
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace MCEControl;
@@ -144,13 +145,29 @@ public static class AgentRuntime {
     // -------------------------------------------------------------------------------------------
 
     private static readonly Lock _sessionGate = new();
-    private static AgentSession? _session;
+
+    /// <summary>
+    /// Live sessions keyed by <see cref="AgentSession.SessionId"/> (Phase 3). Both the implicit default
+    /// session and every explicitly <c>session-start</c>ed one are registered here, so a call can be
+    /// routed to any of them by echoing its id. Sessions are removed by <c>session-end</c> (or a test
+    /// reset); there is no time-based reaping in-process (a session is cheap; its only heap cost is the
+    /// small last-target/observation/action/error state, and capture bytes already spill to disk).
+    /// </summary>
+    private static readonly Dictionary<string, AgentSession> _sessions = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The implicit default session: the one a call with no <c>sessionId</c> runs in, so the common
+    /// single-agent / stdio case "just works" with one ambient session (Phase 3, decision 1). Created on
+    /// first use and also registered in <see cref="_sessions"/> under its id, so an agent that reads the
+    /// default's id from <c>session-status</c> can then address it explicitly and get the same instance.
+    /// </summary>
+    private static AgentSession? _defaultSession;
     private static string? _artifactRoot;
 
     /// <summary>
     /// Root directory under which each session reserves its artifact subdirectory. Defaults to a
     /// <c>sessions</c> folder beside MCEC's settings/logs (or a temp fallback if that can't be resolved);
-    /// overridable by the host or tests. Setting it clears the ambient session so the next one uses it.
+    /// overridable by the host or tests. Setting it clears every live session so the next ones use it.
     /// </summary>
     public static string ArtifactRoot {
         get {
@@ -161,30 +178,83 @@ public static class AgentRuntime {
         set {
             lock (_sessionGate) {
                 _artifactRoot = value;
-                _session = null;
+                _sessions.Clear();
+                _defaultSession = null;
             }
         }
     }
 
     /// <summary>
-    /// The ambient agent session, created on first use. Phase 2 (#86) runs a single runner-owned session;
-    /// explicit <c>session/start|status|end</c> lifecycle and per-call routing arrive in Phase 3. The
-    /// session carries <c>sessionId</c> onto every result and the last target/observation/action/error
-    /// for debugging and replay.
+    /// The implicit default agent session (#86), created and registered on first use. A tool call that
+    /// carries no <c>sessionId</c> runs here; explicit <c>session-start</c> creates additional addressable
+    /// sessions alongside it (see <see cref="StartSession"/>/<see cref="TryResolveSession"/>). The session
+    /// carries <c>sessionId</c> onto every result and the last target/observation/action/error for
+    /// debugging and replay.
     /// </summary>
     public static AgentSession Session {
         get {
             lock (_sessionGate) {
-                return _session ??= AgentSession.Create(_artifactRoot ??= DefaultArtifactRoot());
+                return _defaultSession ??= CreateAndRegister();
             }
         }
     }
 
-    /// <summary>Drops the ambient session so the next access starts a fresh one (used by tests and a future <c>session/end</c>).</summary>
+    /// <summary>
+    /// Phase 3 (<c>session-start</c>): creates, registers, and returns a fresh addressable session. Unlike
+    /// <see cref="Session"/> it never becomes the default; the agent routes to it by echoing the returned
+    /// <see cref="AgentSession.SessionId"/> as the <c>sessionId</c> argument on later calls.
+    /// </summary>
+    public static AgentSession StartSession() {
+        lock (_sessionGate) {
+            return CreateAndRegister();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the session a call runs in (Phase 3, decision 1): the session named by
+    /// <paramref name="sessionId"/>, or the implicit default when it is null/empty. Returns false with
+    /// <paramref name="session"/> null when a non-empty id names no live session, so the caller can refuse
+    /// the call rather than silently forking a new session's state under a stale id.
+    /// </summary>
+    public static bool TryResolveSession(string? sessionId, out AgentSession session) {
+        lock (_sessionGate) {
+            if (string.IsNullOrWhiteSpace(sessionId)) {
+                session = _defaultSession ??= CreateAndRegister();
+                return true;
+            }
+            return _sessions.TryGetValue(sessionId.Trim(), out session!);
+        }
+    }
+
+    /// <summary>
+    /// Phase 3 (<c>session-end</c>): removes a session by id, returning whether it existed. Ending the
+    /// default session drops the ambient pointer so the next default access starts a fresh one; a
+    /// subsequent call with that (now dead) id resolves to nothing and is refused.
+    /// </summary>
+    public static bool EndSession(string sessionId) {
+        lock (_sessionGate) {
+            string id = sessionId?.Trim() ?? "";
+            bool removed = _sessions.Remove(id);
+            if (_defaultSession?.SessionId == id) {
+                _defaultSession = null;
+            }
+            return removed;
+        }
+    }
+
+    /// <summary>Drops every live session so the next access starts fresh (used by tests; a <c>session-end</c> on a specific id is <see cref="EndSession"/>).</summary>
     public static void ResetSession() {
         lock (_sessionGate) {
-            _session = null;
+            _sessions.Clear();
+            _defaultSession = null;
         }
+    }
+
+    /// <summary>Creates a session against the current artifact root and registers it in <see cref="_sessions"/>. Caller holds <see cref="_sessionGate"/>.</summary>
+    private static AgentSession CreateAndRegister() {
+        AgentSession session = AgentSession.Create(_artifactRoot ??= DefaultArtifactRoot());
+        _sessions[session.SessionId] = session;
+        return session;
     }
 
     private static string DefaultArtifactRoot() {

--- a/src/Agent/AgentSession.cs
+++ b/src/Agent/AgentSession.cs
@@ -13,10 +13,12 @@ namespace MCEControl;
 /// (<see cref="SessionId"/>), a per-session artifact directory, and a memory of the most recent
 /// target/observation/action/error so a multi-step task is one durable, debuggable record.
 ///
-/// <para>Phase 2 (#86) introduces a single <b>ambient</b> session owned by
-/// <see cref="AgentRuntime.Session"/>; explicit <c>session/start|status|end</c> lifecycle tools and
-/// per-call session routing are Phase 3. The state recorded here is what feeds <c>sessionId</c> on
-/// every result, <c>error.lastObservation</c> on failures, and (later) #87's evidence bundle.</para>
+/// <para>Phase 2 (#86) introduced a single <b>ambient</b> session; Phase 3 adds explicit
+/// <c>session-start</c>/<c>session-status</c>/<c>session-end</c> lifecycle tools and per-call routing, so
+/// there can now be several addressable sessions alongside the implicit default (see
+/// <see cref="AgentRuntime.StartSession"/>/<see cref="AgentRuntime.TryResolveSession"/>). The state
+/// recorded here is what feeds <c>sessionId</c> on every result, <c>error.lastObservation</c> on
+/// failures, and (later) #87's evidence bundle.</para>
 ///
 /// All mutators are guarded by an internal lock because an <c>invoke</c> can finish on a background
 /// worker thread after the dispatching call has already returned.
@@ -223,7 +225,7 @@ public sealed class AgentSession {
         return dir;
     }
 
-    /// <summary>A debug/replay snapshot of the session's current state (the basis for <c>session/status</c>, Phase 3).</summary>
+    /// <summary>A debug/replay snapshot of the session's current state (the payload of the <c>session-status</c> tool, #86 Phase 3).</summary>
     public JsonObject ToStatusJson() {
         lock (_gate) {
             JsonObject obj = new() {

--- a/src/Agent/AgentToolResult.cs
+++ b/src/Agent/AgentToolResult.cs
@@ -21,8 +21,9 @@ namespace MCEControl;
 /// <para>Since #206 the envelope is built from the <see cref="CommandResult"/> OBJECT the command
 /// returned (see <see cref="FromCommandResult"/>); no serialize → re-parse round-trip, and no
 /// free-text "categorization": every agent command emits the structured code/category itself
-/// (enforced by <see cref="AgentCommand"/>'s sealed template). <see cref="SessionId"/> stays null
-/// until the session store lands (Phase 2/3).</para>
+/// (enforced by <see cref="AgentCommand"/>'s sealed template). <see cref="SessionId"/> names the
+/// session the call ran in (#86; the implicit default session unless the call routed itself with a
+/// <c>sessionId</c> argument).</para>
 /// </summary>
 public sealed class AgentToolResult {
     private AgentToolResult(bool ok, JsonObject? result, AgentError? error, string? sessionId, IReadOnlyList<AgentWarning> warnings) {

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -332,6 +332,16 @@ public static class ToolCatalog {
     internal static JsonObject PropSchema(string type, string description) =>
         new() { ["type"] = type, ["description"] = description };
 
+    /// <summary>
+    /// The optional per-call session-routing argument (#86 Phase 3). Every observation/actuation tool and
+    /// <c>send_command</c> accepts it: echo the <c>sessionId</c> that <c>session-start</c> returned to run
+    /// the call in that session, or omit it to use the implicit default session. Advertised on those tools'
+    /// schemas (injected in <see cref="JsonRpcDispatcher"/>) so a schema-validating client keeps it. The
+    /// session-lifecycle tools read <c>sessionId</c> as a TARGET, not routing, and carry their own copy.
+    /// </summary>
+    internal static JsonObject SessionArgProp() =>
+        PropSchema("string", "Optional session id (from session-start) to run this call in; omit to use the default session (#86).");
+
     /// <summary>Schema for a drag/click endpoint: either an element ({ by, value }) or a pixel ({ x, y }).</summary>
     private static JsonObject EndpointSchema(string description) => new() {
         ["type"] = "object",

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -45,7 +45,9 @@ public static class AgentServer {
     private static readonly AgentToolExecutor _executor = new(
         () => AgentRuntime.Settings,
         () => AgentRuntime.Invoker,
-        () => AgentRuntime.Session);
+        sessionId => AgentRuntime.TryResolveSession(sessionId, out AgentSession s) ? s : null,
+        () => AgentRuntime.StartSession(),
+        id => AgentRuntime.EndSession(id));
 
     /// <summary>The production protocol layer, serving the embedded <see cref="Instructions"/>.</summary>
     private static readonly JsonRpcDispatcher _dispatcher = new(_executor, () => Instructions);
@@ -104,8 +106,8 @@ public static class AgentServer {
     /// <summary>See <see cref="AgentToolExecutor.BuildCommand"/> (#201/#205). Kept for tests (InternalsVisibleTo).</summary>
     internal static Command? BuildCommand(string name, JsonObject args) => AgentToolExecutor.BuildCommand(name, args);
 
-    /// <summary>See <see cref="AgentToolExecutor.RunAgentCommand"/>. Kept for tests (InternalsVisibleTo).</summary>
-    internal static JsonObject RunAgentCommand(string name, JsonObject args) => _executor.RunAgentCommand(name, args);
+    /// <summary>See <see cref="AgentToolExecutor.RunAgentCommand"/>. Kept for tests (InternalsVisibleTo); runs in the default session.</summary>
+    internal static JsonObject RunAgentCommand(string name, JsonObject args) => _executor.RunAgentCommand(name, args, AgentRuntime.Session);
 
     /// <summary>
     /// Built-in guidance handed to an agent at connect time (the MCP client shows this to the model). It

--- a/src/Services/AgentServer.cs
+++ b/src/Services/AgentServer.cs
@@ -45,7 +45,7 @@ public static class AgentServer {
     private static readonly AgentToolExecutor _executor = new(
         () => AgentRuntime.Settings,
         () => AgentRuntime.Invoker,
-        sessionId => AgentRuntime.TryResolveSession(sessionId, out AgentSession s) ? s : null,
+        sessionId => AgentRuntime.TryResolveSession(sessionId, out AgentSession? s) ? s : null,
         () => AgentRuntime.StartSession(),
         id => AgentRuntime.EndSession(id));
 

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -39,16 +39,38 @@ public sealed class AgentToolExecutor {
 
     private readonly Func<AppSettings?> _settings;
     private readonly Func<CommandInvoker?> _invoker;
-    private readonly Func<AgentSession> _session;
+    private readonly Func<string?, AgentSession?> _resolveSession;
+    private readonly Func<AgentSession> _startSession;
+    private readonly Func<string, bool> _endSession;
 
     /// <param name="settings">Accessor for the live settings (gates + provisioning opt-in).</param>
     /// <param name="invoker">Accessor for the loaded command table/engine.</param>
-    /// <param name="session">Accessor for the ambient agent session (#86).</param>
-    public AgentToolExecutor(Func<AppSettings?> settings, Func<CommandInvoker?> invoker, Func<AgentSession> session) {
+    /// <param name="resolveSession">Routes a call to its session (#86 Phase 3): returns the session named
+    /// by the id, the implicit default when the id is null/empty, or null when a non-empty id names no
+    /// live session.</param>
+    /// <param name="startSession">Creates and registers a fresh addressable session (<c>session-start</c>).</param>
+    /// <param name="endSession">Ends a session by id (<c>session-end</c>); returns whether it existed.</param>
+    public AgentToolExecutor(
+        Func<AppSettings?> settings,
+        Func<CommandInvoker?> invoker,
+        Func<string?, AgentSession?> resolveSession,
+        Func<AgentSession> startSession,
+        Func<string, bool> endSession) {
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         _invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
-        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _resolveSession = resolveSession ?? throw new ArgumentNullException(nameof(resolveSession));
+        _startSession = startSession ?? throw new ArgumentNullException(nameof(startSession));
+        _endSession = endSession ?? throw new ArgumentNullException(nameof(endSession));
     }
+
+    /// <summary>Routes a call to its session; false with <paramref name="session"/> null when a non-empty id names no live session.</summary>
+    private bool TryResolveRoutedSession(string? sessionId, out AgentSession session) {
+        session = _resolveSession(sessionId)!;
+        return session is not null;
+    }
+
+    /// <summary>The implicit default session's id, for stamping an envelope on a call that has no routed session of its own (a refusal, or a global meta-op).</summary>
+    private string DefaultSessionId() => _resolveSession(null)!.SessionId;
 
     /// <summary>The agent observation/actuation opt-in (#74) as seen through the injected settings.</summary>
     private bool AgentCommandsEnabled => _settings()?.AgentCommandsEnabled ?? false;
@@ -85,7 +107,47 @@ public sealed class AgentToolExecutor {
             AgentRuntime.Audit(name, "BLOCKED; emergency stop engaged; operator must re-arm");
             return ToolError(
                 "Emergency stop is engaged; the operator halted this session. All tool calls are refused until they re-arm. Stop and tell the user; do not retry.",
-                "emergency-stopped");
+                "emergency-stopped", AgentErrorCategory.Internal, DefaultSessionId());
+        }
+
+        // Session lifecycle (#86 Phase 3): session-start/status/end. These read `sessionId` as an explicit
+        // TARGET (which session to start/inspect/end), not as call routing, so they're handled before the
+        // generic routing refusal below. They are part of the agent surface, so they honor the same
+        // AgentCommandsEnabled opt-in as every other tool.
+        if (name is "session-start" or "session-status" or "session-end") {
+            if (!AgentCommandsEnabled) {
+                AgentRuntime.Audit(name, "BLOCKED; agent commands disabled");
+                return ToolError("Agent commands are disabled. Set AgentCommandsEnabled=true to opt in.", "agent-commands-disabled", AgentErrorCategory.Internal, DefaultSessionId());
+            }
+            return name switch {
+                "session-start" => RunSessionStart(),
+                "session-status" => RunSessionStatus(Str(args, "sessionId")),
+                _ => RunSessionEnd(Str(args, "sessionId")),
+            };
+        }
+
+        // Isolated-INSTALL lifecycle (#138): provision-session / end-session. Their `sessionId` names a
+        // provisioned MCEC *install* on disk, NOT an in-process agent session, so they must NOT be routed
+        // through the resolver below; they carry their own gates (provisioning opt-in / teardown token) and
+        // just stamp the default session id onto their envelope.
+        if (name == "provision-session") {
+            return RunProvisionSession(args, _resolveSession(null)!);
+        }
+        if (name == "end-session") {
+            return RunEndSession(args, _resolveSession(null)!);
+        }
+
+        // Route this call to its session (#86 Phase 3, decision 1): an explicit sessionId (from
+        // session-start) runs the call in that session and is echoed on the result; absent, the implicit
+        // default session is used so the single-agent / stdio case just works. A non-empty id that names
+        // no live session is refused rather than silently spawning a new one, so a stale id can't fork
+        // state unnoticed. Every branch below stamps the resolved session's id onto its envelope.
+        string? routeId = Str(args, "sessionId");
+        if (!TryResolveRoutedSession(routeId, out AgentSession session)) {
+            AgentRuntime.Audit(name, $"BLOCKED; unknown sessionId '{routeId}'");
+            return ToolError(
+                $"Unknown sessionId '{routeId}'. It was never started or has ended. Call session-start to get a fresh sessionId, or omit sessionId to use the default session.",
+                "unknown-session", AgentErrorCategory.InvalidArgument, DefaultSessionId());
         }
 
         if (name == "send_command") {
@@ -99,38 +161,82 @@ public sealed class AgentToolExecutor {
                 AgentRuntime.Audit("send_command", "BLOCKED; agent commands disabled; send_command over HTTP requires AgentCommandsEnabled");
                 return ToolError(
                     "send_command over HTTP requires AgentCommandsEnabled=true. Enable the agent surface to opt in, or drive send_command over the local stdio transport (mcec.exe --mcp).",
-                    "agent-commands-disabled");
+                    "agent-commands-disabled", AgentErrorCategory.Internal, session.SessionId);
             }
-            return RunSendCommand(args);
-        }
-
-        if (name == "provision-session") {
-            return RunProvisionSession(args);
-        }
-
-        if (name == "end-session") {
-            return RunEndSession(args);
+            return RunSendCommand(args, session);
         }
 
         // The gated agent tools are exactly the ToolCatalog membership (#205); no hand-synced whitelist.
         if (ToolCatalog.Contains(name)) {
             if (!AgentCommandsEnabled) {
                 AgentRuntime.Audit(name, "BLOCKED; agent commands disabled");
-                return ToolError("Agent commands are disabled. Set AgentCommandsEnabled=true to opt in.", "agent-commands-disabled");
+                return ToolError("Agent commands are disabled. Set AgentCommandsEnabled=true to opt in.", "agent-commands-disabled", AgentErrorCategory.Internal, session.SessionId);
             }
             // `drag`/`click` generate real mouse input from their endpoints, and a missing pixel field would
             // otherwise default to 0 and actuate at a bogus coordinate. Reject an ill-formed endpoint up
             // front rather than actuating it.
             if (name == "drag" && DragArgsError(args) is { } dragError) {
-                return ToolError(dragError, "bad-arguments", AgentErrorCategory.InvalidArgument);
+                return ToolError(dragError, "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
             }
             if (name == "click" && ClickArgsError(args) is { } clickError) {
-                return ToolError(clickError, "bad-arguments", AgentErrorCategory.InvalidArgument);
+                return ToolError(clickError, "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
             }
-            return RunAgentCommand(name, args);
+            return RunAgentCommand(name, args, session);
         }
 
-        return ToolError($"Unknown tool: {name}", "unknown-tool");
+        return ToolError($"Unknown tool: {name}", "unknown-tool", AgentErrorCategory.Internal, session.SessionId);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Session lifecycle tools (#86 Phase 3)
+    // -------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// <c>session-start</c>: creates a fresh addressable session and returns its status. The agent routes
+    /// later calls to it by echoing the returned <c>sessionId</c>; a call that omits <c>sessionId</c> keeps
+    /// using the implicit default session, which this never becomes.
+    /// </summary>
+    private JsonObject RunSessionStart() {
+        AgentSession session = _startSession();
+        AgentRuntime.Audit("session-start", session.SessionId);
+        return McpResult(AgentToolResult.Success(session.ToStatusJson(), session.SessionId));
+    }
+
+    /// <summary>
+    /// <c>session-status</c>: returns the debug/replay snapshot (active target, last observation/action/
+    /// error, artifact dir) of the session named by <paramref name="sessionId"/>, or the default session
+    /// when it is omitted. An id that names no live session is refused with <c>unknown-session</c>.
+    /// </summary>
+    private JsonObject RunSessionStatus(string? sessionId) {
+        if (!TryResolveRoutedSession(sessionId, out AgentSession session)) {
+            return ToolError(
+                $"Unknown sessionId '{sessionId}'. It was never started or has ended. Call session-start, or omit sessionId for the default session.",
+                "unknown-session", AgentErrorCategory.InvalidArgument, DefaultSessionId());
+        }
+        AgentRuntime.Audit("session-status", session.SessionId);
+        return McpResult(AgentToolResult.Success(session.ToStatusJson(), session.SessionId));
+    }
+
+    /// <summary>
+    /// <c>session-end</c>: ends the session named by <paramref name="sessionId"/> (required). Idempotent;
+    /// ending an id that is already gone returns <c>ended:false</c> rather than an error, so a retry is
+    /// safe. The envelope is stamped with the default session's id (the ended session no longer exists).
+    /// </summary>
+    private JsonObject RunSessionEnd(string? sessionId) {
+        if (string.IsNullOrWhiteSpace(sessionId)) {
+            return ToolError("session-end requires a non-empty 'sessionId' argument (the session to end).", "bad-arguments", AgentErrorCategory.InvalidArgument, DefaultSessionId());
+        }
+        string id = sessionId.Trim();
+        bool ended = _endSession(id);
+        AgentRuntime.Audit("session-end", $"{id}; ended={ended}");
+        JsonObject result = new() {
+            ["sessionId"] = id,
+            ["ended"] = ended,
+        };
+        if (!ended) {
+            result["note"] = "No live session had that id (already ended or never started); nothing to do.";
+        }
+        return McpResult(AgentToolResult.Success(result, DefaultSessionId()));
     }
 
     /// <summary>
@@ -173,14 +279,14 @@ public sealed class AgentToolExecutor {
 
     // Internal so tests can exercise the unknown-tool refusal for a name that passed the
     // tools/call gate but has no argument mapping (InternalsVisibleTo). See #201.
-    internal JsonObject RunAgentCommand(string name, JsonObject args) {
+    internal JsonObject RunAgentCommand(string name, JsonObject args, AgentSession session) {
         // #201: if a name passes the gate but has no command mapping, refuse with a structured error
         //; the old default arm silently mapped unknown names onto InvokeCommand (an ACTUATION) with
         // garbage selector args. Since #205 the gate and the mapping are the SAME ToolCatalog, so
         // this can only trip for a caller that bypassed the gate (tests exercise it directly).
         if (BuildCommand(name, args) is not { } cmd) {
             AgentRuntime.Audit(name, "BLOCKED; tool has no argument mapping; refusing to run it as another command");
-            return ToolError($"Unknown tool: {name}", "unknown-tool");
+            return ToolError($"Unknown tool: {name}", "unknown-tool", AgentErrorCategory.Internal, session.SessionId);
         }
 
         // Honor the per-command Enabled flag; the documented second security gate. The MCP tool only
@@ -188,7 +294,7 @@ public sealed class AgentToolExecutor {
         // the operator opts in per-command via mcec.commands). Fail closed if the table/command is missing.
         if ((_invoker()?[name] as Command)?.Enabled != true) {
             AgentRuntime.Audit(name, "BLOCKED; command is disabled in mcec.commands");
-            return ToolError($"The '{name}' command is disabled. Enable it in mcec.commands (set Enabled=\"true\").", "command-disabled");
+            return ToolError($"The '{name}' command is disabled. Enable it in mcec.commands (set Enabled=\"true\").", "command-disabled", AgentErrorCategory.Internal, session.SessionId);
         }
 
         CapturingReply reply = new();
@@ -198,10 +304,9 @@ public sealed class AgentToolExecutor {
 
         AgentRuntime.Audit(name, args.ToJsonString(AgentJson.Options));
 
-        // The ambient session (#86) carries sessionId onto this result and remembers the target/
+        // The routed session (#86) carries sessionId onto this result and remembers the target/
         // observation/action/error. Snapshot the prior observation now, before this call records its own,
         // so a failure can carry the last good state into error.lastObservation.
-        AgentSession session = _session();
         JsonObject? priorObservation = session.LastObservation;
         session.RecordAction(name);
 
@@ -298,15 +403,15 @@ public sealed class AgentToolExecutor {
         return worker.Join(InvokeModalGraceMs);
     }
 
-    private JsonObject RunSendCommand(JsonObject args) {
+    private JsonObject RunSendCommand(JsonObject args, AgentSession session) {
         string command = args["command"]?.GetValue<string>() ?? "";
         if (string.IsNullOrWhiteSpace(command)) {
-            return ToolError("send_command requires a non-empty 'command' argument.", "bad-arguments", AgentErrorCategory.InvalidArgument);
+            return ToolError("send_command requires a non-empty 'command' argument.", "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
         }
 
         CommandInvoker? invoker = _invoker();
         if (invoker is null) {
-            return ToolError("Command engine is not available.", "engine-unavailable");
+            return ToolError("Command engine is not available.", "engine-unavailable", AgentErrorCategory.Internal, session.SessionId);
         }
 
         AgentRuntime.Audit("send_command", command);
@@ -321,33 +426,32 @@ public sealed class AgentToolExecutor {
         CapturingReply reply = new();
         CommandEnqueueResult enqueued = invoker.TryEnqueueWithCompletion(reply, command, out Task<bool>? completion);
 
-        AgentSession session = _session();
         session.RecordAction("send_command");
 
         if (enqueued == CommandEnqueueResult.UnknownCommand) {
             return ToolError(
                 $"Unknown command: '{command}' is not in the loaded command table. Nothing was executed.",
-                "unknown-command");
+                "unknown-command", AgentErrorCategory.Internal, session.SessionId);
         }
         if (enqueued != CommandEnqueueResult.Enqueued || completion is null) {
             return ToolError(
                 $"The command '{command}' was dropped whole and never executed: it exceeds the queue bounds " +
                 "(over the embedded-expansion limit, or the execute queue is full) or the command engine is shutting down. " +
                 "Send less at once and let the queue drain before retrying.",
-                "command-dropped");
+                "command-dropped", AgentErrorCategory.Internal, session.SessionId);
         }
 
         if (!completion.Wait(SendCommandCompletionTimeoutMs)) {
             return ToolError(
                 $"send_command timed out after {SendCommandCompletionTimeoutMs / 1000}s waiting for '{command}' to execute. " +
                 "The command queue is still draining it (a long macro, pause, or a hung command); it was not cancelled.",
-                "send-command-timeout");
+                "send-command-timeout", AgentErrorCategory.Internal, session.SessionId);
         }
         if (!completion.Result) {
             return ToolError(
                 "The queue was dropped before this command finished (emergency stop engaged or the command engine shut down). " +
                 "It may have PARTIALLY executed; verify the desktop state with query/capture before assuming nothing ran.",
-                "emergency-stopped");
+                "emergency-stopped", AgentErrorCategory.Internal, session.SessionId);
         }
 
         // The legacy command path returns opaque text, not a CommandResult; carry it forward as the
@@ -364,12 +468,12 @@ public sealed class AgentToolExecutor {
     /// the operator's <see cref="AppSettings.AllowSessionProvisioning"/> opt-in; the one thing that cannot
     /// be self-served; and never touches the installed config. Also reaps stale session dirs opportunistically.
     /// </summary>
-    private JsonObject RunProvisionSession(JsonObject args) {
+    private JsonObject RunProvisionSession(JsonObject args, AgentSession session) {
         if (_settings()?.AllowSessionProvisioning != true) {
             AgentRuntime.Audit("provision-session", "BLOCKED; session provisioning is not authorized");
             return ToolError(
                 "Session provisioning is not authorized. The operator must enable AllowSessionProvisioning to opt in; it cannot be self-served.",
-                "provisioning-not-authorized");
+                "provisioning-not-authorized", AgentErrorCategory.Internal, session.SessionId);
         }
 
         bool mcpServer = args["mcpServer"] is not JsonValue mv || !mv.TryGetValue(out bool m) || m; // default true
@@ -377,12 +481,12 @@ public sealed class AgentToolExecutor {
 
         try {
             SessionProvisioner.ReapOrphans(TimeSpan.FromHours(SessionReapAgeHours));
-            ProvisionedSession session = SessionProvisioner.Provision(mcpServer, commands);
-            return McpResult(AgentToolResult.Success(session.ToJsonObject(), _session().SessionId));
+            ProvisionedSession provisioned = SessionProvisioner.Provision(mcpServer, commands);
+            return McpResult(AgentToolResult.Success(provisioned.ToJsonObject(), session.SessionId));
         }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"AgentServer: provision-session failed: {e.Message}");
-            return ToolError($"Failed to provision a session: {e.Message}", "provisioning-failed");
+            return ToolError($"Failed to provision a session: {e.Message}", "provisioning-failed", AgentErrorCategory.Internal, session.SessionId);
         }
     }
 
@@ -393,16 +497,16 @@ public sealed class AgentToolExecutor {
     /// authorization gate (teardown must always be possible), so before the token this tool let any
     /// MCP caller delete any session it could name; now only the token holder can.
     /// </summary>
-    private JsonObject RunEndSession(JsonObject args) {
+    private JsonObject RunEndSession(JsonObject args, AgentSession session) {
         string? sessionId = Str(args, "sessionId");
         if (string.IsNullOrWhiteSpace(sessionId)) {
-            return ToolError("end-session requires a non-empty 'sessionId' argument.", "bad-arguments", AgentErrorCategory.InvalidArgument);
+            return ToolError("end-session requires a non-empty 'sessionId' argument.", "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
         }
         string? token = Str(args, "token");
         if (string.IsNullOrWhiteSpace(token)) {
             return ToolError(
                 "end-session requires the session 'token' returned by provision-session (the teardown credential).",
-                "bad-arguments", AgentErrorCategory.InvalidArgument);
+                "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
         }
         switch (SessionProvisioner.ValidateTeardownToken(sessionId, token)) {
             case SessionTokenValidation.TokenMismatch:
@@ -411,7 +515,7 @@ public sealed class AgentToolExecutor {
                     "The token does not match this session (or the session's config could not be verified). " +
                     "Use the exact token provision-session returned; a session you did not provision is not yours to tear down. " +
                     "Orphaned sessions are reaped automatically.",
-                    "session-token-invalid");
+                    "session-token-invalid", AgentErrorCategory.Internal, session.SessionId);
             case SessionTokenValidation.InvalidId:
             case SessionTokenValidation.SessionGone:
             case SessionTokenValidation.Valid:
@@ -426,7 +530,7 @@ public sealed class AgentToolExecutor {
         if (!removed) {
             result["note"] = "The session directory could not be deleted; its mcec.exe may still be running. Stop it and retry, or MCEC will reap it on a later launch.";
         }
-        return McpResult(AgentToolResult.Success(result, _session().SessionId));
+        return McpResult(AgentToolResult.Success(result, session.SessionId));
     }
 
     /// <summary>Reads a JSON array of strings into a list, or null when the node is absent/empty.</summary>
@@ -478,14 +582,14 @@ public sealed class AgentToolExecutor {
 
     /// <summary>
     /// A tool-level failure (a security gate or a bad request) reported as the #101 envelope. Security/
-    /// policy refusals the agent cannot recover from on its own map to the default <c>internal</c>
-    /// category; argument-validation refusals pass <see cref="AgentErrorCategory.InvalidArgument"/>
-    /// (#191; the recovery is to fix the request, not report a bug). <paramref name="code"/>
-    /// distinguishes the specific cause. The ambient session's id is attached so even a refused call
-    /// tells the agent which session it belonged to.
+    /// policy refusals the agent cannot recover from on its own map to the <c>internal</c> category;
+    /// argument-validation refusals pass <see cref="AgentErrorCategory.InvalidArgument"/> (#191; the
+    /// recovery is to fix the request, not report a bug). <paramref name="code"/> distinguishes the
+    /// specific cause. <paramref name="sessionId"/> (the routed session, or the default when the call
+    /// never resolved one) is attached so even a refused call tells the agent which session it belonged to.
     /// </summary>
-    private JsonObject ToolError(string message, string code = "internal-error", AgentErrorCategory category = AgentErrorCategory.Internal) =>
-        McpResult(AgentToolResult.Failure(new AgentError(code, category, message), _session().SessionId));
+    private static JsonObject ToolError(string message, string code, AgentErrorCategory category, string sessionId) =>
+        McpResult(AgentToolResult.Failure(new AgentError(code, category, message), sessionId));
 
     private static JsonObject TextContent(string text) => new() {
         ["type"] = "text",

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,8 +65,8 @@ public sealed class AgentToolExecutor {
     }
 
     /// <summary>Routes a call to its session; false with <paramref name="session"/> null when a non-empty id names no live session.</summary>
-    private bool TryResolveRoutedSession(string? sessionId, out AgentSession session) {
-        session = _resolveSession(sessionId)!;
+    private bool TryResolveRoutedSession(string? sessionId, [MaybeNullWhen(false)] out AgentSession session) {
+        session = _resolveSession(sessionId);
         return session is not null;
     }
 
@@ -143,11 +144,14 @@ public sealed class AgentToolExecutor {
         // no live session is refused rather than silently spawning a new one, so a stale id can't fork
         // state unnoticed. Every branch below stamps the resolved session's id onto its envelope.
         string? routeId = Str(args, "sessionId");
-        if (!TryResolveRoutedSession(routeId, out AgentSession session)) {
+        if (!TryResolveRoutedSession(routeId, out AgentSession? session)) {
             AgentRuntime.Audit(name, $"BLOCKED; unknown sessionId '{routeId}'");
+            // Stamp the REJECTED id, not the default session: a client that carries envelope.sessionId
+            // forward after an error must not be silently handed the default session (which would fork the
+            // isolated task's state). We only reach here for a non-empty id (empty routes to default above).
             return ToolError(
                 $"Unknown sessionId '{routeId}'. It was never started or has ended. Call session-start to get a fresh sessionId, or omit sessionId to use the default session.",
-                "unknown-session", AgentErrorCategory.InvalidArgument, DefaultSessionId());
+                "unknown-session", AgentErrorCategory.InvalidArgument, routeId!);
         }
 
         if (name == "send_command") {
@@ -208,10 +212,12 @@ public sealed class AgentToolExecutor {
     /// when it is omitted. An id that names no live session is refused with <c>unknown-session</c>.
     /// </summary>
     private JsonObject RunSessionStatus(string? sessionId) {
-        if (!TryResolveRoutedSession(sessionId, out AgentSession session)) {
+        if (!TryResolveRoutedSession(sessionId, out AgentSession? session)) {
+            // Echo the rejected id, not the default (see the routing refusal in CallTool). Non-empty here:
+            // an omitted/empty id resolves to the default session and never enters this branch.
             return ToolError(
                 $"Unknown sessionId '{sessionId}'. It was never started or has ended. Call session-start, or omit sessionId for the default session.",
-                "unknown-session", AgentErrorCategory.InvalidArgument, DefaultSessionId());
+                "unknown-session", AgentErrorCategory.InvalidArgument, sessionId!);
         }
         AgentRuntime.Audit("session-status", session.SessionId);
         return McpResult(AgentToolResult.Success(session.ToStatusJson(), session.SessionId));
@@ -220,7 +226,8 @@ public sealed class AgentToolExecutor {
     /// <summary>
     /// <c>session-end</c>: ends the session named by <paramref name="sessionId"/> (required). Idempotent;
     /// ending an id that is already gone returns <c>ended:false</c> rather than an error, so a retry is
-    /// safe. The envelope is stamped with the default session's id (the ended session no longer exists).
+    /// safe. The envelope is stamped with the ended id (metadata; consistent with <c>session-status</c>
+    /// stamping its inspected session), so a client can correlate the result with the session it ended.
     /// </summary>
     private JsonObject RunSessionEnd(string? sessionId) {
         if (string.IsNullOrWhiteSpace(sessionId)) {
@@ -236,7 +243,7 @@ public sealed class AgentToolExecutor {
         if (!ended) {
             result["note"] = "No live session had that id (already ended or never started); nothing to do.";
         }
-        return McpResult(AgentToolResult.Success(result, DefaultSessionId()));
+        return McpResult(AgentToolResult.Success(result, id));
     }
 
     /// <summary>

--- a/src/Services/JsonRpcDispatcher.cs
+++ b/src/Services/JsonRpcDispatcher.cs
@@ -93,19 +93,42 @@ public sealed class JsonRpcDispatcher {
         JsonArray tools = [];
 
         // The gated agent tools; one descriptor per tool, schema included; live in ToolCatalog (#205).
+        // Each also accepts the optional per-call session-routing arg (#86 Phase 3), injected here in one
+        // place rather than repeated in every catalog schema.
         foreach (ToolDescriptor descriptor in ToolCatalog.All) {
-            tools.Add(descriptor.BuildSchema());
+            JsonObject schema = descriptor.BuildSchema();
+            AddSessionArg(schema);
+            tools.Add(schema);
         }
 
         // META-TOOLS: deliberately NOT in the catalog, because they do not map 1:1 onto a Command in
         // the loaded table and have their own gating. send_command is the raw pass-through into the
         // CommandInvoker queue (transport-sensitive gate, #153); provision-session/end-session are the
-        // isolated-session lifecycle (#138, gated by the operator's AllowSessionProvisioning). They are
+        // isolated-session lifecycle (#138, gated by the operator's AllowSessionProvisioning);
+        // session-start/status/end are the in-process agent-session lifecycle (#86 Phase 3). They are
         // special-cased here and in AgentToolExecutor.CallTool, right next to the catalog dispatch.
-        tools.Add(ToolCatalog.Tool("send_command",
+        JsonObject sendCommandSchema = ToolCatalog.Tool("send_command",
             "Send any raw MCEC command string to the existing command core (e.g. actuation commands).",
             new JsonObject { ["command"] = ToolCatalog.PropSchema("string", "The MCEC command string to enqueue") },
-            ["command"]));
+            ["command"]);
+        AddSessionArg(sendCommandSchema); // send_command is routable like the catalog tools (#86)
+        tools.Add(sendCommandSchema);
+
+        // In-process agent-session lifecycle (#86 Phase 3). session-start hands back a fresh addressable
+        // sessionId; session-status/end read `sessionId` as the TARGET session (not call routing), so they
+        // are NOT given the injected routing arg above. NOTE: hyphenated names (session-start, not
+        // session/start) because MCP/Anthropic tool names must match ^[a-zA-Z0-9_-]{1,64}$; '/' is invalid.
+        tools.Add(ToolCatalog.Tool("session-start",
+            "Start a new agent session and get its sessionId. Echo that sessionId on later tool calls to run them in this session (its own active target, last observation/action/error, and artifact directory); omit sessionId on a call to use the default session. Returns the new session's status. Use this to run independent multi-step tasks that must not share state.",
+            [], []));
+        tools.Add(ToolCatalog.Tool("session-status",
+            "Report a session's state: active target window, last observation, last action, last error, artifact directory, and any emergency stop. Pass 'sessionId' to inspect a specific session (from session-start), or omit it for the default session.",
+            new JsonObject { ["sessionId"] = ToolCatalog.PropSchema("string", "The session to inspect (from session-start); omit for the default session") },
+            []));
+        tools.Add(ToolCatalog.Tool("session-end",
+            "End an agent session started with session-start, freeing its server-side state. Idempotent: ending an unknown/already-ended id reports ended:false rather than erroring. After this, a tool call echoing that sessionId is refused with unknown-session.",
+            new JsonObject { ["sessionId"] = ToolCatalog.PropSchema("string", "The session to end (from session-start)") },
+            ["sessionId"]));
 
         // Isolated session provisioning (#138). Requires the operator to have opted in
         // (AllowSessionProvisioning); it never mutates the installed config.
@@ -130,6 +153,17 @@ public sealed class JsonRpcDispatcher {
             ["sessionId", "token"]));
 
         return tools;
+    }
+
+    /// <summary>
+    /// Adds the optional <c>sessionId</c> routing property (#86 Phase 3) to a tool's
+    /// <c>inputSchema.properties</c>. It stays optional (never added to <c>required</c>) so omitting it
+    /// keeps using the default session. Best-effort: a schema without the expected shape is left untouched.
+    /// </summary>
+    private static void AddSessionArg(JsonObject schema) {
+        if (schema["inputSchema"] is JsonObject input && input["properties"] is JsonObject props) {
+            props["sessionId"] = ToolCatalog.SessionArgProp();
+        }
     }
 
     // -------------------------------------------------------------------------------------------

--- a/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
+++ b/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
@@ -21,8 +21,10 @@ public class ToolCatalogTests {
         "capture", "query", "displays", "find", "wait-for", "invoke", "drag", "click", "record", "launch",
     ];
 
-    /// <summary>The meta-tools that are deliberately NOT in the catalog (no 1:1 Command mapping).</summary>
-    private static readonly string[] _metaToolNames = ["send_command", "provision-session", "end-session"];
+    /// <summary>The meta-tools that are deliberately NOT in the catalog (no 1:1 Command mapping), in tools/list order.</summary>
+    private static readonly string[] _metaToolNames = [
+        "send_command", "session-start", "session-status", "session-end", "provision-session", "end-session",
+    ];
 
     [Fact]
     public void Catalog_ContainsExactlyTheGatedAgentTools_InToolsListOrder() {

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -600,6 +600,205 @@ public class AgentServerTests {
         Assert.Equal("hi", invoke.Text);
     }
 
+    // -------------------------------------------------------------------------------------------
+    // #86 Phase 3: session lifecycle tools (session-start/status/end) + per-call sessionId routing.
+    // -------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Dispatch_ToolsList_AdvertisesSessionLifecycleAndRoutingArg() {
+        JsonObject resp = AgentServer.Dispatch(Request(2, "tools/list"))!;
+        JsonArray tools = resp["result"]!.AsObject()["tools"]!.AsArray();
+
+        Dictionary<string, JsonObject> byName = [];
+        foreach (JsonNode? tool in tools) {
+            if (tool?["name"]?.GetValue<string>() is { } n) {
+                byName[n] = tool.AsObject();
+            }
+        }
+
+        // The three lifecycle tools are advertised (hyphenated, not session/start; '/' is invalid in an
+        // MCP/Anthropic tool name).
+        Assert.Contains("session-start", byName.Keys);
+        Assert.Contains("session-status", byName.Keys);
+        Assert.Contains("session-end", byName.Keys);
+
+        // Routable tools (catalog + send_command) advertise an OPTIONAL sessionId arg.
+        foreach (string routable in (string[])["capture", "invoke", "drag", "send_command"]) {
+            JsonObject schema = byName[routable]["inputSchema"]!.AsObject();
+            Assert.True(schema["properties"]!.AsObject().ContainsKey("sessionId"), $"{routable} should advertise sessionId");
+            Assert.DoesNotContain("sessionId", Required(schema));
+        }
+
+        // session-end targets a session, so its sessionId is REQUIRED; session-status's is optional;
+        // session-start takes none (it never routes; it mints a new id).
+        Assert.Contains("sessionId", Required(byName["session-end"]["inputSchema"]!.AsObject()));
+        Assert.True(byName["session-status"]["inputSchema"]!.AsObject()["properties"]!.AsObject().ContainsKey("sessionId"));
+        Assert.DoesNotContain("sessionId", Required(byName["session-status"]["inputSchema"]!.AsObject()));
+        Assert.False(byName["session-start"]["inputSchema"]!.AsObject()["properties"]!.AsObject().ContainsKey("sessionId"));
+    }
+
+    [Fact]
+    public void Dispatch_SessionStart_MintsFreshAddressableSessionDistinctFromDefault() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+        AgentRuntime.ResetSession();
+        try {
+            string defaultId = AgentRuntime.Session.SessionId;
+
+            JsonObject env = CallEnvelope(40, "session-start");
+            Assert.True(env["ok"]!.GetValue<bool>());
+            string started = env["result"]!.AsObject()["sessionId"]!.GetValue<string>();
+
+            // The started session names itself on the envelope, is a real new id, and is NOT the default.
+            Assert.Equal(started, env["sessionId"]!.GetValue<string>());
+            Assert.NotEqual(defaultId, started);
+
+            // Two starts give two different sessions.
+            string started2 = CallEnvelope(41, "session-start")["result"]!.AsObject()["sessionId"]!.GetValue<string>();
+            Assert.NotEqual(started, started2);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
+        }
+    }
+
+    [Fact]
+    public void Dispatch_SessionId_RoutesTheCall_AndEchoesTheRoutedId() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+        AgentRuntime.ResetSession();
+        try {
+            string started = CallEnvelope(42, "session-start")["result"]!.AsObject()["sessionId"]!.GetValue<string>();
+
+            // A tool call echoing that sessionId runs in (and names) that session; the command itself is
+            // disabled (no loaded table), but the refusal still carries the ROUTED session id.
+            JsonObject routed = CallEnvelope(43, "capture", new JsonObject { ["sessionId"] = started });
+            Assert.Equal(started, routed["sessionId"]!.GetValue<string>());
+
+            // A call with no sessionId falls back to the default session, a different id.
+            JsonObject defaulted = CallEnvelope(44, "capture");
+            Assert.Equal(AgentRuntime.Session.SessionId, defaulted["sessionId"]!.GetValue<string>());
+            Assert.NotEqual(started, defaulted["sessionId"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
+        }
+    }
+
+    [Fact]
+    public void Dispatch_UnknownSessionId_IsRefused_NotSilentlyForked() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+        AgentRuntime.ResetSession();
+        try {
+            JsonObject env = CallEnvelope(45, "capture", new JsonObject { ["sessionId"] = "deadbeefcafe" });
+            Assert.False(env["ok"]!.GetValue<bool>());
+            JsonObject error = env["error"]!.AsObject();
+            Assert.Equal("unknown-session", error["code"]!.GetValue<string>());
+            Assert.Equal("invalid-argument", error["category"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
+        }
+    }
+
+    [Fact]
+    public void Dispatch_SessionStatus_ReturnsSessionState() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+        AgentRuntime.ResetSession();
+        try {
+            string started = CallEnvelope(46, "session-start")["result"]!.AsObject()["sessionId"]!.GetValue<string>();
+
+            JsonObject env = CallEnvelope(47, "session-status", new JsonObject { ["sessionId"] = started });
+            Assert.True(env["ok"]!.GetValue<bool>());
+            JsonObject status = env["result"]!.AsObject();
+            Assert.Equal(started, status["sessionId"]!.GetValue<string>());
+            Assert.True(status.ContainsKey("startedAt"));
+            Assert.True(status.ContainsKey("artifactDir"));
+
+            // Omitting sessionId reports the DEFAULT session.
+            JsonObject def = CallEnvelope(48, "session-status");
+            Assert.Equal(AgentRuntime.Session.SessionId, def["result"]!.AsObject()["sessionId"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
+        }
+    }
+
+    [Fact]
+    public void Dispatch_SessionEnd_RemovesSession_ThenRoutingItIsUnknown_AndReEndIsIdempotent() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+        AgentRuntime.ResetSession();
+        try {
+            string started = CallEnvelope(49, "session-start")["result"]!.AsObject()["sessionId"]!.GetValue<string>();
+
+            JsonObject ended = CallEnvelope(50, "session-end", new JsonObject { ["sessionId"] = started });
+            Assert.True(ended["ok"]!.GetValue<bool>());
+            Assert.True(ended["result"]!.AsObject()["ended"]!.GetValue<bool>());
+
+            // The id no longer resolves: a routed call is refused.
+            JsonObject afterEnd = CallEnvelope(51, "capture", new JsonObject { ["sessionId"] = started });
+            Assert.False(afterEnd["ok"]!.GetValue<bool>());
+            Assert.Equal("unknown-session", afterEnd["error"]!.AsObject()["code"]!.GetValue<string>());
+
+            // Re-ending is idempotent (ended:false, not an error).
+            JsonObject reEnd = CallEnvelope(52, "session-end", new JsonObject { ["sessionId"] = started });
+            Assert.True(reEnd["ok"]!.GetValue<bool>());
+            Assert.False(reEnd["result"]!.AsObject()["ended"]!.GetValue<bool>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
+        }
+    }
+
+    [Fact]
+    public void Dispatch_SessionLifecycle_RequiresAgentCommandsEnabled() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = null; // agent surface not opted in
+        AgentRuntime.ResetSession();
+        try {
+            JsonObject env = CallEnvelope(53, "session-start");
+            Assert.False(env["ok"]!.GetValue<bool>());
+            Assert.Equal("agent-commands-disabled", env["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
+        }
+    }
+
+    /// <summary>Dispatches a tools/call and returns the #101 envelope from its first text content block.</summary>
+    private static JsonObject CallEnvelope(int id, string name, JsonObject? arguments = null) {
+        JsonObject prms = new() { ["name"] = name, ["arguments"] = arguments ?? [] };
+        JsonObject resp = AgentServer.Dispatch(Request(id, "tools/call", prms))!;
+        return JsonNode.Parse(FirstTextBlock(resp["result"]!.AsObject()))!.AsObject();
+    }
+
+    /// <summary>The <c>required</c> array of an inputSchema as a list of strings.</summary>
+    private static List<string> Required(JsonObject inputSchema) {
+        List<string> required = [];
+        if (inputSchema["required"] is JsonArray arr) {
+            foreach (JsonNode? r in arr) {
+                if (r?.GetValue<string>() is { } s) {
+                    required.Add(s);
+                }
+            }
+        }
+        return required;
+    }
+
     private static string FirstTextBlock(JsonObject toolResult) {
         foreach (JsonNode? block in toolResult["content"]!.AsArray()) {
             if (block?["type"]?.GetValue<string>() == "text") {

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -701,6 +701,31 @@ public class AgentServerTests {
             JsonObject error = env["error"]!.AsObject();
             Assert.Equal("unknown-session", error["code"]!.GetValue<string>());
             Assert.Equal("invalid-argument", error["category"]!.GetValue<string>());
+
+            // The refusal echoes the REJECTED id, never the default session; else a client that carries
+            // envelope.sessionId forward after an error would silently continue the independent task in the
+            // default session, cross-contaminating the state the explicit session was meant to isolate (CR).
+            Assert.Equal("deadbeefcafe", env["sessionId"]!.GetValue<string>());
+            Assert.NotEqual(AgentRuntime.Session.SessionId, env["sessionId"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
+        }
+    }
+
+    [Fact]
+    public void Dispatch_WhitespaceOnlySessionId_IsRefused_NotRoutedToDefault() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+        AgentRuntime.ResetSession();
+        try {
+            // A whitespace-only id is non-empty content, not an omitted arg: refuse it as unknown rather
+            // than silently routing to the default session (which would fork/cross-contaminate state) (CR).
+            JsonObject env = CallEnvelope(54, "capture", new JsonObject { ["sessionId"] = "   " });
+            Assert.False(env["ok"]!.GetValue<bool>());
+            Assert.Equal("unknown-session", env["error"]!.AsObject()["code"]!.GetValue<string>());
         }
         finally {
             AgentRuntime.Settings = null;
@@ -746,6 +771,9 @@ public class AgentServerTests {
             JsonObject ended = CallEnvelope(50, "session-end", new JsonObject { ["sessionId"] = started });
             Assert.True(ended["ok"]!.GetValue<bool>());
             Assert.True(ended["result"]!.AsObject()["ended"]!.GetValue<bool>());
+            // The envelope names the ended session (metadata; consistent with session-status stamping its
+            // inspected session), so a client can correlate the result with the session it ended (CR).
+            Assert.Equal(started, ended["sessionId"]!.GetValue<string>());
 
             // The id no longer resolves: a routed call is refused.
             JsonObject afterEnd = CallEnvelope(51, "capture", new JsonObject { ["sessionId"] = started });


### PR DESCRIPTION
Implements **Phase 3** of #86: promotes the ambient agent session (Phases 1–2, already merged) into an addressable, multi-session runtime with explicit lifecycle tools and per-call routing.

## What changed

- **Session store** (`AgentRuntime`): a dictionary keyed by `sessionId` plus the implicit default session. `StartSession` / `TryResolveSession` / `EndSession` back the lifecycle; `Session` (default) and `ResetSession` stay for existing callers/tests. Setting `ArtifactRoot` clears all sessions.
- **Per-call routing** (`AgentToolExecutor`): every `tools/call` resolves the session it runs in from an optional `sessionId` argument, per the issue's **decision 1** (identity carried in-band, not bound to the transport). No `sessionId` → the implicit default session, so the single-agent / stdio case just works. A non-empty id that names no live session is refused with `unknown-session` (category `invalid-argument`) rather than silently forking fresh state. The resolved id is stamped on **every** envelope, success or failure.
- **New meta-tools**: `session-start`, `session-status`, `session-end`.
- **`tools/list`** advertises the three lifecycle tools and injects an optional `sessionId` routing arg onto every catalog tool + `send_command` (in one place, not per-schema).
- **Guidance**: folded the session loop into `AgentInstructions.md` (the in-product single source of truth) and documented it in `docs/agent-server.md`.

## Naming decision (please confirm)

The issue writes the tools as `session/start|status|end`. I implemented them **hyphenated** (`session-start`, etc.) because MCP/Anthropic tool names must match `^[a-zA-Z0-9_-]{1,64}$` — a `/` is invalid and would be rejected by the very clients (Claude) that drive MCEC. Hyphens also match the existing `wait-for` / `end-session` / `provision-session` convention. Easy to rename if you'd rather.

## Scope note

`provision-session` / `end-session` (#138) use `sessionId` to mean a provisioned **install** id, not an in-process session; they are handled before routing so their arg is not misread as call routing. Left untouched otherwise.

## Acceptance criteria (#86) mapping

- *Results include `sessionId` + structured warnings/errors* — every envelope now carries the routed/default `sessionId` (Phases 1–2 landed the envelope; Phase 3 makes the id real and routable).
- *State survives across tool calls in a mounted MCP session* — the default session persists; explicit sessions are addressable by id across stdio/HTTP.
- *Docs explain how agents should use sessions* — `AgentInstructions.md` SESSIONS section + `docs/agent-server.md` "Agent sessions".

Phase 4 (per-session actuation lock #113; already partly present) is out of scope here.

## Tests

New xUnit coverage: `session-start` mints a fresh addressable id distinct from the default; routing echoes the routed id and falls back to the default; unknown id is refused; `session-status` returns state; `session-end` removes and is idempotent, and a routed call afterward is `unknown-session`; lifecycle honors `AgentCommandsEnabled`. Full suite green: **867 passed, 22 skipped** (desktop-E2E gated), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
