### PR TITLE
docs: document the purpose-built-tools-vs-send_command strategy (#76)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,22 +32,27 @@ which loads the embedded file and collapses each blank-line-separated paragraph 
 > 3. **Act**: prefer `invoke` (`by` name/automationId/classname; `action` invoke|toggle|setvalue|
 >    setfocus|expand|collapse|select) over coordinate clicks. `invoke` **fast-fails** if the control isn't present (it does not
 >    wait), so `find`/`wait-for` the control first; an `invoke` that returns `no-target` means it hasn't
->    appeared yet; `wait-for` it rather than retrying blindly. Use `select` for TabItem/ListItem/RadioButton. `send_command` sends any raw MCEC command
->    (keystrokes, mouse, launch). To **drag** (resize a window by its sizing border, move one by its
->    title bar, or drag a slider/handle; no `invoke` for these), send a press-move-release sequence:
->    `mouse:mt,x,y` to the start, `mouse:lbd`, a stream of `mouse:mt,x,y` along the path, then `mouse:lbu`
->    (absolute screen pixels; pause briefly between moves). Re-`query` after; bounds have moved.
+>    appeared yet; `wait-for` it rather than retrying blindly. Use `select` for TabItem/ListItem/RadioButton.
+>    To **drag** (resize a window by its sizing border, move one by its title bar, or drag a slider/handle;
+>    no `invoke` for these), use the `drag` tool: give a `from` and `to`, each an element `{ by, value }` or
+>    an absolute screen pixel `{ x, y }`, plus optional `path` waypoints; the whole press-move-release is
+>    dispatched **atomically** (prefer it over hand-rolling `mouse:lbd`/`mouse:mt`/`mouse:lbu`, which can
+>    interleave with other input). To **click** a point `invoke` can't reach (a custom-drawn cell, a
+>    canvas/map coordinate, a bare pixel), use the `click` tool. Before firing an app's own keyboard
+>    shortcut at a specific surface (e.g. a MAUI GraphicsView), `focus` it first; keystrokes only reach the
+>    foreground window's focused control. `send_command` is the raw escape hatch for any other MCEC command
+>    (keystrokes, a single mouse action, launch). Re-`query` after acting; bounds have moved.
 > 4. **Verify** with another `query`/`capture`.
 >
 > **Compose creatively.** Many tasks have no single dedicated tool; build them from primitives. Launch an
 > app with the `launch` tool (preferred). Use `invoke` action:select for tabs/list/radios.
-> Drag/resize/move with `mouse:lbd` → a path of `mouse:mt` → `mouse:lbu`; switch a tab by `invoke` select or `query`+click;
+> Drag/resize/move with the `drag` tool; switch a tab by `invoke` select or `click`;
 > record a window by passing its `query`'d bounds as the `record` region;
 > wait for a window by polling `query`. A capable agent uses the *full* command set; reach for a raw
 > `send_command` before concluding something can't be done.
 >
 **There is exactly one copy: edit that file.** It is the observe → target → act → observe playbook
-(targeting; observation with `query`/`capture`/`record`/`displays`; `invoke`, `drag`, `click` and
+(targeting; observation with `query`/`capture`/`record`/`displays`; `invoke`, `drag`, `click`, `focus` and
 `send_command`; the result
 envelope; creative composition of primitives; the on-screen overlay; and the security gates). Nothing here
 to keep in sync.

--- a/docs/environment-controller.md
+++ b/docs/environment-controller.md
@@ -164,6 +164,17 @@ case-insensitive), `handle` (HWND), `process` (process name without `.exe`),
 | `focus`    | Give a window (and optionally a control in it) real **keyboard focus** so `send_command`/`chars` keystrokes reach it. Foregrounds the window, clicks the control (a real click focuses custom-drawn surfaces a bare `setfocus` misses; e.g. a MAUI GraphicsView), then **verifies**. Fails `foreground` if the window won't activate, `focus` if no control takes focus. Use before firing an app's own keyboard shortcut at a specific surface. | window target; optional `at` = `{ by, value }` or `{ x, y }` (omit to just foreground + confirm focus) |
 | `record`   | Record a window or region to an **animated GIF** over time (start/stop or a bounded one-shot). | window target, or region `x`/`y`/`width`/`height`; `action` (`start`\|`stop`\|`oneshot`), `fps`, `durationMs`, `maxWidth`, `file` |
 
+**Why purpose-built tools, not the raw command set.** MCP's value is typed discovery, so the agent
+surface is a small set of **purpose-built** tools rather than a 1:1 mapping of every legacy MCEC command.
+Each new tool supersedes the raw commands it replaces and is more reliable for an agent to drive:
+`launch` replaces the `startprocess`/Win+R dance and returns the new window's handle; `click` and `drag`
+replace hand-rolled `mouse:` sequences and dispatch their move+click / press-move-release **atomically**
+(raw `mouse:lbd`/`mouse:mt`/`mouse:lbu` can interleave with other input); `invoke` and `focus` replace
+the keystroke/message combinations once used to drive and target controls. `send_command` remains the
+**escape hatch**: it runs any raw MCEC command (including the legacy `startprocess`/`mouse:`/`sendmessage`/
+keystroke commands) for cases a typed tool doesn't cover, trading typed discovery for full reach. So the
+catalog stays small and legible while nothing from the underlying command set is lost.
+
 Every MCP **tool call** returns one result envelope. An agent branches on `ok` first; on
 success it reads `result`, on failure it reads `error`:
 
@@ -662,7 +673,7 @@ concurrently; past that the server answers `503` rather than queueing.
 
 ## Summary
 
-- New, opt-in agent surface: `capture`, `query`, `displays`, `windows`, `find`, `wait-for`, `invoke`, `launch`, `drag`, `click`, `record` (plus `send_command`, and `provision-session`/`end-session`).
+- New, opt-in agent surface: `capture`, `query`, `displays`, `windows`, `find`, `wait-for`, `invoke`, `launch`, `drag`, `click`, `focus`, `record` (plus `send_command`, and `provision-session`/`end-session`).
 - Structured `{ ok, result, error, … }` JSON result envelope; the commands are exposed as MCP/HTTP tools.
 - **No per-target sandbox:** an enabled command acts with your rights on whatever it targets. You control
   the *capability surface* (which commands are enabled, so read-only observation is possible), not what an


### PR DESCRIPTION
Closes #76 (retitled to "Document the typed-tools-vs-send_command strategy for legacy commands").

Per the issue's own comment, the typed-tool surface has been done for a while — `capture`/`query`/`displays`/`find`/`wait-for`/`invoke`/`drag`/`click`/`focus`/`record`/`launch` are schema-bearing MCP tools with per-command `Enabled` gating and discovery/dispatch tests; `send_command` is the raw escape hatch. The only remaining piece was **writing down the deliberate decision** and clearing stale guidance.

## Changes (docs-only)

- **`docs/environment-controller.md`** (the successor to the old `docs/agent-server.md`, which no longer exists): added a **"Why purpose-built tools, not the raw command set"** note under the command table. It records the narrowed-scope decision from #76's acceptance criteria: purpose-built tools that supersede the raw legacy commands rather than a 1:1 exposure (`launch` > `startprocess`/Win+R, `click`/`drag` > hand-rolled `mouse:`, `invoke`/`focus` > keystroke/message combos), with `send_command` preserved as the escape hatch so nothing from the underlying command set is lost. Also added `focus` to the Summary surface list (it was missing).
- **`AGENTS.md`**: the observe→act excerpt still told the agent to hand-roll a drag as `mouse:mt`/`mouse:lbd`/`mouse:lbu` (the drift the issue flagged). Updated it to the atomic `drag` tool and added `click`/`focus`, matching the canonical `src/Agent/AgentInstructions.md`.

## Acceptance criteria

- ✅ Decide + document the schema strategy (explicit narrowed scope: purpose-built tools + `send_command`).
- ✅ Core actuation commands exposed as typed tools (pre-existing).
- ✅ `send_command` preserved as escape hatch (documented).
- ✅ Enablement enforced for typed command tools (pre-existing gating + tests).
- ✅ Discovery/dispatch tests exist (`ToolCatalogTests`, `AgentServerTests`).
- ✅ `AGENTS.md` and the `agent-server.md` successor no longer overstate/misstate the surface.

The `AgentDesktopE2ETests` worked-example later in `AGENTS.md` intentionally uses raw `mouse:` primitives (it's a faithful description of that test), so it's left as-is.

Docs-only — CI's `pull_request` build may not fire; happy to dispatch `ci.yml` if you want a run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)