### PR TITLE
Let provisioning bootstrap itself: installed-copy bootstrap MCP mode + operator Provision button (#296)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,12 @@ Two safety features layer on top (see [`docs/safety-emergency-stop-and-provision
   `AllowSessionProvisioning` opt-in, set from **File ▸ Settings ▸ Agent**) hands the agent a disposable
   directory with its own agent-ready config; teardown is deleting the directory, and MCEC reaps orphaned
   session dirs on launch. The installed config is never touched. That same Agent tab lists the provisioned
-  instances and lets the operator delete any an agent leaves behind.
+  instances, lets the operator delete any an agent leaves behind, and (with the opt-in ticked) has a
+  **Provision new…** button that mints one and shows the handoff. So provisioning can bootstrap itself
+  (#296): the installed `mcec.exe --mcp` serves the **bootstrap only** — just `provision-session` /
+  `end-session`, every other tool refused with `bootstrap-only` — so a fresh install's agent has a first
+  hop, while the full observe/act surface is still never served from Program Files. Keep the bootstrap
+  restriction (`Program.ProvisioningBootstrapOnly`) and the meta-tools' own gates intact.
 
 ## Dogfood: test MCEC using MCEC (mcec drives mcec)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,10 +32,13 @@ spawn it on demand and talk JSON-RPC over stdio:
 mcec.exe mcp
 ```
 
-The **installed** copy (under Program Files) refuses to run as an MCP server or to serve the MCP/HTTP
-endpoint: enabling agent gates in the installed configuration would leak them enabled if a session
-crashed. Use [session provisioning](safety-emergency-stop-and-provisioning.md) to get a disposable,
-isolated copy, or copy the install directory somewhere writable and run from there.
+The **installed** copy (under Program Files) never serves the full agent surface: it refuses to start
+the MCP/HTTP endpoint, and over `mcp`/`--mcp` it serves only the provisioning **bootstrap**
+(`provision-session` / `end-session`), because enabling agent gates in the installed configuration would
+leak them enabled if a session crashed. Use [session provisioning](safety-emergency-stop-and-provisioning.md)
+to get a disposable, isolated copy that serves everything — call `provision-session` (or click
+**Provision new…** on File ▸ Settings ▸ Agent), or copy the install directory somewhere writable and run
+from there.
 
 `mcec.exe` also has a command-line surface (built on
 [Terminal.Gui.Cli](https://github.com/gui-cs/cli)): `--help`, `--version`, `--opencli` (machine-readable
@@ -92,7 +95,7 @@ The agent surface is configured by these keys. All are off/safe by default; see
 | `CommandOverlayPosition` | `Right` | Which side of the primary screen the overlay docks to. |
 | `EmergencyStopEnabled` | `true` | Arms the global emergency-stop hotkey while the agent front door could be driving. |
 | `EmergencyStopHotkey` | `Ctrl+Alt+Shift+S` | The panic-hotkey chord (a `+`-separated spec). |
-| `AllowSessionProvisioning` | `false` | Operator opt-in that lets an agent request a fresh, isolated MCEC instance via `provision-session`. |
+| `AllowSessionProvisioning` | `false` | Operator opt-in that lets an agent request a fresh, isolated MCEC instance via `provision-session` (and enables the **Provision new…** button on the Agent tab). |
 | `AgentRecordMaxFps` / `AgentRecordMaxDurationMs` / `AgentRecordMaxFrames` / `AgentRecordMaxWidth` | 30 / 60000 / 600 / 1280 | Safety limits for the `record` tool (requests above them are clamped, not failed). |
 
 Restart MCEC (or relaunch `--mcp`) after editing `mcec.settings`.

--- a/docs/environment-controller.md
+++ b/docs/environment-controller.md
@@ -499,15 +499,19 @@ input/output:
 mcec.exe mcp        # or the equivalent legacy spelling: mcec.exe --mcp
 ```
 
-**Never point an MCP client at the installed copy.** `mcec.exe` under Program Files
-refuses `mcp`/`--mcp` (and refuses to start the MCP/HTTP endpoint) with an error
-explaining the alternatives: serving agents from the installed, operator-owned copy
-would mean enabling agent security gates in the one configuration the operator's own
-MCEC reads, where a crashed session leaks them enabled. Instead, either have an agent
-call `provision-session` (see
-[Agent safety](safety-emergency-stop-and-provisioning.md)) to get a disposable,
-isolated copy, or copy the install directory somewhere writable and point the client
-there; a non-installed copy reads its own co-located `mcec.settings`.
+**Don't drive the installed copy directly; use it to bootstrap.** `mcec.exe` under Program Files never
+serves the full agent surface: it refuses to start the MCP/HTTP endpoint, and over `mcp`/`--mcp` it
+serves **only the provisioning bootstrap** (#296) — `tools/list` and dispatch expose just
+`provision-session` and `end-session`, and every observation/actuation tool is refused with
+`error.code: bootstrap-only` (the connect-time `instructions` say so). Serving the full surface from the
+installed, operator-owned copy would mean enabling agent security gates in the one configuration the
+operator's own MCEC reads, where a crashed session leaks them enabled. So an MCP client points at the
+installed copy only to call `provision-session` (see
+[Agent safety](safety-emergency-stop-and-provisioning.md)) and gets back a disposable, isolated copy that
+serves the full surface — then drives *that*. Alternatives that skip the round-trip: click
+**Provision new…** on File ▸ Settings ▸ Agent and paste the handoff into your client, or copy the install
+directory somewhere writable and point the client there (a non-installed copy reads its own co-located
+`mcec.settings` and serves everything).
 
 The exe also exposes a CLI surface (built on
 [Terminal.Gui.Cli](https://github.com/gui-cs/cli)): `--opencli` emits machine-readable
@@ -529,7 +533,9 @@ style used by most clients):
 ```
 
 (`C:/mcec` here is a writable copy of the install directory, or a provisioned session's
-`directory`; the Program Files path itself would be refused, per above.)
+`directory`. Pointing it at the Program Files path connects, but that copy serves only the
+`provision-session`/`end-session` bootstrap, per above — use it to mint an instance, then repoint your
+client at the instance's `directory`.)
 
 `mcp` is a spawned server, not an interactive command: typed at a terminal it refuses
 (stdin is an interactive console; the server would block on the shared console and

--- a/docs/safety-emergency-stop-and-provisioning.md
+++ b/docs/safety-emergency-stop-and-provisioning.md
@@ -110,10 +110,34 @@ that copy). The agent runs from there and deletes it when done, so any enabled s
 throwaway copy, "cleanup" is `rm -rf <dir>`, and a crashed or killed session leaves the real install
 untouched. Concurrent sessions each get their own directory and never contend.
 
-The installed copy **enforces** its side of this: `mcec.exe` running from Program Files refuses
-`mcp`/`--mcp` and refuses to start the MCP/HTTP endpoint (`Program.IsProgramFilesInstall`), with an
-error pointing at provisioning or a manual writable copy. The operator's install cannot be turned into
-an agent server even by editing its settings.
+The installed copy **enforces** its side of this: `mcec.exe` running from Program Files never serves the
+full agent surface. It refuses to start the MCP/HTTP endpoint (`AgentServer.StartHttp` →
+`Program.IsProgramFilesInstall`), and over `--mcp` it serves **only the provisioning bootstrap** (see
+below). The operator's install cannot be turned into an observation/actuation agent server even by
+editing its settings.
+
+### Bootstrapping: how a fresh install gets its first instance (#296)
+
+There is a chicken-and-egg to close. `provision-session` is itself an MCP tool, so an agent must reach
+*some* MCEC MCP server to call it; but a fresh install's own copy refuses to serve agents, and a new
+user has no other copy yet. Two first hops resolve it, neither requiring the operator to hand-edit a
+config:
+
+- **Operator-initiated (GUI).** The **Agent** tab's **Provision new…** button calls
+  `SessionProvisioner.Provision()` directly (no MCP round-trip) and shows a copyable handoff
+  ([`ProvisionedInstanceDialog`](../src/Dialogs/ProvisionedInstanceDialog.cs)): the directory, the
+  `mcec.exe --mcp` launch line, the HTTP endpoint + bearer token, and teardown notes. The operator
+  pastes that into their agent's MCP client. Enabled only when the opt-in below is ticked.
+- **Bootstrap MCP mode (headless).** An agent may connect to the **installed** `mcec.exe --mcp`; but
+  from the install it serves a restricted surface: `tools/list` and dispatch expose **only**
+  `provision-session` and `end-session`, and every other tool is refused with `error.code:bootstrap-only`
+  (the connect-time `instructions` say so). That is enough to mint a disposable instance and no more; the
+  installed config is never touched because neither meta-tool observes or actuates. Gated, as always, by
+  `AllowSessionProvisioning`. See `Program.ProvisioningBootstrapOnly`, `JsonRpcDispatcher` (restricted
+  `tools/list` + bootstrap `instructions`), and `AgentToolExecutor.CallTool` (the `bootstrap-only` gate).
+
+Either way the agent gets back a **non-installed** disposable copy that serves the full tool surface, and
+drives *that*.
 
 ### Flow
 
@@ -123,7 +147,8 @@ an agent server even by editing its settings.
    to let an agent drive MCEC; it grants access only to a disposable copy, never this installed instance.
    The tab refuses to toggle it from inside a provisioned copy, so a driving agent can never widen its
    own permissions.
-2. Agent calls `provision-session` (optional `mcpServer`, `commands`). MCEC
+2. A session is created, either by the operator's **Provision new…** button or by an agent calling
+   `provision-session` (optional `mcpServer`, `commands`) over the bootstrap MCP surface. MCEC
    ([`SessionProvisioner`](../src/Agent/SessionProvisioner.cs)):
    - creates `%LOCALAPPDATA%\MCEC\sessions\<id>`,
    - **copies the binaries** from the running exe's dir (excluding the installed `mcec.settings` /
@@ -168,9 +193,10 @@ construction, and supersedes the earlier hand-rolled "copy the build and write a
 
 - **Explicit:** `end-session` (or just deleting the directory).
 - **Operator:** the Settings dialog's **Agent** tab lists every provisioned instance (id, age, size,
-  running/stale) and offers per-row **Delete** and **Delete all**, so the operator can clean up copies an
-  agent left behind without hunting through `%LOCALAPPDATA%`. Deleting is the same directory removal
-  `end-session` and the reaper perform; a running instance is locked and skipped (stop it first).
+  running/stale), offers per-row **Delete** and **Delete all**, and (with the opt-in ticked)
+  **Provision new…** to create one, so the operator can create and clean up copies without hunting
+  through `%LOCALAPPDATA%`. Deleting is the same directory removal `end-session` and the reaper
+  perform; a running instance is locked and skipped (stop it first).
 - **Belt-and-suspenders:** on every launch (`Program.Main`) and before each provision, MCEC reaps session
   directories older than `AgentServer.SessionReapAgeHours` (12h). A **running** session's files are locked,
   so a live session is never reaped; it's collected on a later launch after it exits.
@@ -182,7 +208,9 @@ construction, and supersedes the earlier hand-rolled "copy the build and write a
 | Provision / teardown / reap | [`SessionProvisioner`](../src/Agent/SessionProvisioner.cs) |
 | Handoff descriptor | [`ProvisionedSession`](../src/Agent/ProvisionedSession.cs) |
 | MCP tools + authorization gate | `AgentServer` (`provision-session`, `end-session`) |
+| Bootstrap-only MCP surface (#296) | `Program.ProvisioningBootstrapOnly`, `JsonRpcDispatcher` (restricted `tools/list` + `BootstrapInstructions`), `AgentToolExecutor.CallTool` (`bootstrap-only`) |
 | Operator opt-in + management UI | Settings dialog **Agent** tab ([`AgentSettingsTab`](../src/Dialogs/SettingsTabs/AgentSettingsTab.cs)) → `AppSettings.AllowSessionProvisioning` |
+| Operator "Provision new…" handoff (#296) | [`ProvisionedInstanceDialog`](../src/Dialogs/ProvisionedInstanceDialog.cs) |
 | Session enumeration for the UI | `SessionProvisioner.ListSessions` |
 | Reap on launch | `Program.Main` |
 

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -177,8 +177,11 @@ you will never see or target it, and it is never a candidate window; but it DOES
 full-screen/region `capture`s and `record`ings (not in window-targeted captures).
 
 PROVISION: do NOT drive the operator's installed MCEC by enabling agent commands in it; an abnormal exit
-leaks those security gates enabled, and the installed copy refuses to serve as an agent server anyway.
-Instead, when the operator has authorized it,
+leaks those security gates enabled, and the installed copy will not serve the full agent surface anyway.
+When you connect to the installed `mcec.exe --mcp`, it serves ONLY the provisioning BOOTSTRAP: the sole
+tools are `provision-session` and `end-session`, and every observation/actuation tool is refused with
+`error.code:bootstrap-only` (its connect-time instructions say so). That is by design and is your first
+hop, not a dead end: when the operator has authorized it,
 call `provision-session` to get a fresh, disposable, isolated instance: it returns a `directory` containing
 `mcec.exe` plus an agent-ready co-located config (agent commands enabled ONLY inside that copy), how to
 launch/connect (`exePath`, and an `mcpEndpoint` when the MCP server is enabled), a `sessionId`, and a
@@ -192,8 +195,10 @@ down; orphaned sessions are reaped automatically. If `provision-session` returns
 `error.code:provisioning-not-authorized` (these feature-specific refusals ride in `error.code`, while
 `error.category` stays `internal`), the operator has not opted in; tell them to enable "Allow agents to
 provision disposable instances" on the Settings dialog's Agent tab (File > Settings > Agent), then retry;
-do not retry blindly before they do. That same Agent tab lists the provisioned instances and lets the
-operator delete any you leave behind, but you own teardown: `end-session` every instance you provision.
+do not retry blindly before they do. On that same Agent tab the operator can also click "Provision new…"
+to create an instance themselves and hand you its directory/endpoint; and it lists the provisioned
+instances and lets them delete any you leave behind. But you own teardown: `end-session` every instance
+you provision.
 
 EMERGENCY STOP: the operator has a global panic hotkey (default Ctrl+Alt+Shift+S) that instantly halts the
 session from any window. If ANY tool returns `error.code:emergency-stopped` (the code, not the category;

--- a/src/Dialogs/ProvisionedInstanceDialog.cs
+++ b/src/Dialogs/ProvisionedInstanceDialog.cs
@@ -1,0 +1,116 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace MCEControl;
+
+/// <summary>
+/// Shows the operator the handoff for an instance they just provisioned from the Agent tab's
+/// "Provision new…" button (#296): where the disposable copy lives, how to point an agent at it
+/// (the stdio <c>--mcp</c> launch line and, when enabled, the HTTP endpoint + bearer token), and how
+/// to tear it down. The whole handoff is one read-only, copyable text block; the operator's next act
+/// is pasting this into an MCP client config, so Copy-all is the primary affordance.
+///
+/// <para>SECURITY: the text includes the session token (#215). That is the point; the operator IS
+/// the session owner and needs the credential to hand to their agent; and it is no wider an
+/// exposure than <c>provision-session</c> returning the same token to a connected agent.</para>
+/// </summary>
+internal sealed class ProvisionedInstanceDialog : Form {
+    public ProvisionedInstanceDialog(ProvisionedSession session) {
+        ArgumentNullException.ThrowIfNull(session);
+
+        Text = $"MCE Controller - Provisioned instance {session.SessionId}";
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MinimizeBox = false;
+        MaximizeBox = false;
+        ShowInTaskbar = false;
+        StartPosition = FormStartPosition.CenterParent;
+        AutoScaleMode = AutoScaleMode.Font;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+
+        TextBox handoff = new() {
+            Multiline = true,
+            ReadOnly = true,
+            WordWrap = false,
+            ScrollBars = ScrollBars.Both,
+            Font = new Font(FontFamily.GenericMonospace, 9f),
+            Text = BuildHandoffText(session),
+            Size = new Size(640, 320),
+            Margin = new Padding(4, 4, 4, 8),
+            TabStop = false,
+        };
+
+        Button copy = new() {
+            Text = "&Copy all",
+            AutoSize = true,
+        };
+        copy.Click += (_, _) => Clipboard.SetText(handoff.Text);
+        Button close = new() {
+            Text = "Close",
+            DialogResult = DialogResult.OK,
+            AutoSize = true,
+        };
+
+        FlowLayoutPanel buttons = new() {
+            FlowDirection = FlowDirection.RightToLeft,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Anchor = AnchorStyles.Right,
+            Margin = new Padding(0),
+        };
+        // RightToLeft flow: first added lands right-most; Close sits right, Copy all beside it.
+        buttons.Controls.Add(close);
+        buttons.Controls.Add(copy);
+
+        TableLayoutPanel layout = new() {
+            ColumnCount = 1,
+            RowCount = 2,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Padding = new Padding(12),
+        };
+        layout.Controls.Add(handoff, 0, 0);
+        layout.Controls.Add(buttons, 0, 1);
+        Controls.Add(layout);
+
+        AcceptButton = close;
+        CancelButton = close;
+    }
+
+    /// <summary>
+    /// Renders the copyable handoff: the same facts <see cref="ProvisionedSession.ToJsonObject"/>
+    /// hands a connected agent, phrased for the operator who will paste them into an MCP client
+    /// config. Static and internal so tests can verify the text without showing a window.
+    /// </summary>
+    internal static string BuildHandoffText(ProvisionedSession session) {
+        StringBuilder sb = new();
+        _ = sb.AppendLine("A fresh, disposable MCEC instance is ready. Agent commands are enabled ONLY");
+        _ = sb.AppendLine("inside this copy; your installed MCEC is untouched.");
+        _ = sb.AppendLine();
+        _ = sb.AppendLine($"Directory:  {session.Directory}");
+        _ = sb.AppendLine($"Session id: {session.SessionId}");
+        _ = sb.AppendLine($"Token:      {session.Token}");
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("Connect over stdio (recommended): configure your MCP client to spawn:");
+        _ = sb.AppendLine($"  \"{session.ExePath}\" --mcp");
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("e.g. Claude Code:");
+        _ = sb.AppendLine($"  claude mcp add mcec -- \"{session.ExePath}\" --mcp");
+        if (session.McpServerEnabled) {
+            _ = sb.AppendLine();
+            _ = sb.AppendLine($"Or launch \"{session.ExePath}\" and POST JSON-RPC to its HTTP endpoint:");
+            _ = sb.AppendLine($"  http://{session.BindAddress}:{session.Port}/mcp");
+            _ = sb.AppendLine($"  with the header: Authorization: Bearer {session.Token}");
+        }
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("Teardown: have the agent call end-session with the session id and token (after");
+        _ = sb.AppendLine("stopping the instance), or delete it from this Agent tab; stale instances are");
+        _ = sb.AppendLine("also cleaned up automatically.");
+        return sb.ToString();
+    }
+}

--- a/src/Dialogs/SettingsTabs/AgentSettingsTab.Designer.cs
+++ b/src/Dialogs/SettingsTabs/AgentSettingsTab.Designer.cs
@@ -37,6 +37,7 @@ namespace MCEControl {
             this._columnStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this._columnDelete = new System.Windows.Forms.DataGridViewButtonColumn();
             this._labelNoSessions = new System.Windows.Forms.Label();
+            this._buttonProvision = new System.Windows.Forms.Button();
             this._buttonDeleteAll = new System.Windows.Forms.Button();
             this._toolTipAgent = new System.Windows.Forms.ToolTip(this.components);
             this._groupSessions.SuspendLayout();
@@ -71,6 +72,7 @@ namespace MCEControl {
             this._groupSessions.BackColor = System.Drawing.SystemColors.Window;
             this._groupSessions.Controls.Add(this._gridSessions);
             this._groupSessions.Controls.Add(this._labelNoSessions);
+            this._groupSessions.Controls.Add(this._buttonProvision);
             this._groupSessions.Controls.Add(this._buttonDeleteAll);
             this._groupSessions.Location = new System.Drawing.Point(12, 82);
             this._groupSessions.Margin = new System.Windows.Forms.Padding(1);
@@ -155,6 +157,18 @@ namespace MCEControl {
             this._labelNoSessions.TabIndex = 1;
             this._labelNoSessions.Text = "No provisioned instances.";
             //
+            // _buttonProvision
+            //
+            this._buttonProvision.Location = new System.Drawing.Point(8, 120);
+            this._buttonProvision.Margin = new System.Windows.Forms.Padding(1);
+            this._buttonProvision.Name = "_buttonProvision";
+            this._buttonProvision.Size = new System.Drawing.Size(110, 26);
+            this._buttonProvision.TabIndex = 3;
+            this._buttonProvision.Text = "&Provision new...";
+            this._buttonProvision.UseVisualStyleBackColor = true;
+            this._toolTipAgent.SetToolTip(this._buttonProvision, "Creates a fresh, disposable, isolated MCEC instance and shows how to point an agent at it. Requires the opt-in above.");
+            this._buttonProvision.Click += new System.EventHandler(this.ButtonProvisionClick);
+            //
             // _buttonDeleteAll
             //
             this._buttonDeleteAll.Location = new System.Drawing.Point(326, 120);
@@ -202,6 +216,7 @@ namespace MCEControl {
         private System.Windows.Forms.DataGridViewTextBoxColumn _columnStatus;
         private System.Windows.Forms.DataGridViewButtonColumn _columnDelete;
         private System.Windows.Forms.Label _labelNoSessions;
+        private System.Windows.Forms.Button _buttonProvision;
         private System.Windows.Forms.Button _buttonDeleteAll;
         private System.Windows.Forms.ToolTip _toolTipAgent;
     }

--- a/src/Dialogs/SettingsTabs/AgentSettingsTab.cs
+++ b/src/Dialogs/SettingsTabs/AgentSettingsTab.cs
@@ -24,13 +24,21 @@ namespace MCEControl;
 public partial class AgentSettingsTab : UserControl, ISettingsTab {
     private AppSettings? _settings;
 
+    /// <summary>
+    /// Cached once at construction: whether THIS running copy is itself a provisioned instance. A
+    /// provisioned copy must neither re-authorize provisioning nor provision again (its config is
+    /// disposable and locked to <c>AllowSessionProvisioning=false</c>), so both the checkbox and the
+    /// operator "Provision new…" action are frozen for it.
+    /// </summary>
+    private readonly bool _runningFromSessionsRoot = IsRunningFromSessionsRoot();
+
     public AgentSettingsTab() {
         InitializeComponent();
         // SECURITY: inside a provisioned copy the agent CAN drive this very dialog (agent commands
         // are enabled there), and it must never widen its own permissions by re-authorizing
         // provisioning (Provision writes AllowSessionProvisioning=false into every copy). Freeze the
         // checkbox when this instance is itself running from under the sessions root.
-        if (IsRunningFromSessionsRoot()) {
+        if (_runningFromSessionsRoot) {
             _checkBoxAllowProvisioning.Enabled = false;
             _toolTipAgent.SetToolTip(_checkBoxAllowProvisioning,
                 "This is a provisioned instance; it cannot authorize provisioning.");
@@ -76,7 +84,17 @@ public partial class AgentSettingsTab : UserControl, ISettingsTab {
         }
         _buttonDeleteAll.Enabled = sessions.Count > 0;
         _labelNoSessions.Visible = sessions.Count == 0;
+        UpdateProvisionEnabled();
     }
+
+    /// <summary>
+    /// The operator "Provision new…" action is available only when provisioning is authorized (the
+    /// checkbox above, which maps to <see cref="AppSettings.AllowSessionProvisioning"/>) and this is
+    /// not itself a provisioned copy. Mirrors the same opt-in the MCP <c>provision-session</c> tool
+    /// enforces, so the button never offers what the engine would refuse.
+    /// </summary>
+    private void UpdateProvisionEnabled() =>
+        _buttonProvision.Enabled = _checkBoxAllowProvisioning.Checked && !_runningFromSessionsRoot;
 
     private static bool IsRunningFromSessionsRoot() {
         try {
@@ -101,7 +119,36 @@ public partial class AgentSettingsTab : UserControl, ISettingsTab {
         }
 
         _settings.AllowSessionProvisioning = _checkBoxAllowProvisioning.Checked;
+        UpdateProvisionEnabled();
         SettingsChanged();
+    }
+
+    /// <summary>
+    /// "Provision new…": creates a fresh, disposable, isolated instance right now (no MCP round-trip
+    /// needed; #296) and shows the operator its handoff to paste into an agent's MCP client. Unlike
+    /// the opt-in checkbox this is an immediate on-disk action (like Delete), so it does not wait for
+    /// the dialog's OK. The provisioned instance's MCP/HTTP server is enabled so the handoff can offer
+    /// both the stdio and HTTP connect options; agent commands are enabled ONLY inside that copy.
+    /// </summary>
+    private void ButtonProvisionClick(object? sender, EventArgs e) {
+        // Defense in depth: the button is disabled unless authorized, but never provision without the
+        // opt-in even if some path re-enabled it. Mirrors the MCP tool's own AllowSessionProvisioning gate.
+        if (!_checkBoxAllowProvisioning.Checked || _runningFromSessionsRoot) {
+            return;
+        }
+        ProvisionedSession session;
+        try {
+            session = SessionProvisioner.Provision(mcpServerEnabled: true);
+        }
+        catch (Exception ex) {
+            _ = MessageBox.Show(this,
+                $"Could not provision a new instance:\n\n{ex.Message}",
+                "Provision instance", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+        RefreshSessions();
+        using ProvisionedInstanceDialog dialog = new(session);
+        _ = dialog.ShowDialog(this);
     }
 
     private void AgentSettingsTab_VisibleChanged(object? sender, EventArgs e) {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -59,29 +59,49 @@ internal static class Program {
 
     /// <summary>
     ///     True when the running exe lives under Program Files; the installed, operator-owned copy.
-    ///     SECURITY: the installed copy must never serve agents (no <c>--mcp</c>, no MCP/HTTP server).
-    ///     Serving from it requires enabling agent security gates in the one config the operator's own
-    ///     MCEC reads (redirected to %AppData%), where a crashed or killed session leaks them enabled;
-    ///     exactly what isolated session provisioning (#138) exists to prevent. Agent serving is only
-    ///     allowed from non-installed locations (a provisioned session or a manual copy), which read a
-    ///     disposable co-located config instead.
+    ///     SECURITY: the installed copy must never serve the agent observation/actuation surface (no
+    ///     MCP/HTTP server; <c>--mcp</c> serves only the provisioning bootstrap, see
+    ///     <see cref="ProvisioningBootstrapOnly" />). Serving the full surface from it requires
+    ///     enabling agent security gates in the one config the operator's own MCEC reads (redirected
+    ///     to %AppData%), where a crashed or killed session leaks them enabled; exactly what isolated
+    ///     session provisioning (#138) exists to prevent. Full agent serving is only allowed from
+    ///     non-installed locations (a provisioned session or a manual copy), which read a disposable
+    ///     co-located config instead.
     /// </summary>
     internal static bool IsProgramFilesInstall =>
         IsProgramFilesInstallOverrideForTests ??
         GetProgramFilesRoot(AppDomain.CurrentDomain.BaseDirectory) is not null;
 
     /// <summary>
-    ///     The operator-facing explanation both refusal sites share (the <c>--mcp</c> exit and the
-    ///     MCP/HTTP server start).
+    ///     True when the MCP surface must be restricted to the provisioning BOOTSTRAP; exactly
+    ///     <c>provision-session</c> and <c>end-session</c>; because we are serving from the installed
+    ///     (Program Files) copy (#296). Without this, provisioning could not bootstrap itself: the
+    ///     tool that mints a disposable instance is an MCP tool, but a fresh install refused to serve
+    ///     MCP at all, so a new user had no first hop. The bootstrap is safe from the install because
+    ///     neither meta-tool observes or actuates anything: <c>provision-session</c> (still gated by
+    ///     the operator's <c>AllowSessionProvisioning</c> opt-in) only writes a NEW throwaway
+    ///     directory, and <c>end-session</c> (token-gated) only deletes one; the installed config is
+    ///     never touched, and every observation/actuation tool (including <c>send_command</c>) is
+    ///     refused at dispatch (<see cref="AgentToolExecutor.CallTool" />) and hidden from
+    ///     <c>tools/list</c> (<see cref="JsonRpcDispatcher" />).
+    /// </summary>
+    internal static bool ProvisioningBootstrapOnly => IsProgramFilesInstall;
+
+    /// <summary>
+    ///     The operator-facing explanation for the one remaining refusal site (the MCP/HTTP server
+    ///     start), also echoed in docs: how to get an agent-servable MCEC when the installed copy
+    ///     won't open its own front door.
     /// </summary>
     internal const string InstalledAgentServingGuidance =
-        "MCEC will not serve agents from its installed (Program Files) location: enabling agent " +
-        "security gates in the installed copy's configuration would leak them enabled if a session " +
-        "crashed. Either (1) run the installed MCEC normally and have your agent call the " +
-        "'provision-session' MCP tool (requires AllowSessionProvisioning=true in Settings) to get a " +
-        "disposable, isolated copy to drive, or (2) copy the MCEC install directory somewhere " +
-        "writable and run it from there; a non-installed copy reads its own co-located mcec.settings. " +
-        "See the Environment Controller documentation (docs/environment-controller.md).";
+        "MCEC will not serve the full agent surface from its installed (Program Files) location: " +
+        "enabling agent security gates in the installed copy's configuration would leak them enabled " +
+        "if a session crashed. Get a disposable, isolated copy instead: (1) click 'Provision new...' " +
+        "on File > Settings > Agent and point your agent at the instance it creates, (2) have your " +
+        "agent connect to the installed 'mcec.exe --mcp' (it serves ONLY the provision-session/" +
+        "end-session bootstrap; requires AllowSessionProvisioning=true in Settings) and call " +
+        "'provision-session', or (3) copy the MCEC install directory somewhere writable and run it " +
+        "from there; a non-installed copy reads its own co-located mcec.settings. See the Environment " +
+        "Controller documentation (docs/environment-controller.md).";
 
     /// <summary>
     ///     Safely launches a URL, file, or folder using the shell (UseShellExecute).
@@ -257,13 +277,15 @@ internal static class Program {
     ///     pump thread), then serves MCP over stdio. Returns the process exit code.
     /// </summary>
     private static int RunHeadlessMcp() {
-        // SECURITY: the installed copy never serves agents (see IsProgramFilesInstall). stderr so a
-        // terminal user and an MCP client's error log both see WHY the server exited immediately.
-        if (IsProgramFilesInstall) {
-            Logger.Instance.Log4.Error($"MCEC: --mcp refused from the installed location. {InstalledAgentServingGuidance}");
-            Console.Error.WriteLine("mcec: --mcp refused: running from the installed (Program Files) location.");
-            Console.Error.WriteLine(InstalledAgentServingGuidance);
-            return ExitCodes.UsageError;
+        // SECURITY: from the installed copy this server is restricted to the provisioning bootstrap
+        // (#296, see ProvisioningBootstrapOnly): tools/list shows and dispatch accepts ONLY
+        // provision-session/end-session, so a fresh install's agent can mint a disposable instance
+        // to drive; without this, provisioning could not bootstrap itself. The full agent surface is
+        // still never served from the install (the pre-#296 behavior was to refuse --mcp outright).
+        if (ProvisioningBootstrapOnly) {
+            Logger.Instance.Log4.Info(
+                "MCEC: --mcp from the installed location; serving the provisioning bootstrap only " +
+                "(provision-session/end-session).");
         }
 
         // mcp serves JSON-RPC over stdio and is meant to be SPAWNED by an MCP client with

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -111,6 +111,23 @@ public sealed class AgentToolExecutor {
                 "emergency-stopped", AgentErrorCategory.Internal, DefaultSessionId());
         }
 
+        // Provisioning bootstrap (#296): the installed (Program Files) copy serves ONLY the
+        // isolated-install lifecycle (provision-session/end-session), so a fresh install's agent can
+        // mint a disposable instance without the operator hand-editing configs. Everything else;
+        // observation, actuation, raw send_command (which is otherwise ungated over stdio), and the
+        // in-process session lifecycle; stays refused from the install; the full surface is served by
+        // the provisioned copy the agent gets back. Checked before every branch below so no tool,
+        // present or future, can slip past the restriction.
+        if (Program.ProvisioningBootstrapOnly && name is not ("provision-session" or "end-session")) {
+            AgentRuntime.Audit(name, "BLOCKED; the installed copy serves only the provisioning bootstrap (provision-session/end-session)");
+            return ToolError(
+                "This is MCEC's installed copy serving the provisioning bootstrap: only provision-session and " +
+                "end-session are available here. Call provision-session to get a fresh, disposable, isolated " +
+                "MCEC instance (it returns the directory, exePath, sessionId, and token), launch that " +
+                "instance's mcec.exe --mcp (or use its HTTP mcpEndpoint), and drive it instead.",
+                "bootstrap-only", AgentErrorCategory.Internal, DefaultSessionId());
+        }
+
         // Session lifecycle (#86 Phase 3): session-start/status/end. These read `sessionId` as an explicit
         // TARGET (which session to start/inspect/end), not as call routing, so they're handled before the
         // generic routing refusal below. They are part of the agent surface, so they honor the same

--- a/src/Services/JsonRpcDispatcher.cs
+++ b/src/Services/JsonRpcDispatcher.cs
@@ -71,6 +71,22 @@ public sealed class JsonRpcDispatcher {
         }
     }
 
+    /// <summary>
+    /// Connect-time guidance served instead of the full playbook when only the provisioning bootstrap
+    /// is available (#296, <see cref="Program.ProvisioningBootstrapOnly"/>): the full observe/target/act
+    /// instructions would teach tools this server refuses, so teach the two-step handoff instead.
+    /// </summary>
+    internal const string BootstrapInstructions =
+        "This is MCEC's installed copy serving the provisioning BOOTSTRAP only: the sole tools are " +
+        "provision-session and end-session; every other tool is refused with error.code:bootstrap-only. " +
+        "To drive the desktop, call provision-session (requires the operator's 'Allow agents to provision " +
+        "disposable instances' opt-in on File > Settings > Agent) to get a fresh, disposable, isolated MCEC " +
+        "instance; it returns the directory, exePath, sessionId, and token. Launch \"<exePath>\" --mcp as a " +
+        "stdio MCP server (or POST JSON-RPC to its HTTP mcpEndpoint with 'Authorization: Bearer <token>') " +
+        "and do ALL observation and actuation against THAT instance; it serves the full tool surface and " +
+        "the full connect-time instructions. When finished, stop the instance's mcec.exe, then call " +
+        "end-session here with the sessionId AND token to delete it.";
+
     private JsonObject BuildInitializeResult() => new() {
         ["protocolVersion"] = ProtocolVersion,
         ["capabilities"] = new JsonObject { ["tools"] = new JsonObject() },
@@ -79,8 +95,9 @@ public sealed class JsonRpcDispatcher {
             ["version"] = Application.ProductVersion,
         },
         // Built-in agent guidance: surfaced to the model by the MCP client so it knows how to drive
-        // MCEC effectively (the observe -> target -> act loop) and understands the security model.
-        ["instructions"] = _instructions(),
+        // MCEC effectively (the observe -> target -> act loop) and understands the security model. In
+        // bootstrap mode (#296) the playbook would teach refused tools, so serve the handoff recipe.
+        ["instructions"] = Program.ProvisioningBootstrapOnly ? BootstrapInstructions : _instructions(),
     };
 
     // -------------------------------------------------------------------------------------------
@@ -88,6 +105,13 @@ public sealed class JsonRpcDispatcher {
     // -------------------------------------------------------------------------------------------
 
     private static JsonArray BuildToolsList() {
+        // Provisioning bootstrap (#296): from the installed copy, list exactly what dispatch will
+        // accept (AgentToolExecutor.CallTool refuses everything else with bootstrap-only), so an MCP
+        // client's tool list never advertises a tool this server refuses.
+        if (Program.ProvisioningBootstrapOnly) {
+            return [BuildProvisionSessionTool(), BuildEndSessionTool()];
+        }
+
         JsonArray tools = [];
 
         // The gated agent tools; one descriptor per tool, schema included; live in ToolCatalog (#205).
@@ -130,6 +154,14 @@ public sealed class JsonRpcDispatcher {
 
         // Isolated session provisioning (#138). Requires the operator to have opted in
         // (AllowSessionProvisioning); it never mutates the installed config.
+        tools.Add(BuildProvisionSessionTool());
+        tools.Add(BuildEndSessionTool());
+
+        return tools;
+    }
+
+    /// <summary>The <c>provision-session</c> tool schema (#138); shared by the full list and the bootstrap list (#296).</summary>
+    private static JsonObject BuildProvisionSessionTool() {
         JsonObject provisionProps = new() {
             ["mcpServer"] = ToolCatalog.PropSchema("boolean", "Enable the provisioned instance's localhost MCP/HTTP server (default true)"),
             ["commands"] = new JsonObject {
@@ -138,20 +170,20 @@ public sealed class JsonRpcDispatcher {
                 ["items"] = new JsonObject { ["type"] = "string" },
             },
         };
-        tools.Add(ToolCatalog.Tool("provision-session",
+        return ToolCatalog.Tool("provision-session",
             "Get a fresh, disposable, isolated MCEC instance to run from instead of enabling the installed one. Returns a directory containing mcec.exe + an agent-ready co-located config (agent commands enabled ONLY inside the copy), plus how to launch/connect and the sessionId + token to tear it down. The token is the session credential: HTTP requests to the session's mcpEndpoint must send 'Authorization: Bearer <token>', and end-session requires it. Requires the operator to have enabled AllowSessionProvisioning; the installed config is never touched. Call end-session (or delete the directory) when finished.",
-            provisionProps, []));
+            provisionProps, []);
+    }
 
-        tools.Add(ToolCatalog.Tool("end-session",
+    /// <summary>The <c>end-session</c> tool schema (#138); shared by the full list and the bootstrap list (#296).</summary>
+    private static JsonObject BuildEndSessionTool() =>
+        ToolCatalog.Tool("end-session",
             "Tear down a provisioned session (from provision-session) by deleting its directory. Requires the session's token; the teardown credential provision-session returned. Stop the session's mcec.exe first, or its files stay locked. MCEC also reaps stale session dirs on launch.",
             new JsonObject {
                 ["sessionId"] = ToolCatalog.PropSchema("string", "The sessionId returned by provision-session"),
                 ["token"] = ToolCatalog.PropSchema("string", "The token returned by provision-session (the teardown credential)"),
             },
-            ["sessionId", "token"]));
-
-        return tools;
-    }
+            ["sessionId", "token"]);
 
     /// <summary>
     /// Adds the optional <c>sessionId</c> routing property (#86 Phase 3) to a tool's

--- a/tests/MCEControl.xUnit/Dialogs/AgentSettingsTabTests.cs
+++ b/tests/MCEControl.xUnit/Dialogs/AgentSettingsTabTests.cs
@@ -98,6 +98,56 @@ public class AgentSettingsTabTests : IDisposable {
     }
 
     [Fact]
+    public void AgentTab_ProvisionButton_TracksTheOptInCheckbox() {
+        // "Provision new…" (#296) mirrors the MCP tool's AllowSessionProvisioning gate: available only
+        // when the opt-in is ticked, and it follows the checkbox live.
+        using var tab = new AgentSettingsTab();
+        tab.Bind(new AppSettings { AllowSessionProvisioning = false });
+
+        var provision = FindControl<Button>(tab, "_buttonProvision");
+        var checkbox = FindControl<CheckBox>(tab, "_checkBoxAllowProvisioning");
+        Assert.False(provision.Enabled);
+
+        checkbox.Checked = true;
+        Assert.True(provision.Enabled);
+
+        checkbox.Checked = false;
+        Assert.False(provision.Enabled);
+    }
+
+    [Fact]
+    public void ProvisionButton_EnabledWhenBoundToAuthorizedSettings() {
+        using var tab = new AgentSettingsTab();
+        tab.Bind(new AppSettings { AllowSessionProvisioning = true });
+        Assert.True(FindControl<Button>(tab, "_buttonProvision").Enabled);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ProvisionedInstanceDialog_HandoffText_HasLaunchTokenAndConditionalEndpoint(bool mcpServerEnabled) {
+        var session = new ProvisionedSession {
+            SessionId = "0123456789ab",
+            Directory = @"C:\sessions\0123456789ab",
+            ExePath = @"C:\sessions\0123456789ab\mcec.exe",
+            McpServerEnabled = mcpServerEnabled,
+            BindAddress = "127.0.0.1",
+            Port = 51515,
+            Token = "deadbeefcafef00d",
+        };
+
+        string text = ProvisionedInstanceDialog.BuildHandoffText(session);
+
+        // Always: the stdio launch line, the directory, and the teardown token.
+        Assert.Contains(@"C:\sessions\0123456789ab\mcec.exe"" --mcp", text);
+        Assert.Contains("0123456789ab", text);
+        Assert.Contains("deadbeefcafef00d", text);
+        // The HTTP endpoint + bearer line only when the session's MCP server is enabled.
+        Assert.Equal(mcpServerEnabled, text.Contains("http://127.0.0.1:51515/mcp"));
+        Assert.Equal(mcpServerEnabled, text.Contains("Authorization: Bearer deadbeefcafef00d"));
+    }
+
+    [Fact]
     public void AgentTab_EmptyList_DisablesDeleteAllAndShowsNoSessionsLabel() {
         using var tab = new AgentSettingsTab();
         tab.Bind(new AppSettings());

--- a/tests/MCEControl.xUnit/Integration/CommandExecutionPipelineTests.cs
+++ b/tests/MCEControl.xUnit/Integration/CommandExecutionPipelineTests.cs
@@ -5,7 +5,15 @@ using MCEControl;
 namespace MCEControl.xUnit.Integration;
 
 /// <summary>
-/// Integration tests for the command execution pipeline
+/// Integration tests for the command execution pipeline: they exercise <see cref="CommandInvoker.Enqueue"/>
+/// parsing/routing and assert it does not throw.
+///
+/// SAFETY: every invoker here sets <see cref="CommandInvoker.SuppressDispatcherForTests"/> before the first
+/// enqueue. Without it the invoker starts its real dispatcher thread and EXECUTES enabled commands; the
+/// tests enable <c>chars:</c> and enqueue <c>"chars:hello"</c> and <c>"a"</c>, so a plain <c>dotnet test</c>
+/// synthesized real keystrokes ("hello", "a") into whatever window had focus. Suppressing the dispatcher
+/// keeps the parse/enqueue path (all these tests assert) while guaranteeing no SendInput reaches the desktop
+/// (matches the pattern in <c>CommandInvokerQueueCapTests</c>).
 /// </summary>
 public class CommandExecutionPipelineTests
 {
@@ -16,6 +24,7 @@ public class CommandExecutionPipelineTests
         File.Delete(tempFile);
 
         var invoker = CommandInvoker.Create(tempFile, "1.0.0.0", false);
+        invoker.SuppressDispatcherForTests = true; // never actuate the real desktop from a unit test
 
         // Enable the pause command for testing
         if (invoker["pause"] is PauseCommand pauseCmd)
@@ -39,6 +48,7 @@ public class CommandExecutionPipelineTests
         File.Delete(tempFile);
 
         var invoker = CommandInvoker.Create(tempFile, "1.0.0.0", false);
+        invoker.SuppressDispatcherForTests = true; // never synthesize "hello" into the focused window
 
         // Enable chars command
         if (invoker["chars:"] is CharsCommand charsCmd)
@@ -63,6 +73,7 @@ public class CommandExecutionPipelineTests
         File.Delete(tempFile);
 
         var invoker = CommandInvoker.Create(tempFile, "1.0.0.0", false);
+        invoker.SuppressDispatcherForTests = true;
         var reply = new TestReply();
 
         // This should not throw
@@ -83,6 +94,7 @@ public class CommandExecutionPipelineTests
         File.Delete(tempFile);
 
         var invoker = CommandInvoker.Create(tempFile, "1.0.0.0", false);
+        invoker.SuppressDispatcherForTests = true; // never synthesize "a" into the focused window
 
         // Enable chars command
         if (invoker["chars:"] is CharsCommand charsCmd)

--- a/tests/MCEControl.xUnit/Services/AgentServerSafetyTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerSafetyTests.cs
@@ -68,6 +68,82 @@ public class AgentServerSafetyTests {
         }
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // Provisioning bootstrap from the installed copy (#296): the installed (Program Files) mcec.exe
+    // --mcp serves ONLY provision-session/end-session, so a fresh install can bootstrap a disposable
+    // instance without the operator hand-editing configs. Every other tool is refused, and tools/list
+    // advertises only the two meta-tools so a client never sees a tool this server will refuse.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void BootstrapOnly_ToolsList_ExposesOnlyProvisioningTools() {
+        Program.IsProgramFilesInstallOverrideForTests = true;
+        try {
+            JsonArray tools = AgentServer.Dispatch(Request(10, "tools/list"))!["result"]!.AsObject()["tools"]!.AsArray();
+            string[] names = [.. tools.Select(t => t!["name"]!.GetValue<string>())];
+            Assert.Equal(["provision-session", "end-session"], names);
+        }
+        finally {
+            Program.IsProgramFilesInstallOverrideForTests = null;
+        }
+    }
+
+    [Fact]
+    public void BootstrapOnly_Initialize_ServesBootstrapInstructions() {
+        Program.IsProgramFilesInstallOverrideForTests = true;
+        try {
+            string instructions = AgentServer.Dispatch(Request(11, "initialize"))!["result"]!.AsObject()["instructions"]!.GetValue<string>();
+            Assert.Equal(JsonRpcDispatcher.BootstrapInstructions, instructions);
+        }
+        finally {
+            Program.IsProgramFilesInstallOverrideForTests = null;
+        }
+    }
+
+    [Fact]
+    public void BootstrapOnly_RefusesObservationTool_EvenWhenAgentCommandsEnabled() {
+        Program.IsProgramFilesInstallOverrideForTests = true;
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            JsonObject env = Envelope(Call(12, "capture", new JsonObject { ["foreground"] = true }));
+            Assert.False(env["ok"]!.GetValue<bool>());
+            Assert.Equal("bootstrap-only", env["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            Program.IsProgramFilesInstallOverrideForTests = null;
+        }
+    }
+
+    [Fact]
+    public void BootstrapOnly_RefusesRawSendCommand() {
+        Program.IsProgramFilesInstallOverrideForTests = true;
+        try {
+            JsonObject env = Envelope(Call(13, "send_command", new JsonObject { ["command"] = "winr" }));
+            Assert.Equal("bootstrap-only", env["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            Program.IsProgramFilesInstallOverrideForTests = null;
+        }
+    }
+
+    [Fact]
+    public void BootstrapOnly_AllowsProvisionSessionThroughToItsOwnGate() {
+        // The bootstrap gate must let provision-session THROUGH to its own AllowSessionProvisioning
+        // check; with provisioning unauthorized it fails with provisioning-not-authorized (NOT
+        // bootstrap-only), proving the meta-tool is reachable from the installed copy.
+        Program.IsProgramFilesInstallOverrideForTests = true;
+        AgentRuntime.Settings = new AppSettings { AllowSessionProvisioning = false };
+        try {
+            JsonObject env = Envelope(Call(14, "provision-session", []));
+            Assert.Equal("provisioning-not-authorized", env["error"]!.AsObject()["code"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            Program.IsProgramFilesInstallOverrideForTests = null;
+        }
+    }
+
     [Fact]
     public void ToolsList_IncludesProvisioningTools() {
         JsonArray tools = AgentServer.Dispatch(Request(3, "tools/list"))!["result"]!.AsObject()["tools"]!.AsArray();


### PR DESCRIPTION
## What & why

Closes the chicken-and-egg from #296: a fresh winget install had **no working way to invoke `provision-session`**. It's an MCP tool, but the installed (Program Files) copy refused to serve MCP at all, and the Agent tab could only *delete* sessions, not create one. So the documented "install → enable → agent provisions" happy path had no first hop; the only route was hand-copying the install and writing an agent config — the toil provisioning exists to eliminate.

## Two first hops (neither touches the installed config)

- **Bootstrap-only MCP mode.** `mcec.exe --mcp` from the install now serves a restricted surface: `tools/list` and dispatch expose **only** `provision-session` and `end-session`; every other tool (incl. `send_command`) is refused with `error.code:bootstrap-only`, and `initialize` serves bootstrap instructions instead of the full playbook. Safe from the install because neither meta-tool observes or actuates. The MCP/**HTTP** endpoint stays fully refused from the install (unchanged).
- **Operator "Provision new…" button** on Settings ▸ Agent. Calls `SessionProvisioner.Provision()` directly (no MCP round-trip) and shows a copyable handoff (`ProvisionedInstanceDialog`): directory, `--mcp` launch line, HTTP endpoint + bearer token, teardown. Enabled only when `AllowSessionProvisioning` is ticked and not running from a provisioned copy.

Either way the agent ends up driving a **non-installed** disposable copy that serves the full surface.

## Implementation

- `Program.ProvisioningBootstrapOnly` (= `IsProgramFilesInstall`) gates:
  - `JsonRpcDispatcher`: restricted `tools/list` (shared `BuildProvisionSessionTool`/`BuildEndSessionTool`) + `BootstrapInstructions` on `initialize`.
  - `AgentToolExecutor.CallTool`: `bootstrap-only` refusal for everything except the two meta-tools.
  - `Program.RunHeadlessMcp`: no longer exits from the install; logs that it's serving the bootstrap.
- New `ProvisionedInstanceDialog` + `_buttonProvision` on `AgentSettingsTab` (gating mirrors the MCP tool's `AllowSessionProvisioning` check).
- Docs/guidance updated: `InstalledAgentServingGuidance`, `AgentInstructions.md` (the connect-time playbook), `safety-emergency-stop-and-provisioning.md`, `environment-controller.md`, `configuration.md`, `AGENTS.md`.

## Tests

- Bootstrap gate: `tools/list` exposes only the two tools; `initialize` serves `BootstrapInstructions`; `capture`/`send_command` refused with `bootstrap-only`; `provision-session` passes the gate through to its own `AllowSessionProvisioning` check.
- Provision button gating + `ProvisionedInstanceDialog` handoff text (stdio line always; HTTP endpoint/token only when `mcpServer` enabled).
- Full suite: **985 passed, 22 skipped** (unchanged). Also smoke-tested a real `mcec.exe --mcp` from a non-installed dir: full 19-tool list + instructions serve correctly (non-bootstrap path unbroken).

## Drive-by fix (separate commit): tests were typing into the real desktop

While validating, `dotnet test` typed **"helloa"** into the focused window. `CommandExecutionPipelineTests` created a live `CommandInvoker`, enabled `chars:`, and enqueued `"chars:hello"` + `"a"`; the real dispatcher executed them via `SendInput` — on every `dotnet test`, not gated behind `MCEC_DESKTOP_E2E`. The tests only assert Enqueue parses without throwing, so they never needed actuation. Fixed by setting `SuppressDispatcherForTests=true` before enqueuing (the guard `CommandInvokerQueueCapTests` already uses). Audited the other real-invoker tests — no other unsuppressed actuating enqueue.

Fixes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
