### PR TITLE
docs: document the User Activity Monitor (PC as occupancy sensor for lighting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Enable the agent surface only on a machine and session where you accept an agent
 
 MCEC is also the same **battle-tested remote control for home-automation systems** it has always been. In its long-standing role it runs in the background listening on the network (or a serial port) for commands, and translates them into keystrokes, text input, mouse moves, window messages, and app launches. Any remote control or home-control system that can send text over TCP/IP or RS-232 ([Control4](https://www.control4.com/), [iRule](http://www.iruleathome.com/), [Crestron](http://www.crestron.com/), and others) can use MCEC to drive a Windows PC. The agent surface in 3.0 is **purely additive**: every existing home-automation feature is unchanged.
 
+It also runs the flow in reverse: the **[User Activity Monitor](https://tig.github.io/mcec/home-automation.html#user-activity-monitor)** reports when someone is actively using the PC, turning the machine into an occupancy sensor a control system can use to drive lighting. It is better than a passive motion detector, which gives up on someone sitting still at a desk. The [Control4 User Activity Driver](https://github.com/tig/User_Activity) packages exactly that.
+
 * [Documentation](https://tig.github.io/mcec): start here
 * [Configuration](https://tig.github.io/mcec/configuration.html): configuring mcec
 * [Environment Controller](https://tig.github.io/mcec/environment-controller.html): the full agent/MCP tool reference and security model

--- a/docs/home-automation.md
+++ b/docs/home-automation.md
@@ -134,19 +134,76 @@ When the Serial Server is enabled, MCEC opens the specified COM port (e.g. COM1)
 
 ## User Activity Monitor
 
-MCEC's **User Activity Monitor** sends a command (`activity` by default) to your home-automation system
-when a user is using the PC. It knows the PC is in use by watching keyboard and mouse activity; if the
-mouse is moving or keys are being pressed, the PC is in use. This is useful for adding context to a room
-occupancy sensor.
+The **User Activity Monitor** turns the PC into an occupancy sensor for the room it sits in. While someone
+is actively using the machine, MCEC sends a command (`activity` by default) to your control system; the
+control system treats that as "the room is occupied" and acts on it, most commonly to turn the lights on
+and hold them on.
+
+This is a better occupancy signal than a passive-infrared (PIR) motion detector for any space where people
+sit still. A PIR sensor watches for gross body movement, so it happily switches an office's lights off on
+someone who is reading, on a call, or typing without waving their arms around. MCEC watches keyboard and
+mouse activity instead, so as long as you are actually working, the room reads as occupied and the lights
+stay on.
+
+### What it watches
+
+The monitor combines up to three independent presence signals. Each is a checkbox on the Activity Monitor
+tab, and all three are on by default once the monitor is enabled.
+
+* **Keyboard and mouse input.** The primary signal. A global low-level input hook sees any key press or
+  mouse movement, in any application, and reads it as the user being present. This is the signal that makes
+  MCEC better than a motion detector.
+* **Desktop lock and unlock.** Locking the desktop (Win+L, or an idle timeout) is a strong "nobody is here"
+  signal, so the monitor stops reporting presence; unlocking reports presence again immediately.
+* **Windows user presence and power.** MCEC listens to the Windows power notifications (user present versus
+  inactive, away mode, and monitor on/off) and stops presuming presence when Windows reports that the
+  session has gone idle or the monitor has powered down.
+
+### How often it reports
+
+While presence is detected, MCEC sends the activity command no more often than the **debounce time**
+(default 10 seconds), so the control system is not flooded on every mouse move. As long as you keep using
+the PC it keeps re-sending on that interval, which lets the control system run a simple "turn the lights off
+if I have not heard `activity` in N minutes" timer. When you stop (lock the desktop, walk away and let the
+session go idle, or turn the monitor off), the messages stop and that timer eventually expires.
 
 ![Activity Monitor](settings_activity.png "Activity Monitor")
 
-* **Enable User Activity Monitor**: enables/disables the monitor (disabled by default). If enabled:
-* **Command to send**: the string sent when activity is detected (`activity` by default).
-* **Debounce time (seconds)**: the activity message is sent no more frequently than this.
+Configure it on the **File ▸ Settings… ▸ Activity Monitor** tab:
 
-See the [Control4 User Activity Driver](https://github.com/tig/User_Activity) for an example Control4
-driver that uses this feature.
+* **Enable User Activity Monitor**: turns the monitor on or off (off by default). If enabled:
+* **Detection method**: which of the three signals above to use (all on by default).
+* **Command to send**: the string sent when activity is detected (`activity` by default). Send whatever
+  string your control system expects.
+* **Debounce time (seconds)**: the shortest gap between messages (default 10).
+
+The command travels over whichever transports are enabled (the TCP/IP client, the TCP/IP server, or the
+serial server), so you can either have MCEC connect **out** to your controller (the Client tab) or have the
+controller connect **in** to MCEC (the Server tab).
+
+### Example: your office lights follow you
+
+A typical setup, and the one this feature was built for:
+
+1. On the **Client** tab, enable the client and point it at the control system (for the Control4 driver
+   below, that is the controller's IP address and port **10001**).
+2. On the **Activity Monitor** tab, enable the monitor, leave the command as `activity`, and leave the
+   debounce at 10 seconds.
+3. On the control-system side, receive the `activity` string and use it as an occupancy input: turn the
+   office lights on, and (re)start a countdown that turns them off after, say, 15 minutes of silence.
+
+Now the lights come on when you sit down and start typing, stay on the whole time you are at the desk (even
+when you are just reading, and a motion sensor would have given up on you), and drop a while after you
+leave.
+
+For Control4, the [User Activity Driver](https://github.com/tig/User_Activity) packages exactly this: it
+listens for MCEC's `activity` messages and exposes them as a `CONTACT_SENSOR`, which you wire to a
+motion-sensor input or bind directly to lighting and scene programming. There is also a community
+[Control4.MceControllerDriver](https://github.com/garrynewman/Control4.MceControllerDriver).
+
+MCEC was originally built to feed a Crestron whole-house system, and Crestron works the same way with no
+packaged driver needed: point MCEC at a TCP client (or a serial port) on the processor, and a few lines of
+SIMPL logic latch a digital "occupied" signal on each `activity` string and drive the lighting from it.
 
 ## Enabling or Disabling Commands
 

--- a/docs/home-automation.md
+++ b/docs/home-automation.md
@@ -145,34 +145,36 @@ someone who is reading, on a call, or typing without waving their arms around. M
 mouse activity instead, so as long as you are actually working, the room reads as occupied and the lights
 stay on.
 
-### What it watches
+### How it decides the room is occupied
 
-The monitor combines up to three independent presence signals. Each is a checkbox on the Activity Monitor
-tab, and all three are on by default once the monitor is enabled.
+**Keyboard and mouse input is the occupancy signal, and the engine of the whole feature.** A global
+low-level input hook sees any key press or mouse movement, in any application, and arms a short repeating
+timer that emits the activity command about once per **debounce time** (default 10 seconds), rather than on
+every mouse move. This is the signal that makes MCEC better than a motion detector, and the monitor emits
+nothing without it.
 
-* **Keyboard and mouse input.** The primary signal. A global low-level input hook sees any key press or
-  mouse movement, in any application, and reads it as the user being present. This is the signal that makes
-  MCEC better than a motion detector.
-* **Desktop lock and unlock.** Locking the desktop (Win+L, or an idle timeout) is a strong "nobody is here"
-  signal, so the monitor stops reporting presence; unlocking reports presence again immediately.
-* **Windows user presence and power.** MCEC listens to the Windows power notifications (user present versus
-  inactive, away mode, and monitor on/off) and stops presuming presence when Windows reports that the
-  session has gone idle or the monitor has powered down.
+That timer keeps asserting presence on the same interval even after you stop touching the keyboard (that is
+the point: someone reading at their desk still counts as present). What turns it off is the other two
+options, which are **refinements that stop a stale "occupied" reading once Windows confirms you have
+actually left**, not standalone occupancy sources:
 
-### How often it reports
+* **Desktop lock and unlock.** Locking the desktop (Win+L, or an idle timeout) stops the timer at once;
+  unlocking re-arms it.
+* **Windows user presence and power.** When Windows reports the session has gone idle, entered away mode, or
+  powered the monitor down, the timer stops.
 
-While presence is detected, MCEC sends the activity command no more often than the **debounce time**
-(default 10 seconds), so the control system is not flooded on every mouse move. As long as you keep using
-the PC it keeps re-sending on that interval, which lets the control system run a simple "turn the lights off
-if I have not heard `activity` in N minutes" timer. When you stop (lock the desktop, walk away and let the
-session go idle, or turn the monitor off), the messages stop and that timer eventually expires.
+Leave all three on (the default). Keyboard and mouse input is what actually reports occupancy; lock/unlock
+and user presence are what make it drop promptly when you step away, instead of the timer pulsing presence
+until you lock the desktop or MCEC shuts down.
 
 ![Activity Monitor](settings_activity.png "Activity Monitor")
 
 Configure it on the **File ▸ Settings… ▸ Activity Monitor** tab:
 
 * **Enable User Activity Monitor**: turns the monitor on or off (off by default). If enabled:
-* **Detection method**: which of the three signals above to use (all on by default).
+* **Detection method**: keyboard/mouse input is the occupancy signal and must stay on for the monitor to
+  report anything; desktop lock/unlock and Windows user presence are refinements that make presence drop
+  faster when you leave. Keep all three on (the default).
 * **Command to send**: the string sent when activity is detected (`activity` by default). Send whatever
   string your control system expects.
 * **Debounce time (seconds)**: the shortest gap between messages (default 10).

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,9 @@ home-automation command surface (network and serial), which is unchanged.
 * **[Home Automation & Remote Control](home-automation.html)** — the classic role: listen on TCP/IP or a
   serial port and translate remote commands into keystrokes, text, mouse, window messages, and app
   launches ([Control4](https://www.control4.com/), [iRule](http://www.iruleathome.com/),
-  [Crestron](http://www.crestron.com/), and others).
+  [Crestron](http://www.crestron.com/), and others). The same chapter covers the **User Activity Monitor**,
+  which runs the flow in reverse: it reports when someone is actively using the PC, turning the machine into
+  an occupancy sensor that can drive lighting and scenes.
 
 See also [AGENTS.md](https://github.com/tig/mcec/blob/main/AGENTS.md) for connect-time agent guidance and
 the dogfood recipe (MCEC driving MCEC).


### PR DESCRIPTION
The User Activity Monitor was barely documented despite being one of the most useful home-automation features (a PC that reports when you are actively using it, so a control system can drive lighting). This fills that gap in three places, as requested.

## Overview (`index.md`)
Brief mention in the Home Automation chapter description: the same chapter covers the User Activity Monitor, which turns the PC into an occupancy sensor that can drive lighting and scenes.

## Home Automation (`home-automation.md`, deep)
Rewrote the thin section into a full treatment:
- **Why it beats a PIR motion detector** for anyone sitting still at a desk (reading, on a call, typing) where a motion sensor gives up and kills the lights.
- **What it watches:** keyboard/mouse input (the primary signal), desktop lock/unlock, and Windows user-presence/power notifications; all three on by default once enabled.
- **Debounce behavior:** re-sends `activity` on an interval (default 10s) so the control system can run a simple "lights off if silent for N minutes" timer.
- **All Activity Monitor tab settings**, and how the command reaches a control system over the client, server, or serial transport.

## Worked example
"Your office lights follow you": client → controller on port **10001**, `activity` command, a countdown that holds the lights on. Cites the [Control4 User Activity Driver](https://github.com/tig/User_Activity) (exposes a `CONTACT_SENSOR`) as the ready-made integration, plus the community `Control4.MceControllerDriver`, and describes the equivalent Crestron SIMPL pattern (MCEC's original home).

No em-dashes; no issue/PR references in the doc text.