### PR TITLE
windows tool: wait on window state (appears/disappears/foreground) (#112)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ which loads the embedded file and collapses each blank-line-separated paragraph 
 > app with the `launch` tool (preferred). Use `invoke` action:select for tabs/list/radios.
 > Drag/resize/move with the `drag` tool; switch a tab by `invoke` select or `click`;
 > record a window by passing its `query`'d bounds as the `record` region;
-> wait for a window by polling `query`. A capable agent uses the *full* command set; reach for a raw
+> wait on window state with the `windows` tool + a `timeout` and a `condition` (appears/disappears/foreground).
+> A capable agent uses the *full* command set; reach for a raw
 > `send_command` before concluding something can't be done.
 >
 **There is exactly one copy: edit that file.** It is the observe → target → act → observe playbook

--- a/docs/environment-controller.md
+++ b/docs/environment-controller.md
@@ -154,7 +154,7 @@ case-insensitive), `handle` (HWND), `process` (process name without `.exe`),
 | `capture`  | Screenshot a window (`PrintWindow` + `PW_RENDERFULLCONTENT`, captures WinUI/WPF surfaces) or a screen region, returned as base64 PNG. Blank/black frames are detected and flagged (see [Observation hardening](#observation-hardening--known-limitations)). | window target, or region `x`/`y`/`width`/`height`; optional `file` |
 | `query`    | Dump the **UI Automation tree** of a window: control type, name, automation id, bounds, enabled/offscreen state, value. | window target, `maxDepth` (default 6), `maxNodes` (default 1000) |
 | `displays` | Report **display geometry**; every monitor's pixel `bounds`, `workingArea`, `primary` flag, and `dpi`/`scale`, plus the union `virtualBounds`. Lets an agent interpret the absolute-pixel bounds `query`/`find` return and place pixel clicks/drags without measuring the screen itself. | *(none)* |
-| `windows`  | **Discover top-level windows**: list each window's `handle`, `title`, `className`, `processName`, `processId`, and `bounds`, so an agent can find and target a window instead of guessing. Optionally filtered; with a `timeout` it **waits** (polls) for a matching window to appear. No filter lists all; a `timeout` with no filter is refused (won't wait for an arbitrary window). | `window`/`process`/`className` filters (all optional), `timeout` (ms; wait for a match) |
+| `windows`  | **Discover top-level windows and wait on window state**: list each window's `handle`, `title`, `className`, `processName`, `processId`, and `bounds`, so an agent can target a window instead of guessing. Optionally filtered; with a `timeout` it **waits** for `condition`: `appears` (default; a match exists), `disappears` (no window matches, e.g. a modal closed), or `foreground` (a match is the foreground window). No filter lists all; a wait (or `disappears`/`foreground`) with no filter is refused. A timeout carries `waitedFor` + `lastObservedWindows` for triage. | `window`/`process`/`className` filters, `condition` (appears/disappears/foreground), `timeout` (ms) |
 | `find`     | Find a **UI Automation element** by name / automation id / class.                 | window target, `by` (`name`\|`automationid`\|`classname`), `value`, `timeout` |
 | `wait-for` | Same as `find`, but waits up to a timeout for the element to appear (default 5 s). | window target, `by`, `value`, `timeout` |
 | `invoke`   | Drive a UI Automation element pattern (incl. select for SelectionItem); far more reliable than coordinate clicks. | window target, `by`, `value`, `action` (`invoke`\|`toggle`\|`setvalue`\|`setfocus`\|`expand`\|`collapse`\|`select`), `text` |
@@ -551,7 +551,7 @@ When connected, the server advertises these tools:
 | `capture`      | The `capture` command (window screenshot → base64 PNG).        |
 | `query`        | The `query` command (describe a window).                       |
 | `displays`     | The `displays` command (per-monitor bounds + DPI/scale, virtual bounds). |
-| `windows`      | The `windows` command (list/filter top-level windows for discovery; wait for one with a timeout). |
+| `windows`      | The `windows` command (list/filter top-level windows for discovery; wait on window state (appears/disappears/foreground) with a timeout). |
 | `find`         | The `find` command (match a UI element, one-shot).             |
 | `wait-for`     | The `wait-for` command (poll for a UI element until a timeout). |
 | `invoke`       | The `invoke` command (run an existing MCEC command, incl. select for tabs etc). |

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -6,9 +6,12 @@ Work the loop: observe -> target -> act -> observe.
 `foreground:true`: you MUST give at least one; a call with no target fails. If you do not yet know what to
 target, DISCOVER first with `windows`: it lists the visible top-level windows (handle, title, className,
 processName, processId, bounds), optionally filtered by `window`/`process`/`className`; use it to enumerate
-available targets instead of guessing one, and to WAIT for a window to appear (pass `timeout` ms with a
-filter; it polls until a match shows up or returns `count:0` on timeout). `windows` with no filter lists
-everything; with a `timeout` but no filter it is refused (it will not wait for an arbitrary window). Reuse
+available targets instead of guessing one, and to WAIT on window state (pass `timeout` ms + a filter and a
+`condition`): `appears` (default; poll until a match exists, `count:0` on timeout), `disappears` (until no
+window matches, e.g. a modal you opened has closed), or `foreground` (until a match is the foreground
+window, e.g. a launched app took focus). A wait that times out carries `waitedFor` + `lastObservedWindows`,
+so you can triage without a second observation. `windows` with no filter lists
+everything; a wait (or `disappears`/`foreground`) with no filter is refused (it will not wait for an arbitrary window). Reuse
 the `handle` a `windows`/`query` returns for follow-up calls: it is stable, and a dialog you open shares the
 process name, so re-resolving by process/title can match the wrong window. Open menus and other untitled
 popups are not enumerated by title/process; target them by handle or `foreground:true`.

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -270,8 +270,8 @@ public static class ToolCatalog {
             ["window"] = PropSchema("string", "Filter by window title substring (case-insensitive)"),
             ["process"] = PropSchema("string", "Filter by process name (without .exe)"),
             ["className"] = PropSchema("string", "Filter by window class name (exact)"),
-            ["condition"] = PropSchema("string", "What a timeout waits for: appears (default; a matching window exists), disappears (no window matches any more, e.g. a modal closed), or foreground (a matching window is the foreground window)"),
-            ["timeout"] = PropSchema("integer", "Milliseconds to WAIT for the condition (0 = check/list now, no wait); a wait, and the disappears/foreground conditions, require at least one filter"),
+            ["condition"] = PropSchema("string", "The predicate to evaluate, waited for with a timeout or checked once with timeout:0: appears (default; a matching window exists), disappears (no window matches any more, e.g. a modal closed), or foreground (a matching window is the foreground window). Returns satisfied for the predicate result"),
+            ["timeout"] = PropSchema("integer", "Milliseconds to WAIT for the condition (0 = check/list now, one-shot); a wait, and the disappears/foreground conditions, require at least one filter"),
         };
         return Tool("windows",
             "Discover top-level windows and WAIT on window state. Returns each window's handle, title, className, processName, processId, and bounds so you can target a window instead of guessing; reuse a returned handle directly on query/capture/invoke. Optionally filter by title substring / process / class. With a timeout it WAITS for `condition`: appears (default; poll until a match exists, count:0 on timeout), disappears (poll until no window matches, e.g. a dialog closed), or foreground (poll until a matching window is the foreground window). No filter lists every window; a wait, or disappears/foreground, with no filter is refused. On a timeout the result carries waitedFor + lastObservedWindows for triage.",

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -108,6 +108,7 @@ public static class ToolCatalog {
                 Window = Str(args, "window")!,
                 Process = Str(args, "process")!,
                 ClassName = Str(args, "className")!,
+                Condition = Str(args, "condition")!,
                 Timeout = Int(args, "timeout"),
             },
             CreateCommandInstance = () => new WindowsCommand(),
@@ -269,10 +270,11 @@ public static class ToolCatalog {
             ["window"] = PropSchema("string", "Filter by window title substring (case-insensitive)"),
             ["process"] = PropSchema("string", "Filter by process name (without .exe)"),
             ["className"] = PropSchema("string", "Filter by window class name (exact)"),
-            ["timeout"] = PropSchema("integer", "Milliseconds to WAIT for a matching top-level window to appear (0 = list now, no wait); requires at least one filter"),
+            ["condition"] = PropSchema("string", "What a timeout waits for: appears (default; a matching window exists), disappears (no window matches any more, e.g. a modal closed), or foreground (a matching window is the foreground window)"),
+            ["timeout"] = PropSchema("integer", "Milliseconds to WAIT for the condition (0 = check/list now, no wait); a wait, and the disappears/foreground conditions, require at least one filter"),
         };
         return Tool("windows",
-            "Discover top-level windows: returns each window's handle, title, className, processName, processId, and bounds so you can find and target a window instead of guessing. Optionally filter by title substring / process / class. With a timeout it WAITS, polling until a matching window appears (or the timeout, returning count:0). No filter lists every window; a timeout with no filter is refused (it won't wait for an arbitrary window). Reuse a returned handle directly on query/capture/invoke.",
+            "Discover top-level windows and WAIT on window state. Returns each window's handle, title, className, processName, processId, and bounds so you can target a window instead of guessing; reuse a returned handle directly on query/capture/invoke. Optionally filter by title substring / process / class. With a timeout it WAITS for `condition`: appears (default; poll until a match exists, count:0 on timeout), disappears (poll until no window matches, e.g. a dialog closed), or foreground (poll until a matching window is the foreground window). No filter lists every window; a wait, or disappears/foreground, with no filter is refused. On a timeout the result carries waitedFor + lastObservedWindows for triage.",
             props, []);
     }
 

--- a/src/Agent/WindowResolver.cs
+++ b/src/Agent/WindowResolver.cs
@@ -130,6 +130,44 @@ public static class WindowResolver {
         }
     }
 
+    /// <summary>
+    /// Polls <see cref="ListTopLevel"/> until NO window matches the filter (the target closed) or
+    /// <paramref name="timeoutMs"/> elapses. Returns the STILL-matching windows: empty on success (all
+    /// gone), non-empty on timeout (what did not close). A zero timeout checks once. Lets an agent wait
+    /// for a dialog/app window to disappear (a modal closing) without external sleeps. The caller requires
+    /// a filter; waiting for "any window" to disappear is meaningless (the <c>windows</c> tool refuses it).
+    /// </summary>
+    public static List<WindowInfo> WaitUntilGone(string? title, string? processName, string? className, int timeoutMs, int pollMs = 100) {
+        Stopwatch sw = Stopwatch.StartNew();
+        while (true) {
+            List<WindowInfo> matches = ListTopLevel(title, processName, className);
+            if (matches.Count == 0 || sw.ElapsedMilliseconds >= timeoutMs) {
+                return matches;
+            }
+            Thread.Sleep(Math.Min(pollMs, Math.Max(1, timeoutMs - (int)sw.ElapsedMilliseconds)));
+        }
+    }
+
+    /// <summary>
+    /// Polls until the FOREGROUND window matches the filter or <paramref name="timeoutMs"/> elapses.
+    /// Returns the matching foreground window on success, or null on timeout (the foreground never
+    /// matched). A zero timeout checks the current foreground once. Lets an agent wait for its target
+    /// (a just-launched app, a dialog) to actually take focus before sending keystrokes.
+    /// </summary>
+    public static WindowInfo? WaitForForeground(string? title, string? processName, string? className, int timeoutMs, int pollMs = 100) {
+        Stopwatch sw = Stopwatch.StartNew();
+        while (true) {
+            WindowInfo? fg = Resolve(null, null, null, null, foreground: true);
+            if (fg is not null && Matches(fg, title, processName, className)) {
+                return fg;
+            }
+            if (sw.ElapsedMilliseconds >= timeoutMs) {
+                return null;
+            }
+            Thread.Sleep(Math.Min(pollMs, Math.Max(1, timeoutMs - (int)sw.ElapsedMilliseconds)));
+        }
+    }
+
     /// <summary>Enumerates visible, titled top-level windows.</summary>
     public static List<WindowInfo> EnumerateTopLevel() {
         List<WindowInfo> windows = [];

--- a/src/Commands/WindowsCommand.cs
+++ b/src/Commands/WindowsCommand.cs
@@ -7,25 +7,36 @@ using System.Xml.Serialization;
 namespace MCEControl;
 
 /// <summary>
-/// Agent observation command: first-class top-level window DISCOVERY (issue #77). Where
-/// <see cref="QueryCommand"/>/<see cref="FindCommand"/> resolve ONE window and then look inside it, this
-/// enumerates the visible titled top-level windows themselves, so an agent that starts with only a
-/// partial title, a process name, or the expectation that a window will appear can list the available
-/// targets instead of guessing one. Filters (all optional) narrow the set with the SAME rules
-/// <see cref="WindowResolver.Resolve"/> uses: <c>window</c> title substring (case-insensitive),
-/// <c>process</c> name (exact, without .exe), <c>classname</c> (exact). With a <c>timeout</c> it WAITS,
-/// polling until a matching top-level window appears or the timeout elapses.
+/// Agent observation command: first-class top-level window DISCOVERY and window-WAIT predicates
+/// (issues #77, #112). Where <see cref="QueryCommand"/>/<see cref="FindCommand"/> resolve ONE window and
+/// then look inside it, this enumerates the visible titled top-level windows themselves, and can WAIT for
+/// one to change state, so an agent that starts with only a partial title, a process name, or the
+/// expectation that a window will appear/close/take focus can act with a single call instead of polling.
+/// Filters (all optional for discovery) narrow the set with the SAME rules <see cref="WindowResolver.Resolve"/>
+/// uses: <c>window</c> title substring (case-insensitive), <c>process</c> name (exact, without .exe),
+/// <c>classname</c> (exact).
 ///
-/// Returns <c>{ count, windows: [ { handle, title, className, processName, processId, x, y, width, height }, … ] }</c>;
-/// each array element is a full window OBJECT (the <see cref="WindowInfo"/> shape the other tools echo,
-/// via <see cref="WindowInfo.ToJsonObject"/>), so a listed handle can be reused directly on a follow-up
-/// <c>query</c>/<c>capture</c>/<c>invoke</c>.
+/// With a <c>timeout</c> it WAITS. <c>condition</c> selects the predicate (default <c>appears</c>):
+/// <list type="bullet">
+///   <item><c>appears</c>: poll until a matching window exists; returns the matches (<c>count:0</c> on timeout).</item>
+///   <item><c>disappears</c>: poll until NO window matches (a dialog/app closed); <c>satisfied</c> true when
+///     gone, and <c>windows</c> lists whatever is still present on timeout.</item>
+///   <item><c>foreground</c>: poll until the foreground window matches the filter; returns that <c>window</c>.</item>
+/// </list>
+/// On an unsatisfied wait the result carries actionable diagnostics (#112): <c>waitedFor</c> (the criteria)
+/// and <c>lastObservedWindows</c> (the full top-level set), so a timeout can be triaged without re-querying.
+///
+/// Returns <c>{ condition, count, windows: [ { handle, title, className, processName, processId, x, y, width, height }, … ] }</c>
+/// for <c>appears</c>/<c>disappears</c> (each element the <see cref="WindowInfo"/> shape via
+/// <see cref="WindowInfo.ToJsonObject"/>, so a listed handle is reusable directly), and
+/// <c>{ condition, satisfied, window }</c> for a satisfied <c>foreground</c>.
 ///
 /// SAFETY: a bare list (no filter, no timeout) enumerates ALL windows; that is discovery, not the
 /// silent-arbitrary-target hazard <see cref="WindowResolver.Resolve"/> guards against (it never picks one
-/// for you). But WAITING for "any window" IS that hazard (it would return whatever exists), so a
-/// <c>timeout</c> with no filter is refused. Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and
-/// audited (structurally, via <see cref="AgentCommand"/>). Disabled by default (security).
+/// for you). But WAITING for "any window" IS that hazard, and <c>disappears</c>/<c>foreground</c> are
+/// predicates ABOUT a specific window, so a wait (or either of those conditions) with no filter is refused.
+/// Gated by <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited (structurally, via
+/// <see cref="AgentCommand"/>). Disabled by default (security).
 /// </summary>
 public class WindowsCommand : AgentCommand {
     // NOTE: attribute names MUST be all-lowercase (the .commands load XSLT lower-cases every name; a
@@ -33,6 +44,7 @@ public class WindowsCommand : AgentCommand {
     [XmlAttribute("window")] public string Window { get; set; } = null!;
     [XmlAttribute("process")] public string Process { get; set; } = null!;
     [XmlAttribute("classname")] public string ClassName { get; set; } = null!;
+    [XmlAttribute("condition")] public string Condition { get; set; } = null!;
     [XmlAttribute("timeout")] public int Timeout { get; set; }
 
     public static List<Command> BuiltInCommands {
@@ -43,34 +55,128 @@ public class WindowsCommand : AgentCommand {
     private bool HasFilter =>
         !string.IsNullOrEmpty(Window) || !string.IsNullOrEmpty(Process) || !string.IsNullOrEmpty(ClassName);
 
+    /// <summary>The requested predicate, normalized; <c>appears</c> when omitted.</summary>
+    private string ConditionOrDefault =>
+        string.IsNullOrWhiteSpace(Condition) ? "appears" : Condition.Trim().ToLowerInvariant();
+
     protected override string AuditDetails() =>
-        $"windows title='{Window}' process='{Process}' class='{ClassName}' timeout={Timeout}";
+        $"windows title='{Window}' process='{Process}' class='{ClassName}' condition='{ConditionOrDefault}' timeout={Timeout}";
 
     protected override CommandResult ExecuteCore() {
-        // Waiting for "any window" would return whatever happens to exist; the same silent-arbitrary-target
-        // hazard the no-criteria Resolve refusal exists to prevent. Require a filter to WAIT. (A bare list
-        // with no timeout is fine: it enumerates the whole set for the agent to choose from.)
-        if (Timeout > 0 && !HasFilter) {
+        string condition = ConditionOrDefault;
+        if (condition is not ("appears" or "disappears" or "foreground")) {
             return CommandResult.Fail(Cmd,
-                "windows with a timeout needs at least one of window/process/className to wait for; " +
-                "refusing to wait for an arbitrary window. Drop timeout to list all windows now, or add a filter.",
+                $"windows condition '{Condition}' is not recognized; use appears (default), disappears, or foreground.",
+                "windows-unknown-condition", "invalid-argument");
+        }
+
+        bool waiting = Timeout > 0;
+
+        // disappears/foreground are predicates ABOUT a specific window, so they always need a filter.
+        // appears needs a filter only when WAITING (a bare list enumerates the whole set to choose from);
+        // waiting for "any window" is the silent-arbitrary-target hazard the no-criteria Resolve refuses.
+        bool needsFilter = condition != "appears" || waiting;
+        if (needsFilter && !HasFilter) {
+            return CommandResult.Fail(Cmd,
+                $"windows condition '{condition}' needs at least one of window/process/className to identify the " +
+                "window; refusing to wait for an arbitrary window. For 'appears', drop timeout to list all windows now.",
                 "windows-no-criteria", "invalid-argument");
         }
 
-        List<WindowInfo> windows = Timeout > 0
+        return condition switch {
+            "disappears" => Disappears(),
+            "foreground" => Foreground(),
+            _ => Appears(waiting),
+        };
+    }
+
+    private CommandResult Appears(bool waiting) {
+        List<WindowInfo> matches = waiting
             ? WindowResolver.WaitForTopLevel(Window, Process, ClassName, Timeout)
             : WindowResolver.ListTopLevel(Window, Process, ClassName);
 
+        JsonObject data = new() {
+            ["condition"] = "appears",
+            ["count"] = matches.Count,
+            ["windows"] = ToArray(matches),
+        };
+        // A wait that found nothing is an honest miss (count:0), like a one-shot find miss; not a failure.
+        if (waiting) {
+            bool satisfied = matches.Count > 0;
+            data["satisfied"] = satisfied;
+            if (!satisfied) {
+                AddTimeoutDiagnostics(data);
+            }
+        }
+        return CommandResult.Ok(Cmd, data);
+    }
+
+    private CommandResult Disappears() {
+        List<WindowInfo> remaining = Timeout > 0
+            ? WindowResolver.WaitUntilGone(Window, Process, ClassName, Timeout)
+            : WindowResolver.ListTopLevel(Window, Process, ClassName);
+        bool gone = remaining.Count == 0;
+
+        JsonObject data = new() {
+            ["condition"] = "disappears",
+            ["satisfied"] = gone,
+            ["count"] = remaining.Count,
+            ["windows"] = ToArray(remaining), // still-present matches; empty on success
+        };
+        if (!gone) {
+            AddTimeoutDiagnostics(data);
+        }
+        return CommandResult.Ok(Cmd, data);
+    }
+
+    private CommandResult Foreground() {
+        WindowInfo? match = Timeout > 0
+            ? WindowResolver.WaitForForeground(Window, Process, ClassName, Timeout)
+            : ForegroundIfMatches();
+        bool satisfied = match is not null;
+
+        JsonObject data = new() {
+            ["condition"] = "foreground",
+            ["satisfied"] = satisfied,
+        };
+        if (satisfied) {
+            data["window"] = match!.ToJsonObject();
+        }
+        else {
+            WindowInfo? current = WindowResolver.Resolve(null, null, null, null, foreground: true);
+            data["foreground"] = current?.ToJsonObject(); // what IS foreground now (may be null)
+            AddTimeoutDiagnostics(data);
+        }
+        return CommandResult.Ok(Cmd, data);
+    }
+
+    private WindowInfo? ForegroundIfMatches() {
+        WindowInfo? fg = WindowResolver.Resolve(null, null, null, null, foreground: true);
+        return fg is not null && WindowResolver.Matches(fg, Window, Process, ClassName) ? fg : null;
+    }
+
+    private static JsonArray ToArray(List<WindowInfo> windows) {
         JsonArray arr = [];
         foreach (WindowInfo w in windows) {
             arr.Add(w.ToJsonObject());
         }
-        JsonObject data = new() {
-            ["count"] = windows.Count,
-            ["windows"] = arr,
-        };
-        // A wait that found nothing is an honest empty result (count:0), like a one-shot find miss; the
-        // agent branches on count. It is NOT a failure, so it is not reclassified as a timeout error.
-        return CommandResult.Ok(Cmd, data);
+        return arr;
     }
+
+    // Actionable timeout diagnostics (#112): echo what was waited for and the full last-observed top-level
+    // window set, so an agent can triage a timeout without issuing a second observation.
+    private void AddTimeoutDiagnostics(JsonObject data) {
+        // Echo all three criteria (null for the ones not applied) so a triaging agent sees exactly what
+        // was waited for, plus the current full top-level set.
+        JsonObject waitedFor = new() {
+            ["window"] = NullIfEmpty(Window),
+            ["process"] = NullIfEmpty(Process),
+            ["className"] = NullIfEmpty(ClassName),
+        };
+        data["waitedFor"] = waitedFor;
+        data["lastObservedWindows"] = ToArray(WindowResolver.EnumerateTopLevel());
+    }
+
+    private static JsonNode? NullIfEmpty(string value) =>
+        string.IsNullOrEmpty(value) ? null : JsonValue.Create(value);
 }

--- a/src/Commands/WindowsCommand.cs
+++ b/src/Commands/WindowsCommand.cs
@@ -16,20 +16,24 @@ namespace MCEControl;
 /// uses: <c>window</c> title substring (case-insensitive), <c>process</c> name (exact, without .exe),
 /// <c>classname</c> (exact).
 ///
-/// With a <c>timeout</c> it WAITS. <c>condition</c> selects the predicate (default <c>appears</c>):
+/// With a <c>timeout</c> it WAITS; a <c>timeout</c> of 0 is a one-shot check. <c>condition</c> selects the
+/// predicate (default <c>appears</c>):
 /// <list type="bullet">
-///   <item><c>appears</c>: poll until a matching window exists; returns the matches (<c>count:0</c> on timeout).</item>
-///   <item><c>disappears</c>: poll until NO window matches (a dialog/app closed); <c>satisfied</c> true when
-///     gone, and <c>windows</c> lists whatever is still present on timeout.</item>
-///   <item><c>foreground</c>: poll until the foreground window matches the filter; returns that <c>window</c>.</item>
+///   <item><c>appears</c>: until a matching window exists; returns the matches (a wait also reports
+///     <c>satisfied</c>, and <c>count:0</c> on timeout).</item>
+///   <item><c>disappears</c>: until NO window matches (a dialog/app closed); <c>satisfied</c> true when
+///     gone, and <c>windows</c> lists whatever is still present.</item>
+///   <item><c>foreground</c>: until the foreground window matches the filter; a satisfied result carries
+///     the matched <c>window</c>, an unsatisfied one carries <c>foreground</c> (what IS foreground now).</item>
 /// </list>
-/// On an unsatisfied wait the result carries actionable diagnostics (#112): <c>waitedFor</c> (the criteria)
-/// and <c>lastObservedWindows</c> (the full top-level set), so a timeout can be triaged without re-querying.
+/// A WAIT that times out unsatisfied carries actionable diagnostics (#112): <c>waitedFor</c> (the criteria)
+/// and <c>lastObservedWindows</c> (the full top-level set), so a timeout is triageable without re-querying.
+/// A one-shot check (<c>timeout:0</c>) that misses returns <c>satisfied:false</c> alone, no wait diagnostics.
 ///
 /// Returns <c>{ condition, count, windows: [ { handle, title, className, processName, processId, x, y, width, height }, … ] }</c>
-/// for <c>appears</c>/<c>disappears</c> (each element the <see cref="WindowInfo"/> shape via
-/// <see cref="WindowInfo.ToJsonObject"/>, so a listed handle is reusable directly), and
-/// <c>{ condition, satisfied, window }</c> for a satisfied <c>foreground</c>.
+/// for <c>appears</c>/<c>disappears</c> (a wait adds <c>satisfied</c>; each element the <see cref="WindowInfo"/>
+/// shape via <see cref="WindowInfo.ToJsonObject"/>, so a listed handle is reusable directly), and
+/// <c>{ condition, satisfied, window|foreground }</c> for <c>foreground</c>.
 ///
 /// SAFETY: a bare list (no filter, no timeout) enumerates ALL windows; that is discovery, not the
 /// silent-arbitrary-target hazard <see cref="WindowResolver.Resolve"/> guards against (it never picks one
@@ -79,7 +83,7 @@ public class WindowsCommand : AgentCommand {
         if (needsFilter && !HasFilter) {
             return CommandResult.Fail(Cmd,
                 $"windows condition '{condition}' needs at least one of window/process/className to identify the " +
-                "window; refusing to wait for an arbitrary window. For 'appears', drop timeout to list all windows now.",
+                "window; refusing to act on an arbitrary window. For 'appears', drop timeout to list all windows now.",
                 "windows-no-criteria", "invalid-argument");
         }
 
@@ -123,7 +127,8 @@ public class WindowsCommand : AgentCommand {
             ["count"] = remaining.Count,
             ["windows"] = ToArray(remaining), // still-present matches; empty on success
         };
-        if (!gone) {
+        // Wait diagnostics only when a WAIT actually timed out; a one-shot check (timeout:0) stays lean.
+        if (!gone && Timeout > 0) {
             AddTimeoutDiagnostics(data);
         }
         return CommandResult.Ok(Cmd, data);
@@ -145,7 +150,10 @@ public class WindowsCommand : AgentCommand {
         else {
             WindowInfo? current = WindowResolver.Resolve(null, null, null, null, foreground: true);
             data["foreground"] = current?.ToJsonObject(); // what IS foreground now (may be null)
-            AddTimeoutDiagnostics(data);
+            // Wait diagnostics only when a WAIT actually timed out; a one-shot check (timeout:0) stays lean.
+            if (Timeout > 0) {
+                AddTimeoutDiagnostics(data);
+            }
         }
         return CommandResult.Ok(Cmd, data);
     }

--- a/tests/MCEControl.xUnit/Commands/WindowsCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/WindowsCommandTests.cs
@@ -146,4 +146,121 @@ public class WindowsCommandTests {
             AgentRuntime.Settings = null;
         }
     }
+
+    [Fact] // #112: disappears
+    public void Execute_DisappearsWithFilterMatchingNothing_IsSatisfied() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            // Nothing matches the fake class, so there is nothing to wait for; it is already "gone".
+            WindowsCommand cmd = new() {
+                Cmd = "windows", Enabled = true, Reply = reply,
+                Condition = "disappears", ClassName = "MCEC_NoSuchWindowClass_112",
+            };
+
+            Assert.True(cmd.Execute());
+            JsonObject data = JsonNode.Parse(reply.Captured.Trim())!.AsObject()["data"]!.AsObject();
+            Assert.Equal("disappears", data["condition"]!.GetValue<string>());
+            Assert.True(data["satisfied"]!.GetValue<bool>());
+            Assert.Equal(0, data["count"]!.GetValue<int>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact] // #112: foreground predicate, unsatisfied, carries triage diagnostics
+    public void Execute_ForegroundWithFilterMatchingNothing_NotSatisfied_WithDiagnostics() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            // The foreground window never has this fake class; one-shot (no timeout) so it is fast.
+            WindowsCommand cmd = new() {
+                Cmd = "windows", Enabled = true, Reply = reply,
+                Condition = "foreground", ClassName = "MCEC_NoSuchWindowClass_112",
+            };
+
+            Assert.True(cmd.Execute());
+            JsonObject data = JsonNode.Parse(reply.Captured.Trim())!.AsObject()["data"]!.AsObject();
+            Assert.Equal("foreground", data["condition"]!.GetValue<string>());
+            Assert.False(data["satisfied"]!.GetValue<bool>());
+            Assert.True(data.ContainsKey("waitedFor"));
+            Assert.True(data.ContainsKey("lastObservedWindows"));
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact] // #112: appears timeout miss carries actionable diagnostics (waitedFor + lastObservedWindows)
+    public void Execute_AppearsTimeoutMiss_IncludesDiagnostics() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            WindowsCommand cmd = new() {
+                Cmd = "windows", Enabled = true, Reply = reply,
+                ClassName = "MCEC_NoSuchWindowClass_112", Timeout = 50,
+            };
+
+            Assert.True(cmd.Execute());
+            JsonObject data = JsonNode.Parse(reply.Captured.Trim())!.AsObject()["data"]!.AsObject();
+            Assert.False(data["satisfied"]!.GetValue<bool>());
+            Assert.Equal("MCEC_NoSuchWindowClass_112", data["waitedFor"]!.AsObject()["className"]!.GetValue<string>());
+            Assert.True(data.ContainsKey("lastObservedWindows"));
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact] // #112: disappears without a filter is the arbitrary-target hazard; refused
+    public void Execute_DisappearsWithNoFilter_Refused() {
+        AssertConditionRefusedWithoutFilter("disappears");
+    }
+
+    [Fact] // #112: foreground without a filter is refused for the same reason
+    public void Execute_ForegroundWithNoFilter_Refused() {
+        AssertConditionRefusedWithoutFilter("foreground");
+    }
+
+    [Fact] // #112: an unrecognized condition is a structured invalid-argument refusal
+    public void Execute_UnknownCondition_Refused() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            WindowsCommand cmd = new() {
+                Cmd = "windows", Enabled = true, Reply = reply,
+                Condition = "sideways", ClassName = "MCEC_NoSuchWindowClass_112",
+            };
+
+            Assert.False(cmd.Execute());
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.Equal("windows-unknown-condition", json["errorCode"]!.GetValue<string>());
+            Assert.Equal("invalid-argument", json["errorCategory"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    private static void AssertConditionRefusedWithoutFilter(string condition) {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            WindowsCommand cmd = new() { Cmd = "windows", Enabled = true, Reply = reply, Condition = condition };
+
+            Assert.False(cmd.Execute());
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.Equal("windows-no-criteria", json["errorCode"]!.GetValue<string>());
+            Assert.Equal("invalid-argument", json["errorCategory"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
 }

--- a/tests/MCEControl.xUnit/Commands/WindowsCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/WindowsCommandTests.cs
@@ -170,13 +170,15 @@ public class WindowsCommandTests {
         }
     }
 
-    [Fact] // #112: foreground predicate, unsatisfied, carries triage diagnostics
-    public void Execute_ForegroundWithFilterMatchingNothing_NotSatisfied_WithDiagnostics() {
+    [Fact] // #112: a one-shot predicate miss (timeout=0) is lean: satisfied:false + foreground, NO wait diagnostics
+    public void Execute_ForegroundOneShotMiss_LeanResult_NoWaitDiagnostics() {
         AgentTestSupport.EnsureTelemetry();
         AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
         try {
             CapturingReply reply = new();
-            // The foreground window never has this fake class; one-shot (no timeout) so it is fast.
+            // No timeout: a one-shot "is a matching window foreground right now?" check. The fake class
+            // never matches, so satisfied:false; it reports what IS foreground but attaches no wait
+            // diagnostics (waitedFor/lastObservedWindows are for a timed-out wait).
             WindowsCommand cmd = new() {
                 Cmd = "windows", Enabled = true, Reply = reply,
                 Condition = "foreground", ClassName = "MCEC_NoSuchWindowClass_112",
@@ -185,6 +187,29 @@ public class WindowsCommandTests {
             Assert.True(cmd.Execute());
             JsonObject data = JsonNode.Parse(reply.Captured.Trim())!.AsObject()["data"]!.AsObject();
             Assert.Equal("foreground", data["condition"]!.GetValue<string>());
+            Assert.False(data["satisfied"]!.GetValue<bool>());
+            Assert.True(data.ContainsKey("foreground"));           // reports what IS foreground now
+            Assert.False(data.ContainsKey("waitedFor"));            // no wait -> no wait diagnostics
+            Assert.False(data.ContainsKey("lastObservedWindows"));
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact] // #112: a timed-out predicate miss carries triage diagnostics
+    public void Execute_ForegroundTimedOutMiss_IncludesDiagnostics() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            WindowsCommand cmd = new() {
+                Cmd = "windows", Enabled = true, Reply = reply,
+                Condition = "foreground", ClassName = "MCEC_NoSuchWindowClass_112", Timeout = 50,
+            };
+
+            Assert.True(cmd.Execute());
+            JsonObject data = JsonNode.Parse(reply.Captured.Trim())!.AsObject()["data"]!.AsObject();
             Assert.False(data["satisfied"]!.GetValue<bool>());
             Assert.True(data.ContainsKey("waitedFor"));
             Assert.True(data.ContainsKey("lastObservedWindows"));


### PR DESCRIPTION
Closes #112 — wait for a window to **appear / disappear / become foreground** as a first-class predicate, instead of runner-side `query` polling.

## What

Extends the existing `windows` tool (which already owned window-waiting for *appears*) with a `condition` parameter (default `appears`), reusing the same gate and result envelope:

| `condition` | waits until | result |
|-------------|-------------|--------|
| `appears` (default) | a matching window exists | `{ count, windows[] }` (count:0 on timeout) — unchanged |
| `disappears` | no window matches (a modal/app closed) | `{ satisfied, count, windows[] }` — `windows` lists what's still present on timeout |
| `foreground` | a matching window is the foreground window | `{ satisfied, window }` |

On an **unsatisfied wait**, the result carries `waitedFor` (the criteria) + `lastObservedWindows` (the full top-level set) so a timeout is triageable without a second observation (the #112 diagnostics ask). `disappears`/`foreground` (and any wait) require a filter — the same arbitrary-target refusal as `appears`.

Acceptance: the walking skeleton's runner-side window polling (`Wait-For { query ... }`) becomes a single `windows { condition, <filter>, timeout }` call.

## Design note

Extended the `windows` tool rather than adding a new `wait-for-window` tool: `windows` already is the window-wait mechanism (appears), so this is additive, keeps one command/gate, and the new result fields are backward-compatible (existing consumers still read `count`/`windows`).

## Changes
- `WindowResolver.WaitUntilGone` / `WaitForForeground` (mirror `WaitForTopLevel`).
- `WindowsCommand`: `condition` branch + additive diagnostics.
- `ToolCatalog`: `condition` schema + mapping + refreshed description.
- **Guidance in lockstep** (per the repo rule): `AgentInstructions.md` (embedded, served over MCP), `AGENTS.md`, and the `environment-controller.md` tool reference.

## Testing
`dotnet test tests/MCEControl.xUnit` → **964 passed, 22 skipped, 0 failed**. New tests: disappears/foreground satisfied + unsatisfied-with-diagnostics, no-filter refusal, unknown-condition refusal, appears-timeout diagnostics; all headless-safe (fake filters). Existing `windows` tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)