### PR TITLE
hero(winprint): size knobs (~4MB default) + fix stale docs

### DIFF
--- a/docs/winprint-hero-gif.md
+++ b/docs/winprint-hero-gif.md
@@ -27,8 +27,9 @@ here and accepts `-WinPrintRoot` (default: current directory).
   `provision-session` will fold this artifact cleanup into session provisioning.
 - **Disposable MCEC session** — the harness copies the installed MCEC into
   `%LOCALAPPDATA%\MCEC\sessions\winprint-hero`, writes agent config **only there**, and deletes the
-  dir afterward. The core install's `mcec.settings` / `mcec.commands` are never touched (a formal
-  `provision-session` replaces this copy/delete dance).
+  dir afterward, so the core install's `mcec.settings` / `mcec.commands` are never touched. (The
+  `provision-session` tool now does this properly; the mcec hero uses it and this harness should move
+  to it too.)
 
 ## One-shot regeneration
 
@@ -42,15 +43,18 @@ pwsh -NoProfile -File C:\path\to\mcec\scripts\Generate-WinPrint-HeroGif.ps1
 pwsh -NoProfile -File scripts/Generate-WinPrint-HeroGif.ps1
 ```
 
-**Pre-release dev builds:** until this epic merges to `develop`, the harness needs MCEC with the
-`clipboard` tool (plain `develop` returns `Unknown tool: clipboard`). For local dogfood, pass
-`-McecInstallDir` to a Debug build from this branch:
+**Pre-release dev builds:** MCEC is not yet published to winget, so until it is installed on the box the
+harness has nothing to discover. For local dogfood, build MCEC and point `-McecInstallDir` at the build
+output (it needs the `clipboard` tool, which is on `develop`):
 
 ```powershell
 dotnet build src\MCEControl.csproj -c Debug
 pwsh -NoProfile -File scripts\Generate-WinPrint-HeroGif.ps1 `
   -McecInstallDir C:\path\to\mcec\src\bin\Debug\net10.0-windows
 ```
+
+**Tuning size:** the tour runs ~40 s, so file size tracks frame count (`~40 x Fps`) times frame area.
+Defaults (`-Fps 2 -MaxWidth 560`) produce ~4 MB; raise them for a smoother/larger GIF, lower to shrink.
 
 Evidence bundles land under `artifacts/customer1/` in the mcec repo (see [evidence-bundles.md](evidence-bundles.md)).
 
@@ -59,7 +63,7 @@ Evidence bundles land under `artifacts/customer1/` in the mcec repo (see [eviden
 | Symptom | Recovery |
 |---------|----------|
 | `WinPrint did not appear` after Start search | Kill stray `winprint`/`mcec` processes, pause a few seconds, rerun. The harness already sends Win+D before Win+S; a focused IDE can still steal the first attempt. |
-| `Unknown tool: clipboard` | MCEC is too old or a plain `develop` build without this epic; use a build from `epic-84-winprint-hero-mcec` or pass `-McecInstallDir` to one. |
+| `Unknown tool: clipboard` | MCEC predates the `clipboard` tool; use a current `develop` build (pass `-McecInstallDir` to it). |
 | `Remove-Item` fails on `winprintdemo.pdf` | A PDF viewer still has the file open; the harness sends Alt+F4 after record stop, but kill the viewer manually if a prior run aborted early. |
 
 ## Manual MCP recipe (agent-playbook)

--- a/scripts/Generate-WinPrint-HeroGif.ps1
+++ b/scripts/Generate-WinPrint-HeroGif.ps1
@@ -29,7 +29,12 @@ param(
     [string]$WinPrintRoot = (Get-Location).Path,
     [string]$McecInstallDir = '',
     [string]$PdfPath = (Join-Path $env:USERPROFILE 'Documents\winprintdemo.pdf'),
-    [string]$ArtifactRoot = ''
+    [string]$ArtifactRoot = '',
+    # GIF size knobs. The tour runs ~40 s, so frame count = ~40 x Fps; file size ~= frames x
+    # frame area. Defaults target ~3-4 MB, matching the mcec hero. Raise for a smoother/larger
+    # GIF, lower to shrink. See docs/winprint-hero-gif.md "Tuning size".
+    [int]$Fps = 2,
+    [int]$MaxWidth = 560
 )
 
 $ErrorActionPreference = 'Stop'
@@ -209,7 +214,7 @@ try {
     Step 'controller' 'pass' 'disposable MCEC session up'
 
     Invoke-McecTool 'record' @{
-        action = 'start'; x = $rx; y = $ry; width = $rw; height = $rh; fps = 4; maxWidth = 880
+        action = 'start'; x = $rx; y = $ry; width = $rw; height = $rh; fps = $Fps; maxWidth = $MaxWidth
     } -Session $session | Out-Null
     Step 'record-start' 'pass' 'region record started'
     Start-Sleep -Milliseconds 500


### PR DESCRIPTION
Regenerated `winprint/docs/hero-gui-win.gif` from `develop` and made the recorder produce a README-appropriate artifact.

## What
- **`-Fps` / `-MaxWidth` knobs** on `Generate-WinPrint-HeroGif.ps1`. The record start was hardcoded `fps=4; maxWidth=880`, which with the current ~40s tour wrote a **20.1 MB / 151-frame** GIF (7x the prior committed 2.67 MB, too heavy for a README hero). New defaults `2` / `560` → **4.1 MB / 72 frames**, matching the mcec hero.
- **Doc fixes** in `winprint-hero-gif.md`:
  - Drop the stale "plain `develop` returns `Unknown tool: clipboard`" claim — the clipboard tool + harness landed on develop (#140).
  - Note that `provision-session` now exists (was tracked by the closed #138) and this harness should migrate to it, instead of framing it as unbuilt future work.
  - Add a **Tuning size** note documenting the new knobs.

## Verification
- Two consecutive runs against a develop Debug build (`-McecInstallDir`), **all 13 steps green on the first try each time** — reliability holds.
- Frame-inspected both takes: clean end-to-end tour (WinPrint launch -> SheetViewModel.cs + README.md rendered -> Print -> Save PDF -> open PDF), burnt-orange overlay narrating, no stray menus.
- No C# changed; build green.

## Follow-ups
Larger items (tighter record region / duration, migrate to `provision-session`, agent-driven parity with the mcec hero, winget-publish dependency, final-frame Edge-chrome polish) are tracked in #287. The regenerated GIF itself is committed separately in the winprint repo on say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)