### PR TITLE
fix(overlay): show the "controlling your PC" banner only when the agent front door is open

### DIFF
--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -513,10 +513,12 @@ public partial class MainWindow : Form, IAppHost {
         }
 
         // MCEC 3.0: on-screen command overlay (#119); narrates each command as it executes so anyone
-        // watching sees that MCEC is driving. On by default; headless --mcp hosts its copy on
-        // HeadlessOperatorUi's pump thread, never here. Independent (not owned) so it keeps narrating
-        // even when the MCEC window is minimized to the tray.
-        if (Settings.CommandOverlayEnabled && !AgentRuntime.Headless && _commandOverlay is null) {
+        // watching sees that MCEC is driving. Shown only when the agent front door is open (#292); a
+        // normal instance (e.g. a socket server for a Media Center remote) must never show the
+        // "controlling your PC" banner. Same front-door qualifier as the emergency stop above. Headless
+        // --mcp hosts its copy on HeadlessOperatorUi's pump thread, never here (stdio is always a live
+        // front door there). Independent (not owned) so it keeps narrating even when minimized to the tray.
+        if (ShouldShowCommandOverlay(Settings) && !AgentRuntime.Headless && _commandOverlay is null) {
             _commandOverlay = new CommandOverlayWindow();
             _commandOverlay.Show();
         }
@@ -530,6 +532,16 @@ public partial class MainWindow : Form, IAppHost {
             UserActivityMonitorService.Instance.LogActivity = Settings.LogUserActivity;
             UserActivityMonitorService.Instance.Start();
         }
+    }
+
+    // The command overlay (and its persistent "MCEC is controlling your PC" banner) only makes sense
+    // when an agent could be driving; it must not appear on a normal, non-agent instance (#292). Gated
+    // on the same front door as the emergency stop: the overlay narrates agent commands, so it belongs
+    // exactly when the MCP/HTTP endpoint or the agent commands are enabled. CommandOverlayEnabled=false
+    // still force-disables it. (Headless --mcp is handled by HeadlessOperatorUi, not this gate.)
+    internal static bool ShouldShowCommandOverlay(AppSettings settings) {
+        ArgumentNullException.ThrowIfNull(settings);
+        return settings.CommandOverlayEnabled && (settings.McpServerEnabled || settings.AgentCommandsEnabled);
     }
 
     private void Stop() {

--- a/tests/MCEControl.xUnit/MainWindowOverlayGateTests.cs
+++ b/tests/MCEControl.xUnit/MainWindowOverlayGateTests.cs
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+//-------------------------------------------------------------------
+
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit;
+
+/// <summary>
+/// The GUI host only shows the command overlay (and its "MCEC is controlling your PC" banner) when the
+/// agent front door is open (#292); a normal, non-agent instance must not show it. Pure gate; no Form
+/// is constructed (InternalsVisibleTo).
+/// </summary>
+public class MainWindowOverlayGateTests {
+    [Theory]
+    // overlayEnabled, mcpServerEnabled, agentCommandsEnabled, expected
+    [InlineData(true, false, false, false)] // the bug: enabled by default, but no front door -> hidden
+    [InlineData(true, true, false, true)]   // MCP/HTTP front door open -> shown
+    [InlineData(true, false, true, true)]   // agent commands front door open -> shown
+    [InlineData(true, true, true, true)]    // both open -> shown
+    [InlineData(false, true, false, false)] // CommandOverlayEnabled=false force-disables it
+    [InlineData(false, false, true, false)] // ditto, even with a front door open
+    [InlineData(false, false, false, false)]
+    public void ShouldShowCommandOverlay_RequiresOverlayEnabledAndAnOpenFrontDoor(
+        bool overlayEnabled, bool mcpServerEnabled, bool agentCommandsEnabled, bool expected) {
+        AppSettings settings = new() {
+            CommandOverlayEnabled = overlayEnabled,
+            McpServerEnabled = mcpServerEnabled,
+            AgentCommandsEnabled = agentCommandsEnabled,
+        };
+
+        Assert.Equal(expected, MainWindow.ShouldShowCommandOverlay(settings));
+    }
+}


### PR DESCRIPTION
Closes #292.

## Problem
A normal MCEC instance (Start Menu launch, acting as a socket/TCP server for a Media Center remote, no agent front door enabled) showed the persistent always-on-top **"MCEC is controlling your PC"** banner. Alarming and wrong: no agent could be driving.

## Cause
`MainWindow.Start()` created the overlay gated only on `CommandOverlayEnabled` (default `true`), omitting the agent-front-door qualifier the sibling emergency-stop gate already requires:

```csharp
// emergency stop (correct):
if (!AgentRuntime.Headless && Settings.EmergencyStopEnabled && (Settings.McpServerEnabled || Settings.AgentCommandsEnabled)) { ... }
// overlay (buggy):
if (Settings.CommandOverlayEnabled && !AgentRuntime.Headless && _commandOverlay is null) { ... }
```

## Fix
Show the overlay only when `CommandOverlayEnabled && (McpServerEnabled || AgentCommandsEnabled)`. Extracted into `MainWindow.ShouldShowCommandOverlay(AppSettings)` and covered with a truth-table test.

- A normal, non-agent instance never shows the banner.
- `CommandOverlayEnabled=false` still force-disables it.
- Headless `--mcp` unchanged: `HeadlessOperatorUi` gates on `CommandOverlayEnabled` alone by design (stdio is always a live front door).

## Verification
- `dotnet build src`: 0 warnings, 0 errors.
- Full suite: **976 passed, 0 failed, 22 skipped** (7 new gate cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)