### PR TITLE
Guard launch against whitespace/paren path tokenization (#271)

### DIFF
--- a/src/Commands/LaunchCommand.cs
+++ b/src/Commands/LaunchCommand.cs
@@ -42,6 +42,9 @@ public class LaunchCommand : AgentCommand {
 
         try {
             ProcessStartInfo psi = new ProcessStartInfo {
+                // #271: Path is one literal path (never tokenized on whitespace) and Arguments is passed
+                // separately, so an executable under "Program Files (x86)" (spaces + parens) launches
+                // correctly. Guarded by LaunchCommandTests.
                 FileName = Path,
                 Arguments = Arguments ?? string.Empty,
                 WorkingDirectory = string.IsNullOrWhiteSpace(WorkingDirectory) ? string.Empty : WorkingDirectory,

--- a/tests/MCEControl.xUnit/Commands/LaunchCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/LaunchCommandTests.cs
@@ -88,6 +88,45 @@ public class LaunchCommandTests {
         }
     }
 
+    [Fact]
+    public void Launch_ToolMapping_PreservesPathWithSpacesAndParens() {
+        // #271: a rooted path with spaces AND parentheses (e.g. under "Program Files (x86)") must
+        // survive the tool -> command mapping intact; it must never be tokenized on whitespace.
+        const string path = @"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe";
+        const string arguments = "--new-window https://example.com/a b";
+        JsonObject args = new() { ["path"] = path, ["arguments"] = arguments };
+
+        LaunchCommand cmd = Assert.IsType<LaunchCommand>(AgentServer.BuildCommand("launch", args));
+
+        Assert.Equal(path, cmd.Path);
+        Assert.Equal(arguments, cmd.Arguments);
+    }
+
+    [Fact]
+    public void Execute_PathWithSpacesAndParens_NotRejectedAsMissing() {
+        // #271: a present path containing spaces/parens must not be seen as an empty/missing path.
+        // The target does not exist, so nothing launches; the failure must be the launch itself,
+        // NOT the "requires a non-empty 'path'" rejection.
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            LaunchCommand cmd = new() {
+                Cmd = "launch", Enabled = true, Reply = reply,
+                Path = @"C:\Program Files (x86)\No Such MCEC App (test)\nope.exe",
+            };
+
+            cmd.Execute();
+
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            string error = json["error"]?.GetValue<string>() ?? "";
+            Assert.DoesNotContain("non-empty 'path'", error);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
     // Test-first for Codex CR feedback (P2 on shell:.lnk null Process):
     // We expect that even if internal Process.Start returns null (common for shell targets),
     // the command should still succeed (return ok=true) and attempt to surface window info


### PR DESCRIPTION
Fixes #271 — `launch` returning `launch-path-missing` for a valid executable whose path contains spaces/parentheses (e.g. under `Program Files (x86)`).

## Findings

On `develop` the bug **does not reproduce**. The `launch` tool maps the `path` argument straight to `LaunchCommand.Path` (`ToolCatalog`: `Path = Str(args, "path")`) and the executor runs the command **object directly** (`cmd.Execute()`), with no command-string round-trip since the #206 object-flow refactor. `ExecuteCore` hands `Process.Start` the `FileName` and `Arguments` **separately** (`UseShellExecute = true`), so the path is already treated as one literal path — no whitespace tokenization. (`launch-path-missing` only fires when `path` is empty.)

## Change

Test-only + a clarifying comment — lock the behavior in so it can't regress:

- **`Launch_ToolMapping_PreservesPathWithSpacesAndParens`** — a `Program Files (x86)` path plus arguments survive the tool→command mapping intact.
- **`Execute_PathWithSpacesAndParens_NotRejectedAsMissing`** — a present spaces/parens path is never rejected as a missing path (target doesn't exist, so nothing launches).
- A `#271` comment at the `ProcessStartInfo`.

No production behavior change; an existence check was deliberately **not** added — it would break the valid `shell:`/PATH/`.lnk` launch forms `UseShellExecute` handles.

## Testing

`dotnet test tests/MCEControl.xUnit` → **955 passed, 22 skipped, 0 failed** (the two new tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)