### PR TITLE
agent: verified `focus` tool + real focus/foreground diagnostics (#91, #270)

### DIFF
--- a/docs/agent-server-architecture.md
+++ b/docs/agent-server-architecture.md
@@ -25,7 +25,7 @@ pattern and adds no breaking changes to any existing command, transport, or defa
                                             │  resolves + Execute()s
                                             ▼
    capture / query / displays / find / wait-for / invoke /
-   drag / click / record / launch   (the ToolCatalog set; new Commands)
+   drag / click / focus / record / launch   (the ToolCatalog set; new Commands)
         │            │           │
    ScreenCapture  WindowResolver  UiaService
    (PrintWindow)  (Win32 enum)    (FlaUI / UIA3, one dedicated MTA worker)
@@ -134,7 +134,7 @@ code/category to `unhandled`/`internal`, so every agent failure is categorical b
 
 ## How the new commands plug into the existing pattern
 
-Each agent command (`capture`, `query`, `find`/`wait-for`, `invoke`, `click`, `drag`,
+Each agent command (`capture`, `query`, `find`/`wait-for`, `invoke`, `click`, `focus`, `drag`,
 `record`, `displays`, `launch`) derives from `AgentCommand : Command` and follows
 the house pattern:
 

--- a/docs/design/agent-tool-result-contract.md
+++ b/docs/design/agent-tool-result-contract.md
@@ -80,15 +80,16 @@ falling back to `category`.
 | `no-target`          | A selector matched nothing (no window/element). | Broaden the selector, `query` to discover targets, or wait for the target to appear. |
 | `invalid-argument`   | The request itself is malformed or inapplicable (#191): a client-supplied argument is invalid (unknown action, oversized region, ill-formed endpoint) or cannot apply to the target (an element that lacks the pattern an action needs). | Fix the arguments and re-issue. Do **not** retry the same call, broaden a selector, or re-find the target; the request will keep failing until it changes. |
 | `capture-blank`      | A screenshot was produced but detected as black/blank (composited/occluded/locked-session). | Try foreground/region capture; restore/foreground the window; surface the limitation. The suspect image still rides in `error.partialResult`. |
-| `focus`              | **Reserved** (#261): an action required input focus that could not be set. No code path produces it yet (`setfocus` dispatch is fire-and-forget); it stays in the closed set for wire compatibility and future detection. | Treat like `internal` until a producer exists. |
+| `focus`              | An action required keyboard focus and it could not be confirmed on the target. Produced (#91/#270) by the `focus` tool when the window is foreground but no control took focus (`FocusService.IsFocusInWindow`), and by `invoke setfocus` when the element does not end up with `HasKeyboardFocus` (`UiaInvokeResult.FocusNotSet`). | `click` the exact control (a real click focuses what a bare SetFocus misses), or drive it with `invoke` instead of keystrokes. |
 | `elevation`          | The target runs at a higher integrity level (UAC) than MCEC and cannot be driven. Produced (#261) when a UIA attach/read/dispatch on a valid window fails with E_ACCESSDENIED (UIPI). | Surface to the operator; the action cannot proceed without elevation. |
-| `foreground`         | **Reserved** (#261): an action required the target to be foreground and it could not be brought forward. No agent command checks a SetForegroundWindow result yet; kept for wire compatibility and future detection. | Treat like `internal` until a producer exists. |
+| `foreground`         | An action required the target to be foreground and it could not be brought forward. Produced (#91/#270) by the `focus` tool when `FocusService.BringToForeground` asks Windows to activate the target and `GetForegroundWindow` confirms it did not land. | Retry the `focus` tool once whatever holds the foreground (a foreground lock, a modal on another app, a full-screen exclusive window) is gone, or ask the operator to click the target. |
 | `internal`           | An unexpected MCEC-side fault (bug, unhandled exception). | Not agent-recoverable; report with `lastObservation` for a bug bundle (#87). |
 
 `focus`, `elevation`, and `foreground` are kept distinct (rather than one "input" bucket) because
-the recoveries differ: focus is retryable, foreground is OS-policy-constrained, and elevation is
-not recoverable by the agent at all. In-product guidance (`AgentInstructions.md`) documents recovery
-only for categories that can actually occur; reserved categories must not be taught to agents (#261).
+the recoveries differ: focus is retryable (click the control), foreground is OS-policy-constrained
+(retry once the holder clears), and elevation is not recoverable by the agent at all. In-product
+guidance (`AgentInstructions.md`) documents recovery for every category that can occur; all three now
+have producers (#91/#270).
 
 ### Example error codes per category
 
@@ -101,9 +102,9 @@ only for categories that can actually occur; reserved categories must not be tau
 - `invalid-argument` → `region-too-large`, `action-unknown`, `pattern-unsupported`, `bad-arguments`,
   `launch-path-missing`, `recording-in-progress`, `no-recording`
 - `capture-blank` → `frame-all-black`, `frame-mostly-blank`
-- `focus` → `set-focus-failed` (reserved; no producer yet)
+- `focus` → `focus-not-confirmed` (focus tool), `focus-not-set` (invoke setfocus)
 - `elevation` → `target-elevated`
-- `foreground` → `set-foreground-denied` (reserved; no producer yet)
+- `foreground` → `foreground-not-set`
 - `internal` → `unhandled-exception`, `uia-faulted`, `invoke-faulted`
 
 ## Warning model

--- a/docs/environment-controller.md
+++ b/docs/environment-controller.md
@@ -14,7 +14,7 @@ AI agents and scripts running on a Windows PC. It gives an agent three things:
   drive all of the above over **MCP** (Model Context Protocol) or a tiny **HTTP** floor.
 
 The agent surface is a set of new commands (`capture`, `query`, `displays`, `windows`, `find`,
-`wait-for`, `invoke`, `record`, `launch`, `drag`, and `click`) exposed as **tools over MCP/HTTP**
+`wait-for`, `invoke`, `record`, `launch`, `drag`, `click`, and `focus`) exposed as **tools over MCP/HTTP**
 so an agent can call them directly. Each tool call returns a **structured JSON result
 envelope** (`{ ok, result, … }`) instead of free text, so an agent can reason about
 success and failure uniformly.
@@ -81,7 +81,7 @@ If any one of these switches is off, the corresponding capability simply refuses
 and returns a JSON failure (for commands); it never silently proceeds.
 
 **Which gate applies where.** The agent *tools* (`capture`/`query`/`displays`/`windows`/`find`/`wait-for`/`invoke`/
-`record`/`launch`/`drag`/`click`) are gated by **both** `AgentCommandsEnabled` **and** the per-command `Enabled`
+`record`/`launch`/`drag`/`click`/`focus`) are gated by **both** `AgentCommandsEnabled` **and** the per-command `Enabled`
 flag, over **both** MCP transports (`mcec.exe --mcp` stdio and the HTTP floor): a `tools/call` for a
 command whose `Enabled=false` is refused (`error.code: command-disabled`) even when
 `AgentCommandsEnabled=true`.
@@ -161,6 +161,7 @@ case-insensitive), `handle` (HWND), `process` (process name without `.exe`),
 | `drag`     | Press → move along a path → release, dispatched **atomically** (nothing interleaves). Each endpoint is a UI Automation element (dragged from/to its centre) or an absolute screen pixel; add `path` waypoints for a curved/multi-stop drag. Covers window resize/move by chrome, sliders, marquee-select, drag-reorder. | window target (needed when an endpoint is an element); `from`/`to` each `{ by, value }` or `{ x, y }`; optional `path` `[{ x, y }, …]` |
 | `launch`   | Launch an app directly (path + args + working dir); gated. Returns pid and primary window handle/info when the window appears. Preferred over Win+R composition. | `path` (required), `arguments`, `workingDirectory`, `timeout` |
 | `click`    | Click at a point (a UI Automation element's centre or an absolute screen pixel); move+click is dispatched **atomically**. For element types `invoke` can't drive, or when you must target a pixel. Prefer `invoke` for ordinary buttons/menus. | window target (needed when `at` is an element); `at` = `{ by, value }` or `{ x, y }`; `button` (`left`\|`right`\|`middle`, default `left`); `count` (`1`\|`2`, default `1`) |
+| `focus`    | Give a window (and optionally a control in it) real **keyboard focus** so `send_command`/`chars` keystrokes reach it. Foregrounds the window, clicks the control (a real click focuses custom-drawn surfaces a bare `setfocus` misses; e.g. a MAUI GraphicsView), then **verifies**. Fails `foreground` if the window won't activate, `focus` if no control takes focus. Use before firing an app's own keyboard shortcut at a specific surface. | window target; optional `at` = `{ by, value }` or `{ x, y }` (omit to just foreground + confirm focus) |
 | `record`   | Record a window or region to an **animated GIF** over time (start/stop or a bounded one-shot). | window target, or region `x`/`y`/`width`/`height`; `action` (`start`\|`stop`\|`oneshot`), `fps`, `durationMs`, `maxWidth`, `file` |
 
 Every MCP **tool call** returns one result envelope. An agent branches on `ok` first; on
@@ -183,8 +184,8 @@ Over MCP, the transport's `isError` flag mirrors the envelope (`isError = !ok`).
 
 On failure the `error` object carries a stable, fine-grained `code`, a coarse `category` from
 the closed taxonomy (`timeout`, `ambiguous-selector`, `stale-element`, `no-target`,
-`invalid-argument`, `capture-blank`, `focus`, `elevation`, `foreground`, `internal`; `focus`
-and `foreground` are reserved for future detection and are not currently produced), a
+`invalid-argument`, `capture-blank`, `focus`, `elevation`, `foreground`, `internal`; the `focus`
+tool produces `focus` and `foreground` when it cannot confirm focus or foreground on the target), a
 human-readable `detail`, and (when available) a `lastObservation` (the last good state before
 the failure, so a failed call is debuggable without rerunning it) and a `partialResult` (the
 failing call's own partial payload, e.g. a blank capture's suspect PNG):
@@ -546,6 +547,7 @@ When connected, the server advertises these tools:
 | `drag`         | The `drag` command (atomic press → move-path → release, element or pixel endpoints). |
 | `launch`       | Direct gated app launch (returns pid + window handle).         |
 | `click`        | The `click` command (atomic click at an element centre or pixel). |
+| `focus`        | The `focus` command (foreground + click + verify keyboard focus, for keystroke targeting). |
 | `record`       | The `record` command (window/region → animated GIF over time). |
 | `send_command` | Generic raw-command passthrough; send any MCEC command line.  |
 | `session-start`  | Start a new [agent session](#agent-sessions) and return its `sessionId`. |
@@ -565,9 +567,9 @@ Agent tool calls follow a simple contract so one slow call never stalls the othe
   shared lock**; a deep `query`, a large `capture`, or a long `wait-for` never blocks another tool call,
   even one from a different session. They snapshot state (each UIA read uses its own automation instance;
   screen capture is stateless) and don't mutate the desktop.
-- **Global-input actuation serializes.** `drag` and `send_command` synthesize physical mouse/keyboard;
-  the one input stream is a shared resource, so they serialize on a single gate
-  (`AgentRuntime.InputGate`): `drag` actuates directly under the gate on its worker, while
+- **Global-input actuation serializes.** `drag`, `focus`, and `send_command` synthesize physical
+  mouse/keyboard; the one input stream is a shared resource, so they serialize on a single gate
+  (`AgentRuntime.InputGate`): `drag`/`focus` actuate directly under the gate on their worker, while
   `send_command` enqueues into the command engine, whose single dispatcher thread holds the same
   gate around each input-synthesizing queued command's `Execute` (concurrent requests can't interleave
   keystrokes/mouse). Commands that provably touch no input (`pause`, `mcec:`) run outside the gate, so a

--- a/src/Agent/AgentErrorCategory.cs
+++ b/src/Agent/AgentErrorCategory.cs
@@ -31,10 +31,10 @@ public enum AgentErrorCategory {
     /// <summary>A screenshot was produced but detected as black/blank.</summary>
     CaptureBlank,
 
-    /// <summary>An action required input focus that could not be set. RESERVED (#261): part of the
-    /// closed wire contract but not yet produced by any code path; <c>setfocus</c> dispatch is
-    /// fire-and-forget and no command verifies focus landed. Do not document recovery guidance for it
-    /// until a producer exists.</summary>
+    /// <summary>An action required keyboard focus and it could not be confirmed on the target. Produced
+    /// (#91/#270) by the <c>focus</c> tool when a window is foreground but no control took focus
+    /// (<see cref="FocusService.IsFocusInWindow"/>), and by <c>invoke setfocus</c> when the element does
+    /// not end up with <c>HasKeyboardFocus</c> (<see cref="UiaInvokeResult.FocusNotSet"/>).</summary>
     Focus,
 
     /// <summary>The target runs at a higher integrity level (UAC) than MCEC and cannot be driven.
@@ -43,9 +43,9 @@ public enum AgentErrorCategory {
     Elevation,
 
     /// <summary>An action required the target to be foreground and it could not be brought forward.
-    /// RESERVED (#261): part of the closed wire contract but not yet produced by any code path; no
-    /// agent command checks a SetForegroundWindow result. Do not document recovery guidance for it
-    /// until a producer exists.</summary>
+    /// Produced (#91/#270) by the <c>focus</c> tool when <see cref="FocusService.BringToForeground"/>
+    /// asks Windows to activate the target and <c>GetForegroundWindow</c> confirms it did not land
+    /// (foreground lock, a modal on another app, a full-screen exclusive window).</summary>
     Foreground,
 
     /// <summary>An unexpected MCEC-side fault (bug, unhandled exception) or a policy refusal the agent

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -68,7 +68,14 @@ sends any other raw MCEC command (keystrokes, single mouse actions, launch); the
 `mouse:drag,x1,y1,x2,y2[,...]` is the same atomic drag in pixels and `mouse:mtp,x,y` moves the pointer to
 an absolute screen pixel. If `invoke`/`click` by name returns `no-target`, `query` the tree: WinUI/MAUI
 labels often include emoji and ellipsis; click a control's bounds centre from `query` instead of guessing a
-plain name.
+plain name. Before you send an app's own keyboard SHORTCUT to a specific control (e.g. a MAUI GraphicsView
+that zooms on `+`/`-`, a canvas, a game surface), `focus` it first: keystrokes only reach the foreground
+window's focused control, and a bare `click` or `invoke setfocus` does not reliably focus a custom-drawn
+surface. The `focus` tool foregrounds the window, clicks the control (a real click focuses what SetFocus
+misses), and verifies; give `at` an element `{ by, value }` or pixel `{ x, y }`, or omit `at` to just
+foreground a window and confirm focus. It fails `foreground` if the window won't activate, `focus` if no
+control took focus. `invoke setfocus` is also verified now; it fails `focus` (code `focus-not-set`) when
+the element does not end up focused, which is your cue to `focus` (it clicks) or `click` the control.
 
 4. VERIFY with another `query` or `capture`; always confirm the act had the intended effect.
 
@@ -86,8 +93,12 @@ or an automationId rather than the shared name; retrying it unchanged cannot hel
 `stale-element` means the window/element went away mid-call (closed or re-rendered); re-`query`/`find`
 for a fresh handle, then retry; `elevation` means the target runs elevated (UAC) at a higher integrity
 level than MCEC and cannot be observed or driven; report it to the user, do not retry; `internal` is not
-recoverable by you; report it. `focus` and `foreground` are reserved for future detection and are never
-produced today; treat them like `internal` if one ever appears. Branch on codes and categories, never on
+recoverable by you; report it. `foreground` means Windows refused to bring the target to the foreground
+(a foreground lock, a modal on another app, or a full-screen exclusive window is holding it), so keystrokes
+would not reach it; retry the `focus` tool after whatever holds the foreground is gone, or ask the operator
+to click the target. `focus` means the window is foreground but no control took keyboard focus (it went
+nowhere, or to a sibling); `click` the exact control, or drive it with `invoke` instead of keystrokes.
+Branch on codes and categories, never on
 the wording of `error.detail` (it is human-readable and may change). `error.lastObservation`, when present, is the last good state before the failure, and
 `error.partialResult` is the failing call's OWN partial payload (e.g. a blank capture's suspect PNG).
 For a `capture`, `lastObservation` is a compact summary plus an `artifact` path where the PNG was saved; it

--- a/src/Agent/AgentNativeMethods.cs
+++ b/src/Agent/AgentNativeMethods.cs
@@ -26,6 +26,14 @@ internal static class AgentNativeMethods {
     private const string Dwmapi = "dwmapi.dll";
     private const string Gdi32 = "gdi32.dll";
     private const string Shcore = "shcore.dll";
+    private const string Kernel32 = "kernel32.dll";
+
+    /// <summary>GetAncestor gaFlags: the root window (walks parents to the top-level owner). Used to map a
+    /// focused child HWND back to its top-level window when verifying foreground/focus (#91, #270).</summary>
+    public const uint GA_ROOT = 2;
+
+    /// <summary>ShowWindow nCmdShow: restore a minimized window (a minimized target can never take focus).</summary>
+    public const int SW_RESTORE = 9;
 
     /// <summary>MonitorFromPoint flag: return the monitor nearest the point when it is on none of them.</summary>
     public const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
@@ -143,4 +151,43 @@ internal static class AgentNativeMethods {
     public static extern bool UpdateLayeredWindow(
         IntPtr hwnd, IntPtr hdcDst, ref Point pptDst, ref Size psize,
         IntPtr hdcSrc, ref Point pptSrc, int crKey, ref BlendFunction pblend, int dwFlags);
+
+    // --- Foreground/focus actuation and verification for the `focus` tool and diagnostics (#91, #270) ---
+    // SetForegroundWindow alone is throttled by Windows' foreground lock when the caller is not itself the
+    // foreground process (the common case: MCEC is a background server driving another app). The standard
+    // workaround is to AttachThreadInput the calling thread to the current foreground thread for the
+    // duration of the call, then verify the result with GetForegroundWindow rather than trusting the bool.
+
+    [DllImport(User32, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetForegroundWindow(IntPtr hwnd);
+
+    [DllImport(User32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool BringWindowToTop(IntPtr hwnd);
+
+    [DllImport(User32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, [MarshalAs(UnmanagedType.Bool)] bool fAttach);
+
+    [DllImport(User32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool IsIconic(IntPtr hwnd);
+
+    [DllImport(User32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool ShowWindow(IntPtr hwnd, int nCmdShow);
+
+    /// <summary>Walks a window's ancestors; with <see cref="GA_ROOT"/> returns its top-level owner.</summary>
+    [DllImport(User32)]
+    public static extern IntPtr GetAncestor(IntPtr hwnd, uint gaFlags);
+
+    /// <summary>Reads a GUI thread's input state; <see cref="GuiThreadInfo.HwndFocus"/> is the window with
+    /// keyboard focus in that thread, the signal the focus tool verifies against (#91, #270).</summary>
+    [DllImport(User32, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetGUIThreadInfo(uint idThread, ref GuiThreadInfo lpgui);
+
+    [DllImport(Kernel32)]
+    public static extern uint GetCurrentThreadId();
 }

--- a/src/Agent/FocusService.cs
+++ b/src/Agent/FocusService.cs
@@ -1,0 +1,155 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace MCEControl;
+
+/// <summary>
+/// Verified foreground/focus primitives for the <c>focus</c> agent tool and the focus/foreground
+/// diagnostics (#91, #270). Every operation here VERIFIES its result against the OS rather than trusting
+/// a Win32 bool: <see cref="BringToForeground"/> confirms with <c>GetForegroundWindow</c> after the
+/// AttachThreadInput dance, and <see cref="IsFocusInWindow"/> reads the target GUI thread's
+/// <c>GUITHREADINFO</c> to prove keyboard focus actually landed. The verified booleans are what let a
+/// command emit the closed taxonomy's <c>foreground</c> and <c>focus</c> categories honestly (they were
+/// dead before; the taxonomy and the connect-time guidance were written ahead of any producer).
+///
+/// <para>These run on the calling thread (the MCP worker / dispatcher, never a WinForms message loop):
+/// SetForegroundWindow and AttachThreadInput from a background thread are the documented pattern for a
+/// non-foreground process (MCEC is a background server driving another app), and reading GUITHREADINFO is
+/// thread-agnostic.</para>
+/// </summary>
+public static class FocusService {
+    /// <summary>How long <see cref="BringToForeground"/> re-checks <c>GetForegroundWindow</c> after asking:
+    /// the foreground switch is asynchronous, so a single immediate read can miss a change that lands a few
+    /// milliseconds later. Kept short so a genuinely refused activation still fails fast.</summary>
+    private const int ForegroundConfirmTimeoutMs = 300;
+    private const int ForegroundPollMs = 30;
+
+    /// <summary>How long <see cref="ConfirmFocusInWindow"/> re-checks after a click/SetFocus: the focus
+    /// change a click triggers is delivered through the target's message queue, so it can land a few
+    /// milliseconds after the synthesized input returns.</summary>
+    private const int FocusConfirmTimeoutMs = 250;
+
+    /// <summary>
+    /// Brings <paramref name="hwnd"/>'s top-level window to the foreground and RETURNS WHETHER IT LANDED
+    /// (verified with <c>GetForegroundWindow</c>), not whether the API returned true. Restores the window
+    /// first if minimized (a minimized window can never hold focus). Uses AttachThreadInput to defeat the
+    /// foreground lock Windows applies when the caller is not already the foreground process. A false
+    /// return is the detectable <c>foreground</c> case: the OS refused to activate the target (foreground
+    /// lock, a modal on another app, a full-screen exclusive window).
+    /// </summary>
+    public static bool BringToForeground(IntPtr hwnd) {
+        if (hwnd == IntPtr.Zero) {
+            return false;
+        }
+        IntPtr targetRoot = RootOf(hwnd);
+        if (IsForeground(targetRoot)) {
+            return true;
+        }
+
+        IntPtr fg = AgentNativeMethods.GetForegroundWindow();
+        uint thisThread = AgentNativeMethods.GetCurrentThreadId();
+        uint fgThread = fg == IntPtr.Zero ? 0 : AgentNativeMethods.GetWindowThreadProcessId(fg, out _);
+        uint targetThread = AgentNativeMethods.GetWindowThreadProcessId(hwnd, out _);
+
+        // Attach our input queue to the outgoing foreground thread (and the target's) for the duration of
+        // the call so SetForegroundWindow is honoured instead of throttled to a taskbar flash.
+        bool attachedFg = fgThread != 0 && fgThread != thisThread && AgentNativeMethods.AttachThreadInput(thisThread, fgThread, true);
+        bool attachedTarget = targetThread != 0 && targetThread != thisThread && targetThread != fgThread
+            && AgentNativeMethods.AttachThreadInput(thisThread, targetThread, true);
+        try {
+            if (AgentNativeMethods.IsIconic(hwnd)) {
+                AgentNativeMethods.ShowWindow(hwnd, AgentNativeMethods.SW_RESTORE);
+            }
+            AgentNativeMethods.BringWindowToTop(hwnd);
+            AgentNativeMethods.SetForegroundWindow(hwnd);
+        }
+        finally {
+            if (attachedTarget) {
+                AgentNativeMethods.AttachThreadInput(thisThread, targetThread, false);
+            }
+            if (attachedFg) {
+                AgentNativeMethods.AttachThreadInput(thisThread, fgThread, false);
+            }
+        }
+
+        return ConfirmForeground(targetRoot);
+    }
+
+    /// <summary>
+    /// True when keyboard focus currently sits on <paramref name="hwnd"/> or any descendant of its
+    /// top-level window, read from the target GUI thread's <c>GUITHREADINFO</c>. This is the verification
+    /// the focus tool gates on: a zero focus window (the thread holds no focus at all) or a focus window
+    /// under a DIFFERENT top-level owner both mean focus did NOT land where we drove it; the detectable
+    /// <c>focus</c> case.
+    /// </summary>
+    public static bool IsFocusInWindow(IntPtr hwnd) {
+        if (hwnd == IntPtr.Zero) {
+            return false;
+        }
+        IntPtr focus = FocusedWindow(hwnd);
+        return focus != IntPtr.Zero && RootOf(focus) == RootOf(hwnd);
+    }
+
+    /// <summary>Polls <see cref="IsFocusInWindow"/> briefly, since the focus change a click triggers is
+    /// delivered asynchronously through the target's message queue after the synthesized input returns.</summary>
+    public static bool ConfirmFocusInWindow(IntPtr hwnd) {
+        Stopwatch sw = Stopwatch.StartNew();
+        while (true) {
+            if (IsFocusInWindow(hwnd)) {
+                return true;
+            }
+            if (sw.ElapsedMilliseconds >= FocusConfirmTimeoutMs) {
+                return false;
+            }
+            Thread.Sleep(ForegroundPollMs);
+        }
+    }
+
+    /// <summary>
+    /// The window with keyboard focus in <paramref name="hwnd"/>'s GUI thread, or <see cref="IntPtr.Zero"/>
+    /// when the thread has no focus (typically because it is not the foreground thread) or the query fails.
+    /// Reported in the focus tool's result so an agent can see exactly which control took focus.
+    /// </summary>
+    public static IntPtr FocusedWindow(IntPtr hwnd) {
+        if (hwnd == IntPtr.Zero) {
+            return IntPtr.Zero;
+        }
+        uint tid = AgentNativeMethods.GetWindowThreadProcessId(hwnd, out _);
+        if (tid == 0) {
+            return IntPtr.Zero;
+        }
+        GuiThreadInfo gti = new() { Cb = Marshal.SizeOf<GuiThreadInfo>() };
+        return AgentNativeMethods.GetGUIThreadInfo(tid, ref gti) ? gti.HwndFocus : IntPtr.Zero;
+    }
+
+    /// <summary>The top-level owner of <paramref name="hwnd"/> (GA_ROOT), or the handle itself when it has none.</summary>
+    public static IntPtr RootOf(IntPtr hwnd) {
+        if (hwnd == IntPtr.Zero) {
+            return IntPtr.Zero;
+        }
+        IntPtr root = AgentNativeMethods.GetAncestor(hwnd, AgentNativeMethods.GA_ROOT);
+        return root == IntPtr.Zero ? hwnd : root;
+    }
+
+    /// <summary>Polls <c>GetForegroundWindow</c> briefly, since the foreground switch is asynchronous.</summary>
+    private static bool ConfirmForeground(IntPtr targetRoot) {
+        Stopwatch sw = Stopwatch.StartNew();
+        while (true) {
+            if (IsForeground(targetRoot)) {
+                return true;
+            }
+            if (sw.ElapsedMilliseconds >= ForegroundConfirmTimeoutMs) {
+                return false;
+            }
+            Thread.Sleep(ForegroundPollMs);
+        }
+    }
+
+    private static bool IsForeground(IntPtr targetRoot) =>
+        targetRoot != IntPtr.Zero && RootOf(AgentNativeMethods.GetForegroundWindow()) == targetRoot;
+}

--- a/src/Agent/GuiThreadInfo.cs
+++ b/src/Agent/GuiThreadInfo.cs
@@ -1,0 +1,28 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace MCEControl;
+
+/// <summary>
+/// Win32 <c>GUITHREADINFO</c>: a snapshot of one GUI thread's input state, filled by
+/// <see cref="AgentNativeMethods.GetGUIThreadInfo"/>. The focus tool (#91, #270) reads
+/// <see cref="HwndFocus"/> to VERIFY that keyboard focus actually landed in the target window after it
+/// foregrounded and clicked it; a zero or foreign focus window is the detectable <c>focus</c> failure
+/// the closed taxonomy reserves a category for. <see cref="Cb"/> must be set to the struct size before
+/// the call or the API rejects it.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct GuiThreadInfo {
+    public int Cb;
+    public int Flags;
+    public IntPtr HwndActive;
+    public IntPtr HwndFocus;
+    public IntPtr HwndCapture;
+    public IntPtr HwndMenuOwner;
+    public IntPtr HwndMoveSize;
+    public IntPtr HwndCaret;
+    public NativeRect RcCaret;
+}

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -169,6 +169,18 @@ public static class ToolCatalog {
             Tersify = args => $"click {CommandTersifier.Endpoint(args, "at")}",
             ProvisionedByDefault = true,
         },
+        new() {
+            Name = "focus",
+            BuildSchema = BuildFocusSchema,
+            BuildCommand = BuildFocusCommand,
+            CreateCommandInstance = () => new FocusCommand(),
+            Tersify = args => $"focus {CommandTersifier.Endpoint(args, "at")}",
+            // Like drag, focus synthesizes a real click as part of a compound gesture (foreground →
+            // click → SetFocus → verify); serialize it on the input gate so that gesture cannot
+            // interleave with queue-driven input (send_command/legacy pipeline) mid-sequence (#113).
+            SerializesOnInput = true,
+            ProvisionedByDefault = true,
+        },
         new ToolDescriptor {
             Name = "clipboard",
             BuildSchema = BuildClipboardSchema,
@@ -325,6 +337,14 @@ public static class ToolCatalog {
             clickProps, ["at"]);
     }
 
+    private static JsonObject BuildFocusSchema() {
+        JsonObject focusProps = WindowTargetProps();
+        focusProps["at"] = EndpointSchema("Optional control to focus: an element ({ by, value }) in the target window (clicked at its centre) or an absolute screen pixel ({ x, y }). Omit to just bring the window to the foreground and confirm keyboard focus is in it.");
+        return Tool("focus",
+            "Give a window (and optionally a control in it) real keyboard focus so send_command/chars keystrokes reach it. Foregrounds the window, clicks the control (a real click focuses surfaces a bare UIA setfocus misses; e.g. a MAUI GraphicsView), then verifies. Fails with category 'foreground' if the window won't activate, 'focus' if no control took focus. Use before sending app keyboard shortcuts to a custom-drawn surface.",
+            focusProps, []);
+    }
+
     private static JsonObject BuildClipboardSchema() {
         JsonObject clipboardProps = new() {
             ["action"] = PropSchema("string", "set | get"),
@@ -467,6 +487,27 @@ public static class ToolCatalog {
             Y = Int(at, "y"),
             Button = Str(args, "button") ?? "left",
             Count = count > 0 ? count : 1,
+        };
+    }
+
+    /// <summary>Maps the focus tool's optional <c>at</c> endpoint onto a <see cref="FocusCommand"/>. An
+    /// endpoint with a pixel (<c>x</c>/<c>y</c> present) and no <c>value</c> sets <c>PointSpecified</c> so a
+    /// literal (0,0) is distinguished from "no endpoint" (a bare window focus).</summary>
+    private static FocusCommand BuildFocusCommand(JsonObject args) {
+        JsonObject at = args["at"] as JsonObject ?? [];
+        bool hasElement = !string.IsNullOrEmpty(Str(at, "value"));
+        bool hasPixel = !hasElement && (at.ContainsKey("x") || at.ContainsKey("y"));
+        return new FocusCommand {
+            Window = Str(args, "window")!,
+            Handle = Long(args, "handle"),
+            Process = Str(args, "process")!,
+            ClassName = Str(args, "className")!,
+            Foreground = Bool(args, "foreground"),
+            By = Str(at, "by") ?? "name",
+            Value = Str(at, "value")!,
+            X = Int(at, "x"),
+            Y = Int(at, "y"),
+            PointSpecified = hasPixel,
         };
     }
 

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -496,7 +496,10 @@ public static class ToolCatalog {
     private static FocusCommand BuildFocusCommand(JsonObject args) {
         JsonObject at = args["at"] as JsonObject ?? [];
         bool hasElement = !string.IsNullOrEmpty(Str(at, "value"));
-        bool hasPixel = !hasElement && (at.ContainsKey("x") || at.ContainsKey("y"));
+        // Require BOTH coordinates for a pixel endpoint. The executor's FocusArgsError already rejects a
+        // partial pixel with invalid-argument; this is defense-in-depth for a direct build (tests), so a
+        // half-specified endpoint degrades to a bare window focus rather than a click at (x, 0).
+        bool hasPixel = !hasElement && at.ContainsKey("x") && at.ContainsKey("y");
         return new FocusCommand {
             Window = Str(args, "window")!,
             Handle = Long(args, "handle"),

--- a/src/Agent/UiaInvokeResult.cs
+++ b/src/Agent/UiaInvokeResult.cs
@@ -45,4 +45,10 @@ public enum UiaInvokeResult {
     /// <summary>UIA threw while attaching, finding, or dispatching (COM fault not classified as stale
     /// or elevation). Not agent-recoverable beyond re-observing the target.</summary>
     Faulted,
+
+    /// <summary>A <c>setfocus</c> dispatched but the element did NOT end up with keyboard focus
+    /// (verified via <c>HasKeyboardFocus</c>, #91/#270): e.g. a container that redirects focus, or a
+    /// surface a bare UIA SetFocus cannot focus. Maps to the <c>focus</c> category. Recovery: use the
+    /// <c>focus</c> tool (it clicks to place focus first), or <c>click</c> the control directly.</summary>
+    FocusNotSet,
 }

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -167,11 +167,17 @@ public static class UiaService {
             // caller is a message-loop-free MTA thread (asserted), and UIA3 client objects are
             // free-threaded, so driving the worker-resolved element from here is safe.
             AssertNotOnMessageLoopThread();
+            // setfocus is VERIFIED (#91/#270), not fire-and-forget: it dispatches then confirms the
+            // element actually took keyboard focus, so a container that redirects focus (or a surface a
+            // bare SetFocus cannot focus) reports the closed taxonomy's `focus` category instead of a
+            // false success. The other actions have no such post-condition to check.
+            if (action.ToLowerInvariant() == "setfocus") {
+                return InvokeSetFocusVerified(el);
+            }
             bool dispatched = action.ToLowerInvariant() switch {
                 "invoke" => InvokeDefault(el),
                 "toggle" => InvokeToggle(el),
                 "setvalue" => InvokeSetValue(el, text),
-                "setfocus" => InvokeSetFocus(el),
                 "expand" => InvokeExpand(el),
                 "collapse" => InvokeCollapse(el),
                 "select" => InvokeSelect(el),
@@ -436,9 +442,45 @@ public static class UiaService {
         return true;
     }
 
-    private static bool InvokeSetFocus(AutomationElement el) {
+    /// <summary>How long <see cref="InvokeSetFocusVerified"/> re-reads HasKeyboardFocus after Focus():
+    /// UIA focus lands through the provider's message pump, so the property can lag the call by a few ms.
+    /// Bounded well under <see cref="InvokeFindTimeoutMs"/> so the verified setfocus never approaches the
+    /// modal grace.</summary>
+    private const int FocusConfirmTimeoutMs = 150;
+    private const int FocusConfirmPollMs = 30;
+
+    /// <summary>
+    /// Dispatches <c>setfocus</c> and VERIFIES it (#91/#270): after <c>Focus()</c>, re-reads
+    /// <c>HasKeyboardFocus</c> briefly (it lands asynchronously). Returns <see cref="UiaInvokeResult.Ok"/>
+    /// once the element holds focus, <see cref="UiaInvokeResult.FocusNotSet"/> if it demonstrably did not
+    /// (e.g. a container that redirects focus to a child, or a surface a bare SetFocus cannot focus). When
+    /// the property is unreadable it does NOT manufacture a failure; it assumes success, because a false
+    /// <c>focus</c> error is worse than a missed one and the <c>focus</c> tool is the robust path.
+    /// </summary>
+    private static UiaInvokeResult InvokeSetFocusVerified(AutomationElement el) {
         el.Focus();
-        return true;
+        Stopwatch sw = Stopwatch.StartNew();
+        while (true) {
+            bool? hasFocus = TryReadHasKeyboardFocus(el);
+            if (hasFocus != false) {
+                // true (confirmed) or null (unreadable; assume dispatched) -> Ok.
+                return UiaInvokeResult.Ok;
+            }
+            if (sw.ElapsedMilliseconds >= FocusConfirmTimeoutMs) {
+                return UiaInvokeResult.FocusNotSet;
+            }
+            Thread.Sleep(FocusConfirmPollMs);
+        }
+    }
+
+    /// <summary>Reads <c>HasKeyboardFocus</c> defensively; null when the property is unavailable (stale node).</summary>
+    private static bool? TryReadHasKeyboardFocus(AutomationElement el) {
+        try {
+            return el.Properties.HasKeyboardFocus.ValueOrDefault;
+        }
+        catch (COMException) {
+            return null;
+        }
     }
 
     private static bool InvokeExpand(AutomationElement el) {

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -124,6 +124,41 @@ public static class UiaService {
     }
 
     /// <summary>
+    /// Whether the single element matching the selector currently holds KEYBOARD FOCUS (#272 CR), read
+    /// from UIA's <c>HasKeyboardFocus</c> so it is precise even for windowless (WinUI/MAUI) controls that
+    /// a native focus HWND cannot distinguish (they are all the one top-level window). Polls briefly
+    /// because focus lands asynchronously. Returns <see langword="true"/>/<see langword="false"/> when the
+    /// element is found and the property is readable, or <see langword="null"/> ("unknown") when the
+    /// selector matches none or many, the property is unavailable, or UIA faults. A caller treats null as
+    /// "can't tell" (fall back to a window-level check), never as a confirmation; this is what lets the
+    /// <c>focus</c> tool verify the REQUESTED control took focus rather than a sibling that merely shares
+    /// its top-level window.
+    /// </summary>
+    public static bool? ElementHasKeyboardFocus(IntPtr hwnd, string by, string value) {
+        if (hwnd == IntPtr.Zero) {
+            return null;
+        }
+        try {
+            Stopwatch sw = Stopwatch.StartNew();
+            while (true) {
+                bool? has = RunOnWorker(automation => {
+                    AutomationElement root = automation.FromHandle(hwnd);
+                    AutomationElement[] matches = root.FindAllDescendants(BuildCondition(by, value));
+                    return matches.Length == 1 ? TryReadHasKeyboardFocus(matches[0]) : null;
+                });
+                if (has == true || sw.ElapsedMilliseconds >= FocusConfirmTimeoutMs) {
+                    return has;
+                }
+                Thread.Sleep(FocusConfirmPollMs);
+            }
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Error($"UiaService.ElementHasKeyboardFocus failed: {e.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Finds an element (a short <see cref="InvokeFindTimeoutMs"/> lookup; invoke fast-fails rather
     /// than waiting; see that constant) and dispatches <paramref name="action"/>
     /// (<c>invoke</c>/<c>toggle</c>/<c>setvalue</c>/<c>setfocus</c>/<c>expand</c>/<c>collapse</c>/<c>select</c>).

--- a/src/Commands/CommandRegistry.cs
+++ b/src/Commands/CommandRegistry.cs
@@ -50,6 +50,7 @@ public static class CommandRegistry {
         new("drag", typeof(DragCommand), () => DragCommand.BuiltInCommands),
         new("launch", typeof(LaunchCommand), () => LaunchCommand.BuiltInCommands),
         new("click", typeof(ClickCommand), () => ClickCommand.BuiltInCommands),
+        new("focus", typeof(FocusCommand), () => FocusCommand.BuiltInCommands),
         new("displays", typeof(DisplaysCommand), () => DisplaysCommand.BuiltInCommands),
         new("clipboard", typeof(ClipboardCommand), () => ClipboardCommand.BuiltInCommands),
         new("record", typeof(RecordCommand), () => RecordCommand.BuiltInCommands),

--- a/src/Commands/FocusCommand.cs
+++ b/src/Commands/FocusCommand.cs
@@ -19,8 +19,11 @@ namespace MCEControl;
 /// <c>foreground</c> and <c>focus</c> categories real producers (#91):
 /// <list type="number">
 ///   <item>bring the window to the foreground and confirm it (<see cref="FocusService.BringToForeground"/>) — else <c>foreground</c>;</item>
-///   <item>when an endpoint is given, click it (a real WM_LBUTTONDOWN/UP) to place focus on the control under the point, then reinforce with a UIA <c>SetFocus</c>;</item>
-///   <item>confirm keyboard focus actually landed in the target window (<see cref="FocusService.IsFocusInWindow"/>) — else <c>focus</c>.</item>
+///   <item>when an endpoint is given, click it (a real WM_LBUTTONDOWN/UP) to place focus on the control under the point;</item>
+///   <item>confirm focus landed WHERE ASKED — for an element endpoint the resolved element must hold
+///   <c>HasKeyboardFocus</c> (reinforced with a UIA <c>SetFocus</c> only if the click did not focus it,
+///   so a good click-focus is not misrouted to a sibling); for a pixel/window focus, that focus is
+///   somewhere in the window (<see cref="FocusService.IsFocusInWindow"/>) — else <c>focus</c>.</item>
 /// </list>
 /// Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
 /// <see cref="AgentCommand"/>). Disabled by default (security).
@@ -61,18 +64,19 @@ public class FocusCommand : WindowTargetingAgentCommand {
         }
 
         // 3. Click to place focus on the control under the point (a real click focuses a surface a bare
-        // UIA SetFocus can miss or misroute; #270), then reinforce with UIA SetFocus when we have an
-        // element. The SetFocus is best-effort: a graphics view may take focus from the click yet expose
-        // no focusable UIA pattern, so its outcome does not gate success; step 4 is the real check.
+        // UIA SetFocus can miss or misroute; #270).
         if (point is { } p) {
             MouseCommand.PerformClick(p, "left", 1);
-            if (element is not null) {
-                UiaService.Invoke(hwnd, EffectiveBy, Value, "setfocus", null);
-            }
         }
 
-        // 4. Confirm keyboard focus actually landed in the target window.
-        if (!FocusService.ConfirmFocusInWindow(hwnd)) {
+        // 4. Confirm focus landed WHERE IT WAS ASKED TO. For an element endpoint that means the RESOLVED
+        // element must hold keyboard focus (#272 CR): confirming only that focus is somewhere in the
+        // top-level window would pass even if it stayed on a sibling. For a pixel/window focus no specific
+        // control was named, so a window-level confirmation is all we can honestly check.
+        bool confirmed = element is not null
+            ? ConfirmElementFocus(hwnd)
+            : FocusService.ConfirmFocusInWindow(hwnd);
+        if (!confirmed) {
             return FocusFailure(target);
         }
 
@@ -80,6 +84,23 @@ public class FocusCommand : WindowTargetingAgentCommand {
     }
 
     private string EffectiveBy => string.IsNullOrEmpty(By) ? "name" : By;
+
+    /// <summary>
+    /// Confirms the resolved element holds keyboard focus, reinforcing with a UIA <c>SetFocus</c> only if
+    /// the click did not already focus it; so a good click-focus is never disturbed by a SetFocus that
+    /// could misroute to a sibling (#270/#272). When UIA cannot read focus at all (windowless/unreadable,
+    /// <see langword="null"/>), falls back to the window-level native check rather than manufacturing a
+    /// failure; a definitive "not focused" (<see langword="false"/>) is a real <c>focus</c> failure.
+    /// </summary>
+    private bool ConfirmElementFocus(IntPtr hwnd) {
+        if (UiaService.ElementHasKeyboardFocus(hwnd, EffectiveBy, Value) == true) {
+            return true;
+        }
+        // The click did not focus it (or focus was unreadable); reinforce with UIA SetFocus, then re-check.
+        UiaService.Invoke(hwnd, EffectiveBy, Value, "setfocus", null);
+        bool? has = UiaService.ElementHasKeyboardFocus(hwnd, EffectiveBy, Value);
+        return has == true || (has is null && FocusService.IsFocusInWindow(hwnd));
+    }
 
     /// <summary>
     /// Resolves the optional endpoint: an element (<see cref="Value"/>, clicked at its centre), an

--- a/src/Commands/FocusCommand.cs
+++ b/src/Commands/FocusCommand.cs
@@ -1,0 +1,143 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Xml.Serialization;
+
+namespace MCEControl;
+
+/// <summary>
+/// Agent actuation command: give a target window (and, optionally, a specific control in it) real
+/// KEYBOARD FOCUS, so subsequent keystrokes (<c>send_command</c> VK codes, <c>chars</c>) actually reach
+/// it (#270). Keyboard input only ever goes to the foreground window's focused control, and neither a
+/// bare click nor a bare UIA <c>SetFocus</c> reliably lands focus on a custom-drawn surface (a MAUI
+/// GraphicsView, a game canvas): a UIA <c>SetFocus</c> can misroute to a sibling ComboBox, and a click
+/// only focuses if the window is foreground at that pixel. This command does the whole gesture the way a
+/// human does and VERIFIES each step, which is also what finally makes the closed taxonomy's
+/// <c>foreground</c> and <c>focus</c> categories real producers (#91):
+/// <list type="number">
+///   <item>bring the window to the foreground and confirm it (<see cref="FocusService.BringToForeground"/>) — else <c>foreground</c>;</item>
+///   <item>when an endpoint is given, click it (a real WM_LBUTTONDOWN/UP) to place focus on the control under the point, then reinforce with a UIA <c>SetFocus</c>;</item>
+///   <item>confirm keyboard focus actually landed in the target window (<see cref="FocusService.IsFocusInWindow"/>) — else <c>focus</c>.</item>
+/// </list>
+/// Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
+/// <see cref="AgentCommand"/>). Disabled by default (security).
+/// </summary>
+public class FocusCommand : WindowTargetingAgentCommand {
+    [XmlAttribute("by")] public string By { get; set; } = "name";
+    [XmlAttribute("value")] public string Value { get; set; } = null!;
+    [XmlAttribute("x")] public int X { get; set; }
+    [XmlAttribute("y")] public int Y { get; set; }
+
+    /// <summary>True when the caller gave an absolute-pixel endpoint (<see cref="X"/>/<see cref="Y"/>) rather
+    /// than an element or a bare window; lets a literal <c>(0,0)</c> pixel be distinguished from "no point".</summary>
+    [XmlAttribute("point")] public bool PointSpecified { get; set; }
+
+    // Wait a beat for an element endpoint to appear before failing, matching click/drag's
+    // "wait a beat, then fail cleanly" rather than blocking indefinitely.
+    private const int FindTimeoutMs = 3000;
+
+    public static List<Command> BuiltInCommands {
+        get => [new FocusCommand { Cmd = "focus" }];
+    }
+
+    protected override string AuditDetails() =>
+        $"focus (by={By} value='{Value}' point={(PointSpecified ? $"{X},{Y}" : "-")}) window handle={Handle} title='{Window}' process='{Process}'";
+
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
+        IntPtr hwnd = new IntPtr(target!.Handle);
+
+        // 1. Foreground first (verified): keyboard input only reaches the foreground window, and a click
+        // lands on the target only if it is on top at that pixel.
+        if (!FocusService.BringToForeground(hwnd)) {
+            return ForegroundFailure();
+        }
+
+        // 2. Resolve the endpoint to click (element centre or an explicit pixel), if any was given.
+        if (!TryResolveEndpoint(hwnd, out UiaElementInfo? element, out (int X, int Y)? point, out CommandResult? failure)) {
+            return failure!;
+        }
+
+        // 3. Click to place focus on the control under the point (a real click focuses a surface a bare
+        // UIA SetFocus can miss or misroute; #270), then reinforce with UIA SetFocus when we have an
+        // element. The SetFocus is best-effort: a graphics view may take focus from the click yet expose
+        // no focusable UIA pattern, so its outcome does not gate success; step 4 is the real check.
+        if (point is { } p) {
+            MouseCommand.PerformClick(p, "left", 1);
+            if (element is not null) {
+                UiaService.Invoke(hwnd, EffectiveBy, Value, "setfocus", null);
+            }
+        }
+
+        // 4. Confirm keyboard focus actually landed in the target window.
+        if (!FocusService.ConfirmFocusInWindow(hwnd)) {
+            return FocusFailure(target);
+        }
+
+        return Success(target, element, point);
+    }
+
+    private string EffectiveBy => string.IsNullOrEmpty(By) ? "name" : By;
+
+    /// <summary>
+    /// Resolves the optional endpoint: an element (<see cref="Value"/>, clicked at its centre), an
+    /// explicit pixel (<see cref="PointSpecified"/>), or nothing (a bare window focus). Returns false with
+    /// a structured <paramref name="failure"/> when an element endpoint can't be resolved (not found,
+    /// ambiguous, stale window, elevated target; #261).
+    /// </summary>
+    private bool TryResolveEndpoint(IntPtr hwnd, out UiaElementInfo? element, out (int X, int Y)? point, out CommandResult? failure) {
+        element = null;
+        point = null;
+        failure = null;
+        if (!string.IsNullOrEmpty(Value)) {
+            UiaFindOutcome outcome = UiaService.Find(hwnd, EffectiveBy, Value, FindTimeoutMs);
+            failure = UiaFindFailureFor(Cmd, EffectiveBy, Value, outcome);
+            if (failure is null && outcome.Element is null) {
+                failure = CommandResult.Fail(Cmd, $"element not found ({EffectiveBy}='{Value}')", "element-not-found", "no-target");
+            }
+            if (failure is not null) {
+                return false;
+            }
+            element = outcome.Element!;
+            point = (element.X + (element.Width / 2), element.Y + (element.Height / 2));
+            return true;
+        }
+        if (PointSpecified) {
+            point = (X, Y);
+        }
+        return true;
+    }
+
+    private CommandResult Success(WindowInfo target, UiaElementInfo? element, (int X, int Y)? point) {
+        JsonObject data = new() {
+            ["focused"] = true,
+            ["window"] = target.ToJsonObject(),
+            ["focusHandle"] = FocusService.FocusedWindow(new IntPtr(target.Handle)).ToInt64(),
+        };
+        if (element is not null) {
+            data["element"] = element.ToJsonObject();
+        }
+        if (point is { } p) {
+            data["at"] = new JsonArray { p.X, p.Y };
+        }
+        return CommandResult.Ok(Cmd, data);
+    }
+
+    /// <summary>The <c>foreground</c> failure: Windows refused to activate the target (#91). Internal so
+    /// tests can pin the code/category without a live desktop.</summary>
+    internal CommandResult ForegroundFailure() => CommandResult.Fail(Cmd,
+        "Could not bring the target window to the foreground; Windows refused the activation (foreground lock, " +
+        "a modal on another app, or a full-screen exclusive window is holding it). Keyboard input will not reach " +
+        "the target. Retry after whatever holds the foreground is dismissed, or ask the operator to click the target.",
+        "foreground-not-set", "foreground");
+
+    /// <summary>The <c>focus</c> failure: the window is foreground but no control in it took keyboard focus
+    /// (#91, #270). Carries the resolved window as lastObservation. Internal so tests can pin the mapping.</summary>
+    internal CommandResult FocusFailure(WindowInfo target) => CommandResult.Fail(Cmd,
+        "The target window is foreground but keyboard focus did not land in it (no focusable control took focus, " +
+        "or focus went to a sibling control). App keyboard shortcuts may not reach the intended control. Try a " +
+        "`click` on the exact control first, or drive it with `invoke` instead of keystrokes.",
+        "focus-not-confirmed", "focus", target.ToJsonObject());
+}

--- a/src/Commands/InvokeCommand.cs
+++ b/src/Commands/InvokeCommand.cs
@@ -73,6 +73,11 @@ public class InvokeCommand : WindowTargetingAgentCommand {
             "UI Automation was denied access to the target; it runs at a higher integrity level (UAC) than MCEC " +
             "and cannot be driven. Surface this to the operator; do not retry.",
             "target-elevated", "elevation"),
+        UiaInvokeResult.FocusNotSet => CommandResult.Fail(Cmd,
+            $"setfocus dispatched but the element ({By}='{Value}') did not take keyboard focus (it may redirect " +
+            "focus to a child, or be a surface a bare SetFocus cannot focus). Use the `focus` tool (it clicks to " +
+            "place focus first) or `click` the control directly before sending keystrokes.",
+            "focus-not-set", "focus"),
         _ => CommandResult.Fail(Cmd,
             "Invoke faulted: UI Automation threw while attaching to or driving the target (it may have closed mid-call). Re-observe the window.",
             "invoke-faulted", "internal"),

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -185,6 +185,9 @@ public sealed class AgentToolExecutor {
             if (name == "click" && ClickArgsError(args) is { } clickError) {
                 return ToolError(clickError, "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
             }
+            if (name == "focus" && FocusArgsError(args) is { } focusError) {
+                return ToolError(focusError, "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
+            }
             return RunAgentCommand(name, args, session);
         }
 
@@ -280,6 +283,37 @@ public sealed class AgentToolExecutor {
         bool hasY = at["y"] is JsonValue vy && vy.TryGetValue(out int _);
         if (!hasElement && !(hasX && hasY)) {
             return "click 'at' needs an element 'value' or both 'x' and 'y' pixel coordinates.";
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Validates the <c>focus</c> tool's optional <c>at</c> argument (#272 CR). Unlike <c>click</c>, focus
+    /// allows NO endpoint (a bare window focus). But a PRESENT endpoint must be well-formed: an element
+    /// (<c>value</c> set) OR a full pixel (<c>x</c> and <c>y</c> both present AND integer). A partial pixel
+    /// (`{ x: 400 }`) or a non-integer coordinate would otherwise default the missing field to 0 and
+    /// synthesize a real click at a bogus point. Returns a human-readable error, or <c>null</c> when the
+    /// arguments are acceptable. Mirrors <see cref="ClickArgsError"/>.
+    /// </summary>
+    private static string? FocusArgsError(JsonObject args) {
+        if (!args.ContainsKey("at") || args["at"] is null) {
+            return null; // no endpoint: a valid window-only focus (foreground + confirm).
+        }
+        if (args["at"] is not JsonObject at) {
+            return "focus 'at' must be an object: an element { by?, value } or a pixel { x, y }; omit 'at' to focus just the window.";
+        }
+        bool hasElement = !string.IsNullOrEmpty(Str(at, "value"));
+        if (hasElement) {
+            return null;
+        }
+        bool mentionsPixel = at.ContainsKey("x") || at.ContainsKey("y");
+        bool hasX = at["x"] is JsonValue vx && vx.TryGetValue(out int _);
+        bool hasY = at["y"] is JsonValue vy && vy.TryGetValue(out int _);
+        if (mentionsPixel && !(hasX && hasY)) {
+            return "focus 'at' pixel endpoint needs both integer 'x' and 'y' (or an element 'value', or omit 'at' to focus just the window).";
+        }
+        if (!mentionsPixel) {
+            return "focus 'at' must be an element { by?, value } or a pixel { x, y }; omit 'at' to focus just the window.";
         }
         return null;
     }

--- a/tests/MCEControl.xUnit/Agent/FocusServiceTests.cs
+++ b/tests/MCEControl.xUnit/Agent/FocusServiceTests.cs
@@ -1,0 +1,42 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+/// <summary>
+/// Guard-path tests for <see cref="FocusService"/> (#91/#270). The live foreground/focus behavior needs
+/// real windows (like <see cref="UiaService"/>'s live paths, it is not unit-tested); these pin the
+/// zero-handle guards so a bad handle can never sail into a P/Invoke and returns the honest negative that
+/// makes a command emit the <c>foreground</c>/<c>focus</c> category instead of a false success.
+/// </summary>
+public class FocusServiceTests {
+    [Fact]
+    public void BringToForeground_ZeroHandle_ReturnsFalse() {
+        Assert.False(FocusService.BringToForeground(IntPtr.Zero));
+    }
+
+    [Fact]
+    public void IsFocusInWindow_ZeroHandle_ReturnsFalse() {
+        Assert.False(FocusService.IsFocusInWindow(IntPtr.Zero));
+    }
+
+    [Fact]
+    public void FocusedWindow_ZeroHandle_ReturnsZero() {
+        Assert.Equal(IntPtr.Zero, FocusService.FocusedWindow(IntPtr.Zero));
+    }
+
+    [Fact]
+    public void RootOf_ZeroHandle_ReturnsZero() {
+        Assert.Equal(IntPtr.Zero, FocusService.RootOf(IntPtr.Zero));
+    }
+
+    [Fact]
+    public void ConfirmFocusInWindow_ZeroHandle_ReturnsFalse() {
+        // A zero handle can never hold focus; the bounded confirm poll must give up and report false.
+        Assert.False(FocusService.ConfirmFocusInWindow(IntPtr.Zero));
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
+++ b/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
@@ -16,9 +16,9 @@ namespace MCEControl.xUnit.Agent;
 /// </summary>
 [Collection("AgentSerial")]
 public class ToolCatalogTests {
-    /// <summary>The twelve gated agent tools, in the order tools/list advertises them. Pinned by name.</summary>
+    /// <summary>The thirteen gated agent tools, in the order tools/list advertises them. Pinned by name.</summary>
     private static readonly string[] _catalogNames = [
-        "capture", "query", "displays", "windows", "find", "wait-for", "invoke", "drag", "click", "clipboard", "record", "launch",
+        "capture", "query", "displays", "windows", "find", "wait-for", "invoke", "drag", "click", "focus", "clipboard", "record", "launch",
     ];
 
     /// <summary>The meta-tools that are deliberately NOT in the catalog (no 1:1 Command mapping), in tools/list order.</summary>
@@ -101,9 +101,12 @@ public class ToolCatalogTests {
     }
 
     [Fact]
-    public void SerializesOnInput_ExactlyDrag_InTheCatalog() {
+    public void SerializesOnInput_ExactlyDragAndFocus_InTheCatalog() {
+        // drag and focus both synthesize a real click/gesture that must not interleave with queue-driven
+        // input (#113); every other catalog tool runs unlocked.
+        string[] serializing = ["drag", "focus"];
         foreach (ToolDescriptor d in ToolCatalog.All) {
-            Assert.Equal(d.Name == "drag", d.SerializesOnInput);
+            Assert.Equal(serializing.Contains(d.Name), d.SerializesOnInput);
         }
         // send_command is a meta-tool special case in AgentServer (it serializes indirectly via the
         // dispatcher thread, #195); the public predicate must still report it.
@@ -117,7 +120,7 @@ public class ToolCatalogTests {
         }
         // SessionProvisioner.DefaultCommands is derived from the catalog; pin the exact historical set.
         Assert.Equal(
-            ["capture", "query", "displays", "windows", "find", "wait-for", "invoke", "drag", "click", "clipboard", "record"],
+            ["capture", "query", "displays", "windows", "find", "wait-for", "invoke", "drag", "click", "focus", "clipboard", "record"],
             SessionProvisioner.DefaultCommands);
     }
 
@@ -133,6 +136,7 @@ public class ToolCatalogTests {
             ["invoke"] = typeof(InvokeCommand),
             ["drag"] = typeof(DragCommand),
             ["click"] = typeof(ClickCommand),
+            ["focus"] = typeof(FocusCommand),
             ["clipboard"] = typeof(ClipboardCommand),
             ["record"] = typeof(RecordCommand),
             ["launch"] = typeof(LaunchCommand),

--- a/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
+++ b/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
@@ -67,6 +67,14 @@ public class UiaServiceTests {
     }
 
     [Fact]
+    public void ElementHasKeyboardFocus_ZeroHandle_ReturnsUnknown() {
+        // #272 CR: the focus tool verifies the RESOLVED ELEMENT holds keyboard focus (not just its
+        // window), so a sibling taking focus can't read as success. The guard path is "unknown" (null),
+        // which the command treats as "can't tell", never a false confirmation.
+        Assert.Null(UiaService.ElementHasKeyboardFocus(IntPtr.Zero, "name", "OK"));
+    }
+
+    [Fact]
     public void Find_ZeroHandle_ReturnsCleanMiss() {
         // #261: the guard path is a clean miss (no match, no fault), never a classified failure.
         UiaFindOutcome outcome = UiaService.Find(IntPtr.Zero, "name", "OK", timeoutMs: 0);

--- a/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
+++ b/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
@@ -25,7 +25,7 @@ public class AgentCommandStructuralGateTests {
     /// <c>ToolCatalogTests</c> pins the same list against the catalog itself.
     /// </summary>
     private static readonly string[] _gatedToolNames = [
-        "capture", "query", "displays", "windows", "find", "wait-for", "invoke", "record", "launch", "drag", "click", "clipboard",
+        "capture", "query", "displays", "windows", "find", "wait-for", "invoke", "record", "launch", "drag", "click", "focus", "clipboard",
     ];
 
     public static TheoryData<string> GatedToolNameData {

--- a/tests/MCEControl.xUnit/Commands/FocusCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/FocusCommandTests.cs
@@ -1,0 +1,102 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+[Collection("AgentSerial")]
+public class FocusCommandTests {
+    [Fact]
+    public void Constructor_DisabledByDefault() {
+        FocusCommand cmd = new();
+
+        Assert.False(cmd.Enabled);
+    }
+
+    [Fact]
+    public void BuiltInCommands_NonEmpty_ContainsFocus() {
+        List<Command> builtIns = FocusCommand.BuiltInCommands;
+
+        Assert.NotEmpty(builtIns);
+        Assert.Contains(builtIns, c => c.Cmd == "focus");
+    }
+
+    [Fact]
+    public void Clone_CopiesEndpoint_AndIsIndependent() {
+        FocusCommand original = new() {
+            Cmd = "focus",
+            Enabled = true,
+            Value = "Preview",
+            By = "automationid",
+            X = 400,
+            Y = 250,
+            PointSpecified = true,
+        };
+
+        FocusCommand clone = (FocusCommand)original.Clone(null!);
+
+        Assert.NotSame(original, clone);
+        Assert.Equal("Preview", clone.Value);
+        Assert.Equal("automationid", clone.By);
+        Assert.Equal(400, clone.X);
+        Assert.Equal(250, clone.Y);
+        Assert.True(clone.PointSpecified);
+
+        clone.Value = "changed";
+        Assert.Equal("Preview", original.Value);
+    }
+
+    [Fact]
+    public void Execute_WhenAgentDisabled_ReturnsFalse_WritesFailureJson() {
+        // Disabled path never actuates (no real foreground/focus in tests); it must fail closed.
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = null; // agent commands disabled
+        try {
+            CapturingReply reply = new();
+            FocusCommand cmd = new() { Cmd = "focus", Enabled = true, Reply = reply, Handle = 0x1234 };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void ForegroundFailure_MapsToForegroundCategory() {
+        // #91/#270: the focus tool is the producer of the foreground category. A window that won't
+        // activate is not a bug (internal) and not a retry-the-selector case; it is OS-policy foreground.
+        FocusCommand cmd = new() { Cmd = "focus" };
+
+        CommandResult result = cmd.ForegroundFailure();
+
+        Assert.False(result.Success);
+        Assert.Equal("foreground-not-set", result.ErrorCode);
+        Assert.Equal("foreground", result.ErrorCategory);
+        Assert.False(string.IsNullOrEmpty(result.Error));
+    }
+
+    [Fact]
+    public void FocusFailure_MapsToFocusCategory_AndCarriesTheWindow() {
+        // #91/#270: a foreground window whose focus never landed is the focus category, and the resolved
+        // window rides along as lastObservation so the failure is debuggable.
+        FocusCommand cmd = new() { Cmd = "focus" };
+        WindowInfo window = new() { Handle = 0x99, Title = "WinPrint" };
+
+        CommandResult result = cmd.FocusFailure(window);
+
+        Assert.False(result.Success);
+        Assert.Equal("focus-not-confirmed", result.ErrorCode);
+        Assert.Equal("focus", result.ErrorCategory);
+        Assert.NotNull(result.Data);
+        Assert.Equal(0x99, result.Data!["handle"]!.GetValue<long>());
+    }
+}

--- a/tests/MCEControl.xUnit/Commands/InvokeCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/InvokeCommandTests.cs
@@ -78,6 +78,7 @@ public class InvokeCommandTests {
     [InlineData(UiaInvokeResult.ActionUnknown, "action-unknown", "invalid-argument")]
     [InlineData(UiaInvokeResult.ElementStale, "element-stale", "stale-element")]
     [InlineData(UiaInvokeResult.TargetElevated, "target-elevated", "elevation")]
+    [InlineData(UiaInvokeResult.FocusNotSet, "focus-not-set", "focus")]
     [InlineData(UiaInvokeResult.Faulted, "invoke-faulted", "internal")]
     public void FailureFor_MapsEachOutcomeToADistinctCodeAndCategory(UiaInvokeResult outcome, string code, string category) {
         InvokeCommand cmd = new() { Cmd = "invoke", By = "name", Value = "OK", Action = "toggle" };

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -193,6 +193,83 @@ public class AgentServerTests {
     }
 
     [Fact]
+    public void Dispatch_Focus_IncompletePixelEndpoint_ReportsBadArguments() {
+        // #272 CR (P2): focus synthesizes a real click, so a pixel `at` with x but no y must be rejected
+        // up front, not turned into (x, 0) and clicked. `at` is optional for focus, but a PRESENT pixel
+        // endpoint must be complete.
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            JsonObject prms = new() {
+                ["name"] = "focus",
+                ["arguments"] = new JsonObject {
+                    ["window"] = "Whatever",
+                    ["at"] = new JsonObject { ["x"] = 400 }, // missing y
+                },
+            };
+
+            JsonObject resp = AgentServer.Dispatch(Request(20, "tools/call", prms))!;
+            JsonObject envelope = JsonNode.Parse(FirstTextBlock(resp["result"]!.AsObject()))!.AsObject();
+
+            Assert.False(envelope["ok"]!.GetValue<bool>());
+            Assert.Equal("bad-arguments", envelope["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Dispatch_Focus_NoEndpoint_PassesValidation() {
+        // Omitting `at` is a valid window-only focus (foreground + confirm), NOT a malformed endpoint; it
+        // must get PAST argument validation and stop at the per-command enable gate.
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.Invoker = null;
+        try {
+            JsonObject prms = new() {
+                ["name"] = "focus",
+                ["arguments"] = new JsonObject { ["window"] = "Whatever" },
+            };
+
+            JsonObject resp = AgentServer.Dispatch(Request(21, "tools/call", prms))!;
+            JsonObject envelope = JsonNode.Parse(FirstTextBlock(resp["result"]!.AsObject()))!.AsObject();
+
+            Assert.False(envelope["ok"]!.GetValue<bool>());
+            Assert.NotEqual("bad-arguments", envelope["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Dispatch_Focus_CompletePixelEndpoint_PassesValidation() {
+        // A full integer pixel endpoint is well-formed and must pass validation (stops at the enable gate).
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.Invoker = null;
+        try {
+            JsonObject prms = new() {
+                ["name"] = "focus",
+                ["arguments"] = new JsonObject {
+                    ["window"] = "Whatever",
+                    ["at"] = new JsonObject { ["x"] = 400, ["y"] = 250 },
+                },
+            };
+
+            JsonObject resp = AgentServer.Dispatch(Request(22, "tools/call", prms))!;
+            JsonObject envelope = JsonNode.Parse(FirstTextBlock(resp["result"]!.AsObject()))!.AsObject();
+
+            Assert.False(envelope["ok"]!.GetValue<bool>());
+            Assert.NotEqual("bad-arguments", envelope["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
     public void Dispatch_Click_CompleteEndpoint_PassesValidation() {
         // A well-formed click (element endpoint) must get PAST argument validation. With no Invoker wired
         // in the test host it stops at the per-command enable gate (not bad-arguments), which proves

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -39,6 +39,7 @@ public class AgentServerTests {
     // concurrently (so a long wait-for/query never blocks an unrelated capture); invoke is UIA actuation
     // dispatched on a worker with the modal grace, not under this lock.
     [InlineData("drag", true)]
+    [InlineData("focus", true)]
     [InlineData("send_command", true)]
     [InlineData("query", false)]
     [InlineData("capture", false)]


### PR DESCRIPTION
Fixes #270. Closes the remaining slice of #91 (the `focus` and `foreground` categories; `elevation`/`ambiguous-selector`/`stale-element` already landed in #261).

## Problem

- **#270:** A synthetic `click` on a MAUI `FocusablePlatformGraphicsView` never gave it XAML keyboard focus, so app-internal keyboard shortcuts (WinPrint's `+`/`-`/`0` zoom) were unreachable. A bare UIA `SetFocus` is unreliable here too (it can land on a sibling ComboBox that eats the keys).
- **#91:** The closed error taxonomy reserved `focus` and `foreground` categories that **no code path produced**, yet `AgentInstructions.md` (served to every connecting agent) taught agents to recover from them. The taxonomy was written ahead of the detection code.

Both converge on one capability: reliably give a target keyboard focus, and report precisely when it can't.

## What changed

- **`FocusService`** (`src/Agent/FocusService.cs`): verified foreground (AttachThreadInput dance, confirmed against `GetForegroundWindow`) and focus confirmation (the target GUI thread's `GUITHREADINFO` focus window, mapped to its top-level root). Every op verifies against the OS rather than trusting a Win32 bool, which is what lets a command emit `foreground`/`focus` honestly.
- **`focus` agent tool** (`FocusCommand`): foreground the window → click the control (a real `WM_LBUTTONDOWN/UP` focuses a surface a bare SetFocus misses) → reinforce with UIA `SetFocus` → confirm focus landed. Fails `foreground` if the window won't activate, `focus` if no control takes focus. Give `at` an element `{by,value}` or pixel `{x,y}`, or omit it to just foreground + confirm. Serializes on the input gate (like `drag`); provisioned by default. WinPrint's zoom beat becomes `focus` then `send_command VK_OEM_PLUS`.
- **`invoke setfocus` is now verified**: re-reads `HasKeyboardFocus` and reports `focus` (code `focus-not-set`) when the element didn't end up focused, instead of a false success.
- **Guidance + docs**: `AgentInstructions.md` recovery guidance now teaches the live `focus`/`foreground` categories and the `focus` tool; the result-contract, environment-controller, and architecture docs list the new tool; the taxonomy comments drop their `RESERVED` notes.

## Tests

`dotnet test` green (949 passed). Added `FocusCommandTests` (foreground/focus failure mapping), `FocusServiceTests` (zero-handle guards), and an `invoke` `FocusNotSet → focus` mapping case; updated the catalog / structural-gate / serialization pins for the new tool.

The live foreground/focus behavior needs real windows and is not unit-tested (same convention as `UiaService`'s live paths); the guard paths and the outcome→category mappings are pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)