### PR TITLE
agent: make `chars:` literal + clarify keydown-vs-chars guidance (#269)

### DIFF
--- a/docs/home-automation.md
+++ b/docs/home-automation.md
@@ -254,10 +254,10 @@ A full list of virtual key codes is on
 > a launch sequence), then send the key.
 
 Sending `chars:` plus text simulates typing that text. `chars:3` types `3`; `chars:Hello` types the
-letters H-e-l-l-o (including the shift for the capital). The text after `chars:` can include *character
-escapes* for unprintable/Unicode characters: `chars:\\` sends `\`, `chars:☺` sends `☺`, and
-`chars:€` sends `€`. (The supported escapes are
-[documented here](https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-escapes-in-regular-expressions).)
+letters H-e-l-l-o (including the shift for the capital). The text is typed **literally**, exactly as
+given; there is no escape processing, so `chars:\` sends a single backslash and a Windows path types
+straight through: `chars:C:\Users\me\file.txt` types `C:\Users\me\file.txt` (no backslash doubling).
+Unicode characters pass through as-is: `chars:☺` sends `☺`, `chars:€` sends `€`.
 
 How `chars:` interacts with modifier keys (shift/ctrl/alt/win) is app-dependent; for fine-grained control
 use `SendInput` commands instead.

--- a/docs/winprint-hero-gif.md
+++ b/docs/winprint-hero-gif.md
@@ -76,8 +76,8 @@ operator/harness has provisioned it (agent commands enabled in the session copy 
 | Zoom | `click` preview → `key_equals` ×4 → arrows → `key_0` |
 | Second file | File → clipboard `README.md` → Ctrl+V → Enter |
 | Print | `query` tree → `click` toolbar **Print…** button by bounds (printer already **Microsoft Print to PDF**) |
-| Save PDF | `query` **Save Print Output As** by `handle` → `click` filename field → `chars:C:\\…\\winprintdemo.pdf` (backslashes doubled) → Enter |
-| Open PDF | `send_command winr` → `send_command chars:<pdf path>` (backslashes doubled) → Enter |
+| Save PDF | `query` **Save Print Output As** by `handle` → `click` filename field → `chars:C:\…\winprintdemo.pdf` (typed literally; chars: no longer doubles backslashes) → Enter |
+| Open PDF | `send_command winr` → `send_command chars:<pdf path>` (typed literally) → Enter |
 | Stop | `record { action:"stop", file:"docs/hero-gui-win.gif" }` |
 | Close PDF | `send_command alt_f4` — release the file lock so the next run's harness `Remove-Item` succeeds |
 

--- a/scripts/Generate-WinPrint-HeroGif.ps1
+++ b/scripts/Generate-WinPrint-HeroGif.ps1
@@ -297,13 +297,15 @@ try {
         Start-Sleep -Milliseconds 500
     }
     Send-McecCommand 'ctrl-a' $session; Start-Sleep -Milliseconds 200
-    Send-McecCommand ("chars:" + $PdfPath.Replace('\', '\\')) $session; Start-Sleep -Milliseconds 800
+    # chars: types its argument verbatim (#269), so send $PdfPath as-is; NO backslash doubling.
+    Send-McecCommand ("chars:" + $PdfPath) $session; Start-Sleep -Milliseconds 800
     Send-McecCommand 'enter' $session; Start-Sleep -Seconds 6
     if (-not (Test-Path -LiteralPath $PdfPath)) { throw "PDF not saved at $PdfPath" }
     Step 'print-pdf' 'pass' "saved $PdfPath"
 
     Send-McecCommand 'winr' $session; Start-Sleep -Milliseconds 1000
-    Send-McecCommand ("chars:" + $PdfPath.Replace('\', '\\')) $session; Start-Sleep -Milliseconds 600
+    # chars: types verbatim (#269); send the path as-is, no doubling.
+    Send-McecCommand ("chars:" + $PdfPath) $session; Start-Sleep -Milliseconds 600
     Send-McecCommand 'enter' $session; Start-Sleep -Seconds 3
     Step 'open-pdf' 'pass' 'PDF viewer foreground'
     Start-Sleep -Milliseconds 1500

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -62,8 +62,9 @@ absolute screen pixel `{ x, y }`, with optional `button` (left|right|middle) and
 it doesn't depend on the control being on-screen and unobscured. System file dialogs (Open, Save Print
 Output As) are separate windows; `wait-for`/`query` by title, reuse the returned `handle`, and act on that
 target (don't assume the dialog shares the app's process). They often have no UIA-settable filename field;
-`clipboard { action:set, text:… }` then Ctrl+V and Enter, or `send_command chars:<path>` with every Windows
-backslash doubled (`C:\\folder\\file.ext`). Click the filename field first when paste fails. `send_command`
+`clipboard { action:set, text:… }` then Ctrl+V and Enter, or `send_command chars:<path>` (chars: types the
+path LITERALLY; a single backslash is a backslash, `C:\folder\file.ext`, no doubling). Click the filename
+field first when paste fails. `send_command`
 sends any other raw MCEC command (keystrokes, single mouse actions, launch); the raw
 `mouse:drag,x1,y1,x2,y2[,...]` is the same atomic drag in pixels and `mouse:mtp,x,y` moves the pointer to
 an absolute screen pixel. If `invoke`/`click` by name returns `no-target`, `query` the tree: WinUI/MAUI
@@ -122,10 +123,15 @@ started is refused the same way. (Note the hyphen: the tools are `session-start`
 COMPOSE: many tasks have no single dedicated tool; build them by combining primitives creatively. When
 injected keystrokes must reach Start/search or the bare desktop, first show the desktop (Win+D) or `click` an
 open desktop pixel; IDE/terminal shells otherwise swallow them. Launch
-an app with the dedicated `launch` tool (`path` required, optional `arguments`/`workingDirectory`; returns the pid and the app's window handle once it appears). Fallback if `launch` is unavailable: `send_command winr` then `chars:<path>` then `enter`, or Start Menu: `send_command desktop` (Win+D) then Win+S, type the app name, Enter, then `wait-for`/`query` for its process (the new window is foreground: `query {foreground}` for its handle). If the process never appears, Win+D and retry Win+S once before concluding the app is missing; an IDE/terminal in the foreground can swallow the first attempt even after Win+D. To fire an app ACCELERATOR
-(Ctrl+C/V/A/S), send a real VK+modifier command (like the built-in `ctrl-x`), NOT `shiftdown:ctrl` then
-`chars:c`: `chars:` injects a character and never triggers the accelerator, so the copy/paste silently does
-nothing. Prefer the `clipboard` tool for clipboard text; use Ctrl+C/Ctrl+V keystrokes only to move data
+an app with the dedicated `launch` tool (`path` required, optional `arguments`/`workingDirectory`; returns the pid and the app's window handle once it appears). Fallback if `launch` is unavailable: `send_command winr` then `chars:<path>` then `enter`, or Start Menu: `send_command desktop` (Win+D) then Win+S, type the app name, Enter, then `wait-for`/`query` for its process (the new window is foreground: `query {foreground}` for its handle). If the process never appears, Win+D and retry Win+S once before concluding the app is missing; an IDE/terminal in the foreground can swallow the first attempt even after Win+D.
+KEYSTROKES split two ways, and confusing them silently does nothing. To fire an app SHORTCUT or press a
+navigation/editing key; a Ctrl/Alt/Win chord (Ctrl+C/V/A/S), a lone shortcut key (zoom `+`/`-`/`=`), or an
+arrow/function/Enter/Esc/Tab; send a real KEYDOWN via `send_command`: a `VK_` name (`VK_OEM_PLUS` is `=`/`+`),
+a named key (`enter`, `escape`, `left`/`right`/`up`/`down`, `tab`), or a chord builtin (`ctrl-x`); bracket
+with `shiftdown:<mods>`/`shiftup:<mods>` for extra modifiers. `chars:` is for LITERAL TEXT ONLY (it is
+WM_CHAR text entry): `chars:=` types a `=` and never zooms, and `shiftdown:ctrl` then `chars:c` does NOT
+fire Ctrl+C. So type field values and paths with `chars:`, but fire shortcuts with the keydown command.
+Prefer the `clipboard` tool for clipboard text; use Ctrl+C/Ctrl+V keystrokes only to move data
 through an app that owns the selection (copy a canvas, paste an image). Use `invoke` with `action: "select"` for tabs/list items/radios. 
 Drag/resize/move with the `drag` tool (`from`/`to`, optional `path` waypoints). Switch a tab/list item by `invoke` `select` (preferred) or `click` its centre. Record a window by
 `query`ing its bounds and passing them as the `record` region; use a **desktop region** when Start/search

--- a/src/Commands/CharsCommand.cs
+++ b/src/Commands/CharsCommand.cs
@@ -9,10 +9,9 @@
 //-------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using WindowsInput;
 
-namespace MCEControl; 
+namespace MCEControl;
 /// <summary>
 /// Supports sending raw text.
 /// </summary>
@@ -25,15 +24,23 @@ public class CharsCommand : Command {
         ];
     }
 
+    /// <summary>
+    /// The LITERAL text <c>chars:</c> types: <paramref name="args"/> verbatim (empty when null/blank).
+    /// It deliberately does NO escape processing (#269). It used to run <c>Regex.Unescape</c>, which
+    /// silently mangled any argument containing backslashes; a Windows path like
+    /// <c>C:\Users\tig\file.txt</c> had its <c>\t</c> turned into a TAB and other <c>\x</c> sequences
+    /// eaten, so agents had to double every backslash. <c>chars:</c> is text entry, not an escape-coded
+    /// string; typing the argument as-is is the least-surprising behavior. Pure; unit-testable.
+    /// </summary>
+    internal static string PrepareText(string? args) => args ?? "";
+
     // ICommand:Execute
     public override bool Execute() {
         if (!base.Execute()) {
             return false;
         }
 
-        // if command came in as a literal "chars:foo" command use args
-        // otherwise, use the Chars property
-        string text = !string.IsNullOrEmpty(Args) ? Regex.Unescape(Args) : "";
+        string text = PrepareText(Args);
 
         Logger.Instance.Log4.Info($"{this.GetType().Name}: Typing {text.Length} chars: {text}");
 

--- a/tests/MCEControl.xUnit/Commands/CharsCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/CharsCommandTests.cs
@@ -78,4 +78,37 @@ public class CharsCommandTests
 
         Assert.Equal("Test String", cmd.Args);
     }
+
+    // #269: chars: is LITERAL text entry. It must NOT run Regex.Unescape (which silently mangled Windows
+    // paths: `\t`, `\U`, etc. in `C:\Users\tig\...` were eaten or turned into control chars). PrepareText
+    // is the pure seam Execute types verbatim; these pin that it never processes escape sequences.
+
+    [Fact]
+    public void PrepareText_WindowsPath_TypedVerbatim_NoBackslashMangling()
+    {
+        // The canonical footgun: `C:\Users\tig\file.txt` — the `\t`/`\f` must stay literal, not become a TAB.
+        string path = @"C:\Users\tig\file.txt";
+
+        string result = CharsCommand.PrepareText(path);
+
+        Assert.Equal(path, result);
+        Assert.DoesNotContain('\t', result); // \t was NOT turned into a TAB
+    }
+
+    [Fact]
+    public void PrepareText_BackslashEscapes_StayLiteral()
+    {
+        // A bare `\t`/`\n` sequence types the two characters backslash+t, not a TAB/newline.
+        Assert.Equal(@"a\tb", CharsCommand.PrepareText(@"a\tb"));
+        Assert.Equal(@"one\ntwo", CharsCommand.PrepareText(@"one\ntwo"));
+        Assert.DoesNotContain('\t', CharsCommand.PrepareText(@"a\tb"));
+        Assert.DoesNotContain('\n', CharsCommand.PrepareText(@"one\ntwo"));
+    }
+
+    [Fact]
+    public void PrepareText_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.Equal("", CharsCommand.PrepareText(null));
+        Assert.Equal("", CharsCommand.PrepareText(""));
+    }
 }


### PR DESCRIPTION
Closes #269. Three related guidance/behavior fixes surfaced while driving the WinPrint hero (tig/winprint#207).

## 1. `send_input` (keydown) vs `chars:` (text) was ambiguous
`AgentInstructions.md` said `send_command` "sends keystrokes" and listed `chars:` for text, but never stated that **shortcuts need a real keydown** while **`chars:` is WM_CHAR text entry**. Sending a shortcut like zoom `=` as `chars:=` silently does nothing. The guidance now splits keystrokes clearly:

- **Shortcut / navigation-editing key** (Ctrl/Alt/Win chord, a lone shortcut key like `+`/`-`/`=`, arrows, function keys, Enter/Esc/Tab) → a real **keydown** via `send_command`: a `VK_` name (`VK_OEM_PLUS`), a named key (`enter`, `left`/`right`/`up`/`down`, `tab`), or a chord builtin (`ctrl-x`), bracketed with `shiftdown:`/`shiftup:` for extra modifiers.
- **Literal text / paths** → `chars:` only.

(There is no command literally named `send_input`; the keydown family is the `VK_*`/named-key/chord builtins, so the guidance names those.)

## 2. `chars:` ran `Regex.Unescape`, mangling Windows paths — **fixed at source** (your call)
`CharsCommand.Execute` did `Regex.Unescape(Args)` before `TextEntry`, so `C:\Users\tig\file.txt` had its `\t` turned into a TAB and other `\x` sequences eaten; agents had to double every backslash. Dropped the unescape: `CharsCommand` now types its argument **verbatim** through a testable `PrepareText` seam. Docs updated to match — the file-dialog path guidance and the winprint-hero recipe no longer say "double the backslashes", and the `home-automation.md` `chars:` reference drops the old character-escape paragraph and states the text is literal.

> Behavior change: a `chars:` argument that previously relied on regex escapes (`\n`, `\t`, `\uXXXX`) now types those characters literally. No shipped `.commands` or built-in relies on that.

## 3. Stale cross-repo pointer — already resolved
The WinPrint-hero paragraph that pointed at `docs/winprint-hero-gif.md` and the old harness-driven flow was already removed from `AgentInstructions.md` in a prior trim; verified no `winprint` references remain in `src/`. No change needed.

## Tests
Test-first: `CharsCommand.PrepareText` pins verbatim behavior (Windows path intact, `\t`/`\n` stay literal, null/empty → empty). Full suite green — **956 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)