### PR TITLE
Agent command access by operator consent (request-command-access) + agent-ready provision prompt (#307)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Three independent, **off-by-default** gates; see [`docs/environment-controller.m
 `McpServerEnabled` (HTTP floor, localhost-bound). Every agent action is logged with an `AGENT-AUDIT:`
 line. An agent that hits "agent commands are disabled" should tell the user, not retry.
 
-Two safety features layer on top (see [`docs/safety-emergency-stop-and-provisioning.md`](docs/safety-emergency-stop-and-provisioning.md)):
+Three safety features layer on top (see [`docs/safety-emergency-stop-and-provisioning.md`](docs/safety-emergency-stop-and-provisioning.md)):
 
 - **Emergency stop**: a global "dead man's switch" hotkey (default `Ctrl+Alt+Shift+S`) the operator
   can hit from **any** window to instantly halt a session: it latches the actuation gate (every tool call is
@@ -82,7 +82,20 @@ Two safety features layer on top (see [`docs/safety-emergency-stop-and-provision
   (#296): the installed `mcec.exe --mcp` serves the **bootstrap only** — just `provision-session` /
   `end-session`, every other tool refused with `bootstrap-only` — so a fresh install's agent has a first
   hop, while the full observe/act surface is still never served from Program Files. Keep the bootstrap
-  restriction (`Program.ProvisioningBootstrapOnly`) and the meta-tools' own gates intact.
+  restriction (`Program.ProvisioningBootstrapOnly`) and the meta-tools' own gates intact. The operator's
+  **Provision new…** handoff dialog shows a two-step handoff: MCP client setup plus a ready-made agent
+  briefing prompt (`ProvisionedInstanceDialog.BuildAgentPrompt`); the prompt points at the connect-time
+  instructions rather than duplicating the playbook, keep it that way.
+- **Command-access consent** (#307): a `command-disabled` refusal is recovered by the
+  `request-command-access` meta-tool, never by editing config files. It shows the OPERATOR a consent
+  dialog (`CommandAccessConsentDialog`) with three choices: allow these commands, allow these plus any
+  later requests, or deny (sticky per instance). Grants are **in-memory only** (the loaded table's
+  `Enabled` flags; never persisted), and the dialog is protected from the agent by three layers: the
+  call holds `AgentRuntime.InputGate` while the prompt is up, dispatch refuses actuation-capable tools
+  with `consent-pending` (`AgentToolExecutor.ServedWhileConsentPending` is an allow-list; keep it one),
+  and the dialog registers itself with `WindowResolver` as never-a-target. Do not weaken any of the
+  three, do not persist grants, and do not replace the dialog with MCP elicitation (that routes consent
+  through the agent's own client; the party being constrained).
 
 ## Dogfood: test MCEC using MCEC (mcec drives mcec)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,13 +89,19 @@ Three safety features layer on top (see [`docs/safety-emergency-stop-and-provisi
 - **Command-access consent** (#307): a `command-disabled` refusal is recovered by the
   `request-command-access` meta-tool, never by editing config files. It shows the OPERATOR a consent
   dialog (`CommandAccessConsentDialog`) with three choices: allow these commands, allow these plus any
-  later requests, or deny (sticky per instance). Grants are **in-memory only** (the loaded table's
-  `Enabled` flags; never persisted), and the dialog is protected from the agent by three layers: the
-  call holds `AgentRuntime.InputGate` while the prompt is up, dispatch refuses actuation-capable tools
-  with `consent-pending` (`AgentToolExecutor.ServedWhileConsentPending` is an allow-list; keep it one),
-  and the dialog registers itself with `WindowResolver` as never-a-target. Do not weaken any of the
-  three, do not persist grants, and do not replace the dialog with MCP elicitation (that routes consent
-  through the agent's own client; the party being constrained).
+  later requests, or deny (sticky per instance; an emergency stop dismissing the prompt is NOT a deny
+  and records nothing). Grants are **in-memory only**: the loaded table's `Enabled` flags, never
+  persisted; `CommandInvoker.Save` serializes consent-granted commands as disabled
+  (`AgentConsent.WasGrantedByConsent`) so the Commands window cannot quietly write a grant into
+  mcec.commands. The dialog is protected from the agent by three layers: the call holds
+  `AgentRuntime.InputGate` while the prompt is up; dispatch freezes everything except the
+  `ToolDescriptor.ServedDuringConsent` observation tools with `consent-pending` (default false, so a
+  new tool stays frozen; the freeze runs BEFORE the meta-tool branches, so `provision-session` cannot
+  mint a second, unfrozen instance mid-prompt); and the dialog registers itself with `WindowResolver`
+  as never-a-target. Do not weaken any of the three, do not persist grants, and do not replace the
+  dialog with MCP elicitation (that routes consent through the agent's own client; the party being
+  constrained). Grants land on the key `CommandInvoker.ResolveGateKey` resolves (the entry Enqueue
+  actually gates on); route any new name-resolution through that one resolver.
 
 ## Dogfood: test MCEC using MCEC (mcec drives mcec)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,8 +78,17 @@ The **Agent** tab is where you let an agent (a desktop assistant or computer-use
 * **Allow agents to provision disposable instances**: the one switch to turn on. A connected agent then
   gets a fresh, throwaway copy of MCEC to drive, deleted when it finishes. It never opens up this installed
   copy.
+* **Provision new…**: creates a throwaway copy yourself and shows a two-step handoff: the MCP client
+  setup line, and a ready-made briefing prompt to paste to your agent (its session id, token, rules of
+  engagement, and teardown duty), each with its own copy button.
 * **Provisioned instances**: lists those copies (age, size, running or not), with **Delete** / **Delete
   all** to clear any an agent left behind. MCEC also cleans up stale ones on its own.
+
+While an agent is driving, it may ask to use a command that is disabled (for example `launch`). MCEC then
+shows you a consent dialog naming the command(s) and the agent's stated reason; you can allow just those,
+allow those plus any later requests, or deny (the default; a deny is final for that instance). Grants are
+in-memory and die with the instance; nothing is written to your config files. See
+**[Agent Safety](safety-emergency-stop-and-provisioning.md)**.
 
 ### Agent settings (in `mcec.settings`)
 
@@ -109,13 +118,17 @@ applies to both the classic commands and the agent commands: an agent command ru
 
 Use the **Commands Window** (**Commands ▸ Enable and Test Commands…**) to enable/disable commands and test
 them. Details, including the `mcec.commands` XML format, are in
-**[Home Automation & Remote Control](home-automation.md#enabling-or-disabling-commands)**.
+**[Home Automation & Remote Control](home-automation.md#enabling-or-disabling-commands)**. An agent that
+needs a disabled command can also ask you for it live via `request-command-access`; you approve or deny
+on-screen, and an approval enables it in-memory for that instance only (see
+**[Agent Safety](safety-emergency-stop-and-provisioning.md)**).
 
 ## Agent safety
 
-The agent gates above decide *whether* the agent surface is reachable. Two operator-safety features build
-on them: the global **emergency-stop** hotkey and disposable **isolated session provisioning**. Both are
-covered in **[Agent Safety](safety-emergency-stop-and-provisioning.md)**.
+The agent gates above decide *whether* the agent surface is reachable. Three operator-safety features build
+on them: the global **emergency-stop** hotkey, disposable **isolated session provisioning**, and
+on-screen **command-access consent**. All are covered in
+**[Agent Safety](safety-emergency-stop-and-provisioning.md)**.
 
 ## Logging
 

--- a/docs/environment-controller.md
+++ b/docs/environment-controller.md
@@ -84,7 +84,10 @@ and returns a JSON failure (for commands); it never silently proceeds.
 `record`/`launch`/`drag`/`click`/`focus`) are gated by **both** `AgentCommandsEnabled` **and** the per-command `Enabled`
 flag, over **both** MCP transports (`mcec.exe --mcp` stdio and the HTTP floor): a `tools/call` for a
 command whose `Enabled=false` is refused (`error.code: command-disabled`) even when
-`AgentCommandsEnabled=true`.
+`AgentCommandsEnabled=true`. An agent can recover from `command-disabled` mid-session with the
+`request-command-access` tool, which asks **you** on-screen and enables the command (in-memory, that
+instance only) only if you allow it; see
+[command-access consent](safety-emergency-stop-and-provisioning.md).
 
 **`send_command` is transport-sensitive.** It is a raw pass-through to the existing command engine,
 so it is a command-injection surface. Over the **local stdio** transport (`mcec.exe --mcp`, launched by its
@@ -224,8 +227,10 @@ failing call's own partial payload, e.g. a blank capture's suspect PNG):
 > [`docs/design/agent-tool-result-contract.md`](design/agent-tool-result-contract.md). A
 > couple of feature-specific refusals ride in `error.code` while `error.category` stays `internal`:
 > `emergency-stopped` (the operator engaged the [emergency stop](safety-emergency-stop-and-provisioning.md)),
-> `provisioning-not-authorized` (`AllowSessionProvisioning` is off), and `command-disabled` (the
-> per-command `Enabled` gate).
+> `provisioning-not-authorized` (`AllowSessionProvisioning` is off), `command-disabled` (the
+> per-command `Enabled` gate; recover via `request-command-access`), and the
+> [command-access consent](safety-emergency-stop-and-provisioning.md) family
+> (`consent-denied`, `consent-timeout`, `consent-pending`, `consent-unavailable`).
 
 ### Agent sessions
 
@@ -679,7 +684,7 @@ concurrently; past that the server answers `503` rather than queueing.
 
 ## Summary
 
-- New, opt-in agent surface: `capture`, `query`, `displays`, `windows`, `find`, `wait-for`, `invoke`, `launch`, `drag`, `click`, `focus`, `record` (plus `send_command`, and `provision-session`/`end-session`).
+- New, opt-in agent surface: `capture`, `query`, `displays`, `windows`, `find`, `wait-for`, `invoke`, `launch`, `drag`, `click`, `focus`, `record` (plus `send_command`, `request-command-access`, and `provision-session`/`end-session`).
 - Structured `{ ok, result, error, … }` JSON result envelope; the commands are exposed as MCP/HTTP tools.
 - **No per-target sandbox:** an enabled command acts with your rights on whatever it targets. You control
   the *capability surface* (which commands are enabled, so read-only observation is possible), not what an
@@ -694,7 +699,9 @@ concurrently; past that the server answers `503` rather than queueing.
 
 ## Agent safety
 
-Two operator-safety features build on the gates above: a global **emergency stop** hotkey that halts a
-session instantly from any window, and disposable **isolated session provisioning** so an agent drives a
-throwaway copy instead of your installed instance. Both are covered in
+Three operator-safety features build on the gates above: a global **emergency stop** hotkey that halts a
+session instantly from any window, disposable **isolated session provisioning** so an agent drives a
+throwaway copy instead of your installed instance, and **command-access consent**
+(`request-command-access`) so an agent can gain a disabled command mid-session only by asking you
+on-screen. All three are covered in
 **[Agent Safety](safety-emergency-stop-and-provisioning.md)**.

--- a/docs/safety-emergency-stop-and-provisioning.md
+++ b/docs/safety-emergency-stop-and-provisioning.md
@@ -241,9 +241,12 @@ thread. The agent's call blocks for the answer. Three choices:
 1. **Allow these commands**; enables exactly the requested names.
 2. **Allow these + any later requests**; also auto-approves this instance's future requests (the agent
    still asks per command, and every grant is audit-logged and narrated on the overlay).
-3. **Deny** (the default button; Esc, the close box, the ~2-minute timeout, and an emergency stop
-   engaging all deny). A deny is **sticky** for the instance: re-requesting a denied command returns
-   `consent-denied` without a prompt, so an agent cannot nag the operator into approval.
+3. **Deny** (the default button; Esc, the close box, and the ~2-minute timeout all deny). A deny is
+   **sticky** for the instance: re-requesting a denied command returns `consent-denied` without a
+   prompt, so an agent cannot nag the operator into approval. An **emergency stop** engaging while
+   the prompt is open dismisses it too, but that is the operator halting the session, not answering
+   the question: it is reported as `emergency-stopped`, records no deny, and the command stays
+   grantable after re-arm.
 
 ### Why the agent can't answer its own prompt
 
@@ -252,9 +255,11 @@ by three layers:
 
 1. The call holds the **input gate** (`AgentRuntime.InputGate`) for the prompt's whole lifetime, so no
    queued or synthesized keyboard/mouse input can land while it is up.
-2. Dispatch refuses every actuation-capable tool with `consent-pending` while a prompt is open; only
-   observation is served. This covers `invoke`, which is UIA-pattern actuation that deliberately does
-   not take the input gate.
+2. Dispatch freezes everything except the flagged observation tools (`ToolDescriptor.ServedDuringConsent`;
+   a new tool defaults to frozen) with `consent-pending` while a prompt is open. The freeze runs before
+   the meta-tool branches, so it covers `invoke` (UIA-pattern actuation that deliberately does not take
+   the input gate) **and** `provision-session` (which could otherwise mint a second, unfrozen instance
+   to drive the dialog with).
 3. The dialog registers itself with `WindowResolver` as never-a-target (the overlay's mechanism), so
    in-process targeting can never resolve it.
 
@@ -264,7 +269,9 @@ overlay narration are the mitigations there.
 ### Why grants are in-memory only
 
 A grant flips the command's `Enabled` flag on the **loaded table** of the running instance; nothing is
-written to `mcec.commands` or `mcec.settings`. A leaked session directory therefore never carries
+written to `mcec.commands` or `mcec.settings`, and `CommandInvoker.Save` serializes consent-granted
+commands as **disabled**, so even a later Commands-window "Save changes" cannot quietly persist an
+agent's grant. A leaked session directory therefore never carries
 permissions beyond its provisioned defaults, a respawned instance resets and must ask again, and the
 co-located files remain a faithful record of what *provisioning* granted (the audit log holds what
 *consent* granted). Consent is deliberately MCEC's own out-of-band dialog, never MCP elicitation, which

--- a/docs/safety-emergency-stop-and-provisioning.md
+++ b/docs/safety-emergency-stop-and-provisioning.md
@@ -3,12 +3,13 @@
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 -->
 
-# Agent safety: Emergency Stop and Isolated Session Provisioning
+# Agent safety: Emergency Stop, Isolated Session Provisioning, and Command-Access Consent
 
-Two related safety features for MCEC's Agent Mode. When MCEC is agent-driving the desktop, the **target
+Three related safety features for MCEC's Agent Mode. When MCEC is agent-driving the desktop, the **target
 app has focus, not MCEC**; so the operator needs (a) a way to instantly intervene when a run goes wrong,
-and (b) assurance that a session can't leave the machine in an unsafe state. Both features exist so the
-operator stays in control.
+(b) assurance that a session can't leave the machine in an unsafe state, and (c) a way to grant an agent
+more capability mid-session without ever letting it grant itself. All three exist so the operator stays
+in control.
 
 ---
 
@@ -124,10 +125,13 @@ user has no other copy yet. Two first hops resolve it, neither requiring the ope
 config:
 
 - **Operator-initiated (GUI).** The **Agent** tab's **Provision new…** button calls
-  `SessionProvisioner.Provision()` directly (no MCP round-trip) and shows a copyable handoff
-  ([`ProvisionedInstanceDialog`](../src/Dialogs/ProvisionedInstanceDialog.cs)): the directory, the
-  `mcec.exe --mcp` launch line, the HTTP endpoint + bearer token, and teardown notes. The operator
-  pastes that into their agent's MCP client. Enabled only when the opt-in below is ticked.
+  `SessionProvisioner.Provision()` directly (no MCP round-trip) and shows a two-step handoff
+  ([`ProvisionedInstanceDialog`](../src/Dialogs/ProvisionedInstanceDialog.cs)): step 1, the MCP client
+  setup (the `mcec.exe --mcp` launch line and, when enabled, the HTTP endpoint + bearer token); step 2,
+  a ready-made **briefing prompt to paste to the agent** carrying the session id, directory, token
+  custody, the rules of engagement (ask for disabled commands via `request-command-access`, never edit
+  config files, stop on `emergency-stopped`), and the teardown duty. Each step has its own copy
+  button. Enabled only when the opt-in below is ticked.
 - **Bootstrap MCP mode (headless).** An agent may connect to the **installed** `mcec.exe --mcp`; but
   from the install it serves a restricted surface: `tools/list` and dispatch expose **only**
   `provision-session` and `end-session`, and every other tool is refused with `error.code:bootstrap-only`
@@ -221,4 +225,58 @@ construction, and supersedes the earlier hand-rolled "copy the build and write a
 - **Auto-launch.** `provision-session` returns a directory and how to launch it; it does not spawn the
   process (the caller/host does).
 - **Artifacts.** Evidence bundles live under the session directory, so teardown collects them.
+
+---
+
+## 3. Command access by operator consent (`request-command-access`)
+
+A provisioned session enables the standard agent tool set; everything else (`launch`, raw built-ins like
+`chars:` or `shutdown`, user-defined commands) starts disabled, and any tool or `send_command` that hits
+one is refused with `error.code:command-disabled`. The legitimate mid-session acquisition path is the
+`request-command-access` meta-tool: the agent names the command(s) and a one-line reason, and MCEC shows
+the **operator** a consent dialog ([`CommandAccessConsentDialog`](../src/Dialogs/CommandAccessConsentDialog.cs))
+on their desktop; GUI host on the main window's thread, headless `--mcp` on `HeadlessOperatorUi`'s pump
+thread. The agent's call blocks for the answer. Three choices:
+
+1. **Allow these commands**; enables exactly the requested names.
+2. **Allow these + any later requests**; also auto-approves this instance's future requests (the agent
+   still asks per command, and every grant is audit-logged and narrated on the overlay).
+3. **Deny** (the default button; Esc, the close box, the ~2-minute timeout, and an emergency stop
+   engaging all deny). A deny is **sticky** for the instance: re-requesting a denied command returns
+   `consent-denied` without a prompt, so an agent cannot nag the operator into approval.
+
+### Why the agent can't answer its own prompt
+
+The agent being asked can synthesize input and drive UIA on the same desktop, so the dialog is protected
+by three layers:
+
+1. The call holds the **input gate** (`AgentRuntime.InputGate`) for the prompt's whole lifetime, so no
+   queued or synthesized keyboard/mouse input can land while it is up.
+2. Dispatch refuses every actuation-capable tool with `consent-pending` while a prompt is open; only
+   observation is served. This covers `invoke`, which is UIA-pattern actuation that deliberately does
+   not take the input gate.
+3. The dialog registers itself with `WindowResolver` as never-a-target (the overlay's mechanism), so
+   in-process targeting can never resolve it.
+
+Residual risk: a *second* MCEC instance driven by the same agent shares none of these; the audit log and
+overlay narration are the mitigations there.
+
+### Why grants are in-memory only
+
+A grant flips the command's `Enabled` flag on the **loaded table** of the running instance; nothing is
+written to `mcec.commands` or `mcec.settings`. A leaked session directory therefore never carries
+permissions beyond its provisioned defaults, a respawned instance resets and must ask again, and the
+co-located files remain a faithful record of what *provisioning* granted (the audit log holds what
+*consent* granted). Consent is deliberately MCEC's own out-of-band dialog, never MCP elicitation, which
+would route the question through the agent's own client; the party being constrained.
+
+### Design / where it lives
+
+| Concern | Location |
+| --- | --- |
+| Consent state (single-flight, standing grant, sticky denies) | [`AgentConsent`](../src/Agent/AgentConsent.cs) |
+| The consent dialog | [`CommandAccessConsentDialog`](../src/Dialogs/CommandAccessConsentDialog.cs) |
+| Tool dispatch, gates, and the consent-pending freeze | `AgentToolExecutor` (`request-command-access`, `ConsentPendingRefusal`) |
+| GUI prompt channel | `MainWindow.PromptCommandAccess` |
+| Headless prompt channel | `HeadlessOperatorUi.PromptCommandAccess` |
 

--- a/src/Agent/AgentConsent.cs
+++ b/src/Agent/AgentConsent.cs
@@ -41,6 +41,7 @@ public static class AgentConsent {
     private static bool _pending;
     private static bool _anyCommandGrant;
     private static readonly HashSet<string> _denied = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly HashSet<string> _granted = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// The operator-prompt channel, registered by whichever host has an operator surface
@@ -83,6 +84,31 @@ public static class AgentConsent {
     public static bool IsDenied(string commandName) {
         lock (_gate) {
             return _denied.Contains(commandName);
+        }
+    }
+
+    /// <summary>
+    /// Records a table key the operator's consent enabled, so persistence paths can shield it:
+    /// <see cref="CommandInvoker.Save"/> serializes a consent-granted command as DISABLED, keeping
+    /// the dialog's "nothing is written to any config file" promise even when the operator later
+    /// saves the Commands window (#308 review). Process-lifetime, like the grant itself.
+    /// </summary>
+    internal static void RecordGrantedKey(string commandKey) {
+        lock (_gate) {
+            _ = _granted.Add(commandKey);
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="commandKey"/> was enabled by operator consent this process. A true
+    /// here means the enable is in-memory-only by contract and must never be persisted as enabled.
+    /// </summary>
+    public static bool WasGrantedByConsent(string? commandKey) {
+        if (string.IsNullOrEmpty(commandKey)) {
+            return false;
+        }
+        lock (_gate) {
+            return _granted.Contains(commandKey);
         }
     }
 
@@ -133,12 +159,13 @@ public static class AgentConsent {
         }
     }
 
-    /// <summary>Drops all consent state (pending flag, standing grant, sticky denies). Tests only.</summary>
+    /// <summary>Drops all consent state (pending flag, standing grant, sticky denies, granted keys). Tests only.</summary>
     internal static void ResetForTests() {
         lock (_gate) {
             _pending = false;
             _anyCommandGrant = false;
             _denied.Clear();
+            _granted.Clear();
         }
     }
 }

--- a/src/Agent/AgentConsent.cs
+++ b/src/Agent/AgentConsent.cs
@@ -1,0 +1,144 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace MCEControl;
+
+/// <summary>
+/// The in-memory consent state behind the <c>request-command-access</c> meta-tool (#307): whether a
+/// prompt is currently on screen (single-flight), the operator's standing "allow any later requests"
+/// grant, and the sticky per-command denies. All of it is process-lifetime only, on purpose:
+/// a grant is never written to <c>mcec.commands</c>/<c>mcec.settings</c>, so a leaked provisioned
+/// directory never carries widened permissions and a respawned instance resets to its provisioned
+/// defaults and must ask again.
+///
+/// <para>SECURITY: consent must be OUT-OF-BAND from the agent. The prompt is MCEC's own dialog on the
+/// operator's desktop, reached through <see cref="Prompter"/> (registered by the GUI host and the
+/// headless operator UI); it is deliberately NOT MCP elicitation, which would route the question
+/// through the agent's own client, i.e. through the party being constrained. With no prompter
+/// registered (no interactive operator surface) the tool fails closed with
+/// <c>consent-unavailable</c>.</para>
+/// </summary>
+public static class AgentConsent {
+    /// <summary>
+    /// How long the consent prompt waits for the operator before closing itself as a deny
+    /// (<see cref="CommandAccessDecision.TimedOut"/>). The prompt must not outlive its tool call:
+    /// a late "Allow" landing after the agent already received consent-timeout would be a silent
+    /// grant nobody is waiting on.
+    /// </summary>
+    public const int PromptTimeoutMs = 120_000;
+
+    /// <summary>Upper bound on commands per request, so one prompt stays operator-readable.</summary>
+    public const int MaxCommandsPerRequest = 8;
+
+    /// <summary>Upper bound on the agent's stated reason; anything longer is truncated before display.</summary>
+    public const int MaxReasonLength = 300;
+
+    private static readonly Lock _gate = new();
+    private static bool _pending;
+    private static bool _anyCommandGrant;
+    private static readonly HashSet<string> _denied = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The operator-prompt channel, registered by whichever host has an operator surface
+    /// (GUI: <c>MainWindow</c>; headless: <see cref="HeadlessOperatorUi"/>). Shows the modal
+    /// <see cref="CommandAccessConsentDialog"/> on the operator's UI thread and blocks the calling
+    /// (MCP worker) thread for the decision. Returns null when the prompt cannot be shown (no
+    /// interactive desktop, host torn down), which the executor reports as <c>consent-unavailable</c>;
+    /// fail closed, never fail open. Null when no host registered one (tests, early startup).
+    /// </summary>
+    public static Func<CommandAccessRequest, CommandAccessDecision?>? Prompter { get; set; }
+
+    /// <summary>
+    /// True while a consent prompt is on screen. <see cref="AgentToolExecutor"/> refuses every
+    /// actuation-capable tool call while this is set (<c>consent-pending</c>), which; together with
+    /// the <see cref="AgentRuntime.InputGate"/> hold around the prompt and the dialog registering
+    /// itself as a never-a-target window; is what keeps the agent from answering its own prompt.
+    /// </summary>
+    public static bool IsPending {
+        get {
+            lock (_gate) {
+                return _pending;
+            }
+        }
+    }
+
+    /// <summary>True once the operator chose "allow these and any later requests" (this process only).</summary>
+    public static bool AnyCommandGrantActive {
+        get {
+            lock (_gate) {
+                return _anyCommandGrant;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether the operator already denied <paramref name="commandName"/> this process. A deny is
+    /// STICKY: re-asking returns <c>consent-denied</c> without a prompt, so an agent cannot nag the
+    /// operator into approval (consent fatigue is how consent systems actually fail).
+    /// </summary>
+    public static bool IsDenied(string commandName) {
+        lock (_gate) {
+            return _denied.Contains(commandName);
+        }
+    }
+
+    /// <summary>
+    /// Claims the single prompt slot. False means another consent prompt is already on screen
+    /// (the caller reports <c>consent-pending</c>); one dialog at a time, so a burst of requests can
+    /// never stack prompts. Pair with <see cref="EndPrompt"/> in a finally.
+    /// </summary>
+    internal static bool TryBeginPrompt() {
+        lock (_gate) {
+            if (_pending) {
+                return false;
+            }
+            _pending = true;
+            return true;
+        }
+    }
+
+    /// <summary>Releases the single prompt slot claimed by <see cref="TryBeginPrompt"/>.</summary>
+    internal static void EndPrompt() {
+        lock (_gate) {
+            _pending = false;
+        }
+    }
+
+    /// <summary>
+    /// Records the operator's decision: <see cref="CommandAccessDecision.AllowAny"/> arms the
+    /// standing grant; <see cref="CommandAccessDecision.Denied"/> makes each requested command
+    /// sticky-denied. A timeout records nothing; it is the operator not answering, not the operator
+    /// deciding, so the agent may ask again later.
+    /// </summary>
+    internal static void RecordDecision(CommandAccessDecision decision, IEnumerable<string> commands) {
+        lock (_gate) {
+            switch (decision) {
+                case CommandAccessDecision.AllowAny:
+                    _anyCommandGrant = true;
+                    break;
+                case CommandAccessDecision.Denied:
+                    foreach (string name in commands) {
+                        _ = _denied.Add(name);
+                    }
+                    break;
+                case CommandAccessDecision.TimedOut:
+                case CommandAccessDecision.AllowRequested:
+                default:
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Drops all consent state (pending flag, standing grant, sticky denies). Tests only.</summary>
+    internal static void ResetForTests() {
+        lock (_gate) {
+            _pending = false;
+            _anyCommandGrant = false;
+            _denied.Clear();
+        }
+    }
+}

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -157,7 +157,9 @@ PACING: raw commands (`send_command`) are queued and executed paced (a per-comma
 operator's CommandPacing), and a `send_command` call returns only AFTER its command has actually executed
 (its `result.output` is the command's real output). It fails fast when nothing will run:
 `error.code:unknown-command` means the name isn't in the loaded command table (fix the name; nothing
-executed), and `command-dropped` means the queue refused it whole (bounds/shutdown; nothing executed).
+executed), `command-disabled` means the command exists but the operator has not enabled it (nothing
+executed; recover via `request-command-access`, see COMMAND ACCESS), and `command-dropped` means the
+queue refused it whole (bounds/shutdown; nothing executed).
 The execution wait is bounded at 30s: a command still running past it (a long macro, `pause`, or a deep
 queue backlog ahead of it) returns `error.code:send-command-timeout` while continuing to execute on the
 host; wait and verify with `query`/`capture` rather than resending. The queue is BOUNDED (both total pending
@@ -201,7 +203,26 @@ provision disposable instances" on the Settings dialog's Agent tab (File > Setti
 do not retry blindly before they do. On that same Agent tab the operator can also click "Provision new…"
 to create an instance themselves and hand you its directory/endpoint; and it lists the provisioned
 instances and lets them delete any you leave behind. But you own teardown: `end-session` every instance
-you provision.
+you provision. A provisioned session enables the standard observation/actuation tool set; anything else
+(e.g. `launch`, raw built-ins like `chars:`) starts disabled; acquire it mid-session with
+`request-command-access` (see COMMAND ACCESS), never by editing the session's files.
+
+COMMAND ACCESS: any tool or raw command refused with `error.code:command-disabled` can be requested from
+the OPERATOR with the `request-command-access` tool: pass the command name(s) the refusal reported (e.g.
+`launch`, `chars:`) and a one-line, honest `reason`; MCEC shows the operator a consent dialog on their
+screen and your call BLOCKS (up to ~2 minutes) for their answer. On a grant the commands are immediately
+usable; enabled in-memory in THIS instance only, never written to a config file; NEVER edit mcec.commands,
+mcec.settings, or anything in the session directory to grant yourself access. The operator can also choose
+"allow any later requests", after which further requests auto-approve (still ask per command; every grant
+is audited and narrated on the overlay). A deny is FINAL for this instance: re-requesting a denied command
+returns `error.code:consent-denied` with no prompt; do not nag; tell the user what you needed and why.
+`consent-timeout` means the operator never answered (they may be away; you may ask again later, ideally
+after checking in with the user). `consent-pending` means a consent prompt is already open: while it is up,
+only observation (`capture`/`query`/`displays`/`windows`/`find`/`wait-for`/`record`) is served and every
+other call is refused with that code; wait for your pending request to return. `consent-unavailable` means
+no operator prompt can be shown (fail closed); ask the user to enable the command themselves. You will
+never see or target the consent dialog; it is excluded from targeting like the overlay, and actuation is
+frozen while it is open; only the operator's physical input can answer it.
 
 EMERGENCY STOP: the operator has a global panic hotkey (default Ctrl+Alt+Shift+S) that instantly halts the
 session from any window. If ANY tool returns `error.code:emergency-stopped` (the code, not the category;
@@ -213,7 +234,9 @@ session-start/session-status/session-end lifecycle) only work when the operator 
 AgentCommandsEnabled=true; otherwise they return an error; surface that to the user rather than retrying.
 `send_command` is also gated by AgentCommandsEnabled when you are connected over the HTTP transport (it is
 refused with `error.code:agent-commands-disabled` if the agent surface is not opted in); over the local
-stdio transport (`mcec.exe --mcp`) `send_command` remains available without that opt-in. Either way the raw
-command it runs still needs its own command Enabled in mcec.commands.
+stdio transport (`mcec.exe --mcp`) `send_command` remains available without that opt-in; and
+`request-command-access` follows the same transport rule. Either way the raw
+command it runs still needs its own command Enabled in mcec.commands (recover from `command-disabled` via
+`request-command-access`, never by editing files; see COMMAND ACCESS).
 `provision-session` additionally requires AllowSessionProvisioning, and any tool is refused with
 `emergency-stopped` while the operator's emergency stop is engaged. Every action is audit-logged on the host.

--- a/src/Agent/AgentRuntime.cs
+++ b/src/Agent/AgentRuntime.cs
@@ -88,6 +88,11 @@ public static class AgentRuntime {
     /// wait on a task/thread while holding it; a command's <c>Execute</c> may take seconds (paced
     /// macros), and anything that waits on the dispatcher while holding this deadlocks it.
     /// Observation (query/capture/find/wait-for/record) deliberately never takes it.
+    /// ONE deliberate exception (#307): <c>request-command-access</c> holds this gate for the whole
+    /// lifetime of the operator consent prompt (bounded by the prompt's own timeout), precisely SO
+    /// synthesized input cannot land while the dialog is up; only physical input can answer it. Safe
+    /// against the deadlock rule because the prompt's UI thread never takes this gate and waits on
+    /// nothing that does; actuation stalls behind it by design.
     /// </para>
     /// <para>
     /// KNOWN HAZARD (queue-path modal invoke): the agent's <c>invoke</c> TOOL runs on a worker with

--- a/src/Agent/CommandAccessDecision.cs
+++ b/src/Agent/CommandAccessDecision.cs
@@ -1,0 +1,25 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// The operator's answer to a <c>request-command-access</c> consent prompt (#307). Fail-safe by
+/// construction: everything that is not an explicit Allow (Esc, the close box, the timeout, an
+/// emergency stop engaging while the prompt is up) maps to <see cref="Denied"/> or
+/// <see cref="TimedOut"/>, and <see cref="Denied"/> is the enum default so an unset decision can
+/// never read as a grant.
+/// </summary>
+public enum CommandAccessDecision {
+    /// <summary>The operator explicitly denied the request (final for this instance; the deny is sticky).</summary>
+    Denied,
+
+    /// <summary>The operator never answered; the prompt closed itself. NOT sticky; the agent may ask again.</summary>
+    TimedOut,
+
+    /// <summary>Enable exactly the requested commands.</summary>
+    AllowRequested,
+
+    /// <summary>Enable the requested commands AND auto-approve this instance's future requests.</summary>
+    AllowAny,
+}

--- a/src/Agent/CommandAccessRequest.cs
+++ b/src/Agent/CommandAccessRequest.cs
@@ -1,0 +1,24 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Collections.Generic;
+
+namespace MCEControl;
+
+/// <summary>
+/// One <c>request-command-access</c> ask, shaped for the operator's consent prompt (#307): the
+/// resolved command-table names the agent wants enabled, a display line per command (name plus what
+/// it does, so the operator judges the capability rather than the name), and the agent's stated
+/// reason. The reason is UNTRUSTED text straight from the agent; the dialog renders it visibly
+/// quoted and attributed so it can never impersonate MCEC's own chrome.
+/// </summary>
+public sealed record CommandAccessRequest {
+    /// <summary>The resolved (lower-case) command-table names being requested; already filtered to disabled, known commands.</summary>
+    public required IReadOnlyList<string> Commands { get; init; }
+
+    /// <summary>One line per requested command: the name and a short description of what enabling it permits.</summary>
+    public required IReadOnlyList<string> DisplayLines { get; init; }
+
+    /// <summary>The agent's stated reason (sanitized: length-capped, newlines collapsed). Untrusted.</summary>
+    public required string Reason { get; init; }
+}

--- a/src/Agent/HeadlessOperatorUi.cs
+++ b/src/Agent/HeadlessOperatorUi.cs
@@ -198,6 +198,35 @@ internal static class HeadlessOperatorUi {
         }
     }
 
+    /// <summary>
+    /// The headless consent-prompt channel for <c>request-command-access</c> (#307), registered as
+    /// <see cref="AgentConsent.Prompter"/> by <c>Program.RunHeadlessMcp</c>. Marshals the modal
+    /// <see cref="CommandAccessConsentDialog"/> onto this pump thread (the same pattern as the re-arm
+    /// prompt: the pump keeps the hotkey and overlay live behind the modal) and blocks the calling MCP
+    /// worker for the operator's decision. Null; which the executor reports as
+    /// <c>consent-unavailable</c>, fail closed; when the pump is not hosting (no interactive desktop,
+    /// or the operator disabled both the overlay and the e-stop so <see cref="Start"/> no-op'ed).
+    /// A <see cref="Stop"/> racing an open prompt exits the message loop, which dismisses the dialog
+    /// with its fail-safe default (deny).
+    /// </summary>
+    internal static CommandAccessDecision? PromptCommandAccess(CommandAccessRequest request) {
+        Control? marshal = _marshal;
+        if (marshal is null || !marshal.IsHandleCreated) {
+            return null;
+        }
+        try {
+            return marshal.Invoke(() => {
+                using CommandAccessConsentDialog dialog = new(request);
+                _ = dialog.ShowDialog();
+                return dialog.Decision;
+            });
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Warn($"HeadlessOperatorUi: could not show the consent prompt: {e.Message}");
+            return null;
+        }
+    }
+
     private static void OnStateChanged(bool stopped) {
         if (stopped) {
             RequestPrompt();

--- a/src/Agent/HeadlessOperatorUi.cs
+++ b/src/Agent/HeadlessOperatorUi.cs
@@ -200,32 +200,16 @@ internal static class HeadlessOperatorUi {
 
     /// <summary>
     /// The headless consent-prompt channel for <c>request-command-access</c> (#307), registered as
-    /// <see cref="AgentConsent.Prompter"/> by <c>Program.RunHeadlessMcp</c>. Marshals the modal
-    /// <see cref="CommandAccessConsentDialog"/> onto this pump thread (the same pattern as the re-arm
-    /// prompt: the pump keeps the hotkey and overlay live behind the modal) and blocks the calling MCP
-    /// worker for the operator's decision. Null; which the executor reports as
-    /// <c>consent-unavailable</c>, fail closed; when the pump is not hosting (no interactive desktop,
-    /// or the operator disabled both the overlay and the e-stop so <see cref="Start"/> no-op'ed).
-    /// A <see cref="Stop"/> racing an open prompt exits the message loop, which dismisses the dialog
-    /// with its fail-safe default (deny).
+    /// <see cref="AgentConsent.Prompter"/> by <c>Program.RunHeadlessMcp</c>: the shared
+    /// <see cref="CommandAccessConsentDialog.ShowVia"/> body marshaled onto this pump thread (the
+    /// same pattern as the re-arm prompt: the pump keeps the hotkey and overlay live behind the
+    /// modal). Null; fail closed as <c>consent-unavailable</c>; when the pump is not hosting (no
+    /// interactive desktop, or the operator disabled both the overlay and the e-stop so
+    /// <see cref="Start"/> no-op'ed). A <see cref="Stop"/> racing an open prompt exits the message
+    /// loop, which dismisses the dialog with its fail-safe default (deny).
     /// </summary>
-    internal static CommandAccessDecision? PromptCommandAccess(CommandAccessRequest request) {
-        Control? marshal = _marshal;
-        if (marshal is null || !marshal.IsHandleCreated) {
-            return null;
-        }
-        try {
-            return marshal.Invoke(() => {
-                using CommandAccessConsentDialog dialog = new(request);
-                _ = dialog.ShowDialog();
-                return dialog.Decision;
-            });
-        }
-        catch (Exception e) {
-            Logger.Instance.Log4.Warn($"HeadlessOperatorUi: could not show the consent prompt: {e.Message}");
-            return null;
-        }
-    }
+    internal static CommandAccessDecision? PromptCommandAccess(CommandAccessRequest request) =>
+        CommandAccessConsentDialog.ShowVia(_marshal, nameof(HeadlessOperatorUi), request);
 
     private static void OnStateChanged(bool stopped) {
         if (stopped) {

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -1,4 +1,4 @@
-// Copyright © Kindel, LLC - http://www.kindel.com
+﻿// Copyright © Kindel, LLC - http://www.kindel.com
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
 using System;
@@ -71,6 +71,7 @@ public static class ToolCatalog {
             Tersify = args => $"capture {CommandTersifier.Target(args)}",
             IsObservation = true,
             ProvisionedByDefault = true,
+            ServedDuringConsent = true,
         },
         new() {
             Name = "query",
@@ -92,6 +93,7 @@ public static class ToolCatalog {
             Tersify = args => $"query {CommandTersifier.Target(args)}",
             IsObservation = true,
             ProvisionedByDefault = true,
+            ServedDuringConsent = true,
         },
         new() {
             Name = "displays",
@@ -100,6 +102,7 @@ public static class ToolCatalog {
             CreateCommandInstance = () => new DisplaysCommand(),
             Tersify = _ => "displays",
             ProvisionedByDefault = true,
+            ServedDuringConsent = true,
         },
         new() {
             Name = "windows",
@@ -116,6 +119,7 @@ public static class ToolCatalog {
             // NOT IsObservation: it returns a SET of windows, not a single active target the session
             // should record as LastObservation (that stays query/capture/find/wait-for).
             ProvisionedByDefault = true,
+            ServedDuringConsent = true,
         },
         new() {
             Name = "find",
@@ -125,6 +129,7 @@ public static class ToolCatalog {
             Tersify = args => $"find {CommandTersifier.Selector(args)}",
             IsObservation = true,
             ProvisionedByDefault = true,
+            ServedDuringConsent = true,
         },
         new() {
             Name = "wait-for",
@@ -134,6 +139,7 @@ public static class ToolCatalog {
             Tersify = args => $"wait-for {CommandTersifier.Selector(args)}",
             IsObservation = true,
             ProvisionedByDefault = true,
+            ServedDuringConsent = true,
         },
         new() {
             Name = "invoke",
@@ -217,6 +223,7 @@ public static class ToolCatalog {
             // drift where record rendered as a bare "record" on the overlay.)
             Tersify = args => $"record {CommandTersifier.Target(args)}",
             ProvisionedByDefault = true,
+            ServedDuringConsent = true,
         },
         new() {
             Name = "launch",

--- a/src/Agent/ToolDescriptor.cs
+++ b/src/Agent/ToolDescriptor.cs
@@ -68,4 +68,13 @@ public sealed record ToolDescriptor {
     /// matching <see cref="SessionProvisioner"/>'s historical command set.
     /// </summary>
     public bool ProvisionedByDefault { get; init; }
+
+    /// <summary>
+    /// Whether the tool is still served while an operator consent prompt is open (#307). Default
+    /// FALSE; fail closed: only pure observation may run during the consent freeze, so anything that
+    /// could actuate, mutate state, or mint capability (and every meta-tool, which is not in the
+    /// catalog at all) is refused with <c>consent-pending</c> and can never reach, or help answer,
+    /// the agent's own prompt. A new tool must opt IN to being served, never out of the freeze.
+    /// </summary>
+    public bool ServedDuringConsent { get; init; }
 }

--- a/src/Commands/CommandInvoker.cs
+++ b/src/Commands/CommandInvoker.cs
@@ -172,10 +172,27 @@ public class CommandInvoker : Hashtable {
 
         Command[] values = [.. Values.Cast<Command>()];
 
-        // Sort 
-        sc.commandArray = [.. values.OrderBy(c => c.Cmd)];
+        // SECURITY (#307/#308 review): a consent-granted enable (request-command-access) is
+        // process-lifetime ONLY; "nothing is written to any config file" is the promise the consent
+        // dialog makes the operator. Serialize such commands as DISABLED stand-in clones so a later
+        // Commands-window Save cannot quietly persist an agent's grant into mcec.commands (where it
+        // would survive restart with no consent gate). The live table is untouched; the operator's
+        // own hand-made enables persist as always. (A consent-granted key stays shielded for the
+        // process lifetime even if the operator re-toggles it in the window; persist it by editing
+        // mcec.commands directly, or restart first.)
+        sc.commandArray = [.. values
+            .Select(c => c.Enabled && AgentConsent.WasGrantedByConsent(c.Cmd) ? DisabledCloneForSave(c) : c)
+            .OrderBy(c => c.Cmd)];
 
         SerializedCommands.SaveCommands(userCommandsFile, sc, System.Windows.Forms.Application.ProductVersion);
+    }
+
+    // A serialization stand-in for a consent-granted command: identical, but Enabled=false on disk.
+    // Clone just carries the Reply through (null stays null; Reply is never serialized).
+    private static Command DisabledCloneForSave(Command cmd) {
+        Command clone = cmd.Clone(cmd.Reply!);
+        clone.Enabled = false;
+        return clone;
     }
 
     // Adds a command to the hashtable. Optionally logs. Ensures case insenstiitivy. 
@@ -192,6 +209,41 @@ public class CommandInvoker : Hashtable {
         else {
             Logger.Instance.Log4.Error($"{this.GetType().Name}: Error parsing command: {cmd}");
         }
+    }
+
+    // The 'prefix:args' shape Enqueue splits (group 1 is the table key, group 2 the Args). ONE
+    // compiled pattern shared with ResolveGateKey so the gate and its consumers can never drift.
+    private static readonly Regex _prefixCommandPattern = new(@"(\w+:)(.+)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The loaded-table key <see cref="Enqueue"/> will gate and execute for <paramref name="cmdString"/>
+    /// (#308 review): a single character rides <c>chars:</c> when that is enabled (else a same-named
+    /// single-character entry when one exists, else <c>chars:</c> itself when present, so callers
+    /// report the entry whose disablement actually blocks it); a <c>prefix:args</c> spelling resolves
+    /// to its bare prefix entry (the table's full spellings like <c>mcec:exit</c> are never resolved
+    /// by Enqueue); anything else is looked up whole. Null when nothing in the table matches.
+    /// Consumers: <c>request-command-access</c> (the key a grant must enable) and <c>send_command</c>'s
+    /// <c>command-disabled</c> pre-check; sharing this resolver is what keeps a grant and the gate
+    /// agreeing on the same key.
+    /// </summary>
+    internal string? ResolveGateKey(string cmdString) {
+        if (string.IsNullOrWhiteSpace(cmdString)) {
+            return null;
+        }
+        string trimmed = cmdString.Trim();
+        if (trimmed.Length == 1) {
+            if (this["chars:"] is Command { Enabled: true }) {
+                return "chars:"; // Enqueue's single-character SendInput path
+            }
+            string single = trimmed.ToLowerInvariant();
+            if (this[single] is Command) {
+                return single;
+            }
+            return this["chars:"] is Command ? "chars:" : null;
+        }
+        Match match = _prefixCommandPattern.Match(trimmed);
+        string key = (match.Success ? match.Groups[1].Value : trimmed).ToLowerInvariant();
+        return this[key] is Command ? key : null;
     }
 
     /// <summary>
@@ -212,7 +264,7 @@ public class CommandInvoker : Hashtable {
         // parse cmd and args (eg. char vs "shutdown" vs "mouse:<action>[,<parameter>,<parameter>]"
         // and "mouse:<action>[,<parameter>,<parameter>]"
         // These commands are handled internally as Cmd="cmd:" Args="<args>"
-        Match match = Regex.Match(cmdString, @"(\w+:)(.+)");
+        Match match = _prefixCommandPattern.Match(cmdString);
         if (match.Success) {
             cmd = match.Groups[1].Value;
             args = match.Groups[2].Value;

--- a/src/Dialogs/CommandAccessConsentDialog.cs
+++ b/src/Dialogs/CommandAccessConsentDialog.cs
@@ -1,0 +1,203 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace MCEControl;
+
+/// <summary>
+/// The operator consent prompt for <c>request-command-access</c> (#307): an agent asked to use
+/// disabled command(s), and this dialog is the deliberate, out-of-band operator action that decides.
+/// Three-way: allow exactly the requested commands, allow those plus any later requests (this
+/// instance only), or deny (sticky). Defaults are fail-safe: Deny is the default button, and Enter,
+/// Esc, the close box, the timeout, and an emergency stop engaging all mean deny/timeout; only an
+/// explicit click of an Allow button grants anything.
+///
+/// <para>SECURITY: the agent being asked about can synthesize input and drive UIA on this very
+/// desktop, so the dialog must be unreachable by everything but physical input. Three layers:
+/// (1) the executor holds <see cref="AgentRuntime.InputGate"/> for the prompt's whole lifetime, so
+/// queued/synthesized input cannot land; (2) the executor refuses every actuation-capable tool call
+/// with <c>consent-pending</c> while the prompt is up (notably <c>invoke</c>, which is UIA-pattern
+/// actuation that never takes the gate); (3) this window registers itself with
+/// <see cref="WindowResolver"/> as never-a-target (the overlay's #119 mechanism), so in-process
+/// window resolution can never hand the agent its own consent prompt. Residual risk: a SECOND MCEC
+/// instance driven by the same agent shares none of these; the audit log and overlay narration are
+/// the mitigations there.</para>
+///
+/// <para>The timeout closes the dialog as <see cref="CommandAccessDecision.TimedOut"/> so the prompt
+/// can never outlive its tool call; a late "Allow" after the agent already received consent-timeout
+/// would be a silent grant.</para>
+/// </summary>
+internal sealed class CommandAccessConsentDialog : Form {
+    /// <summary>The operator's decision; <see cref="CommandAccessDecision.Denied"/> unless an Allow button was clicked or the timeout fired.</summary>
+    public CommandAccessDecision Decision { get; private set; } = CommandAccessDecision.Denied;
+
+    private readonly System.Windows.Forms.Timer _timeout;
+    private readonly Action<bool> _onEmergencyStop;
+
+    // The handle currently registered as ignored (never-a-target), tracked so a WinForms handle
+    // recreation never leaves a stale HWND in the resolver's ignore set (see CommandOverlayWindow).
+    private long _registeredHandle;
+
+    public CommandAccessConsentDialog(CommandAccessRequest request, int timeoutMs = AgentConsent.PromptTimeoutMs) {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Text = "MCE Controller - Agent requests command access";
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MinimizeBox = false;
+        MaximizeBox = false;
+        ShowInTaskbar = true;
+        // No owner: the GUI host's MainWindow may be hidden in the tray and headless has no window at
+        // all; TopMost keeps the prompt above whatever the agent was driving.
+        TopMost = true;
+        StartPosition = FormStartPosition.CenterScreen;
+        AutoScaleMode = AutoScaleMode.Font;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+
+        Label message = new() {
+            AutoSize = true,
+            MaximumSize = new Size(520, 0),
+            Margin = new Padding(4, 4, 4, 12),
+            Text = BuildBody(request, timeoutMs / 1000),
+            // The reason inside the body is untrusted agent text; a Label renders it inert (no
+            // links, no mnemonics), so it cannot smuggle an accelerator or spoof a control.
+            UseMnemonic = false,
+        };
+
+        Button allowRequested = new() {
+            Text = "Allow &these commands",
+            DialogResult = DialogResult.OK,
+            AutoSize = true,
+        };
+        allowRequested.Click += (_, _) => Decision = CommandAccessDecision.AllowRequested;
+        Button allowAny = new() {
+            Text = "Allow these + &any later requests",
+            DialogResult = DialogResult.OK,
+            AutoSize = true,
+        };
+        allowAny.Click += (_, _) => Decision = CommandAccessDecision.AllowAny;
+        Button deny = new() {
+            Text = "&Deny",
+            DialogResult = DialogResult.Cancel,
+            AutoSize = true,
+        };
+        deny.Click += (_, _) => Decision = CommandAccessDecision.Denied;
+
+        FlowLayoutPanel buttons = new() {
+            FlowDirection = FlowDirection.RightToLeft,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Anchor = AnchorStyles.Right,
+            Margin = new Padding(0),
+        };
+        // RightToLeft flow: first added lands right-most. Deny (the safe choice) sits right, first in
+        // tab order, and is both AcceptButton and CancelButton below.
+        buttons.Controls.Add(deny);
+        buttons.Controls.Add(allowAny);
+        buttons.Controls.Add(allowRequested);
+
+        TableLayoutPanel layout = new() {
+            ColumnCount = 1,
+            RowCount = 2,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Padding = new Padding(12),
+        };
+        layout.Controls.Add(message, 0, 0);
+        layout.Controls.Add(buttons, 0, 1);
+        Controls.Add(layout);
+
+        AcceptButton = deny;
+        CancelButton = deny;
+
+        _timeout = new System.Windows.Forms.Timer { Interval = timeoutMs };
+        _timeout.Tick += (_, _) => {
+            Decision = CommandAccessDecision.TimedOut;
+            Close();
+        };
+        _timeout.Start();
+
+        // The operator's panic hotkey wins over an open consent prompt: engaging the stop dismisses
+        // this dialog as a deny (Decision stays Denied). Fires on the hook/pool thread; marshal.
+        _onEmergencyStop = stopped => {
+            if (!stopped) {
+                return;
+            }
+            try {
+                if (IsHandleCreated && !IsDisposed) {
+                    BeginInvoke(Close);
+                }
+            }
+            catch (InvalidOperationException) {
+                // Handle torn down between the check and the post; the dialog is already closing.
+            }
+        };
+        EmergencyStop.StateChanged += _onEmergencyStop;
+    }
+
+    protected override void OnHandleCreated(EventArgs e) {
+        base.OnHandleCreated(e);
+        // Never-a-target (#119 mechanism): without this, `invoke`/`click` by name could resolve this
+        // very dialog and press its own Allow button (invoke is UIA actuation and does not take the
+        // input gate). Defensively drop any previously-registered handle first (handle recreation).
+        if (_registeredHandle != 0) {
+            WindowResolver.UnregisterIgnoredWindow(_registeredHandle);
+        }
+        _registeredHandle = Handle.ToInt64();
+        WindowResolver.RegisterIgnoredWindow(_registeredHandle);
+    }
+
+    protected override void OnHandleDestroyed(EventArgs e) {
+        if (_registeredHandle != 0) {
+            WindowResolver.UnregisterIgnoredWindow(_registeredHandle);
+            _registeredHandle = 0;
+        }
+        base.OnHandleDestroyed(e);
+    }
+
+    protected override void Dispose(bool disposing) {
+        if (disposing) {
+            _timeout.Dispose();
+            EmergencyStop.StateChanged -= _onEmergencyStop;
+            // OnHandleDestroyed normally clears the registration; unregister defensively in case the
+            // window is disposed without a handle-destroyed notification.
+            if (_registeredHandle != 0) {
+                WindowResolver.UnregisterIgnoredWindow(_registeredHandle);
+                _registeredHandle = 0;
+            }
+        }
+        base.Dispose(disposing);
+    }
+
+    /// <summary>
+    /// Renders the prompt body. Static and internal so tests can verify the text (the command list,
+    /// the quoted-as-untrusted reason framing, the in-memory/this-instance-only scope, the sticky
+    /// deny, and the timeout) without showing a window.
+    /// </summary>
+    internal static string BuildBody(CommandAccessRequest request, int timeoutSeconds) {
+        StringBuilder sb = new();
+        _ = sb.AppendLine("An agent connected to this MCEC instance is asking to use "
+            + (request.Commands.Count == 1 ? "a command that is" : "commands that are")
+            + " currently disabled:");
+        _ = sb.AppendLine();
+        foreach (string line in request.DisplayLines) {
+            _ = sb.AppendLine($"    {line}");
+        }
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("The agent says (unverified):");
+        _ = sb.AppendLine($"    \"{request.Reason}\"");
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("Allowing enables the command(s) in THIS instance only, in memory, until it "
+            + "exits; nothing is written to any config file. \"Allow these + any later requests\" also "
+            + "auto-approves this instance's future requests; every grant is still audit-logged and "
+            + "narrated on the overlay.");
+        _ = sb.AppendLine();
+        _ = sb.Append($"Deny is final for this instance (the agent cannot ask again for these commands). "
+            + $"Doing nothing denies the request in {timeoutSeconds} seconds.");
+        return sb.ToString();
+    }
+}

--- a/src/Dialogs/CommandAccessConsentDialog.cs
+++ b/src/Dialogs/CommandAccessConsentDialog.cs
@@ -121,22 +121,54 @@ internal sealed class CommandAccessConsentDialog : Form {
         };
         _timeout.Start();
 
-        // The operator's panic hotkey wins over an open consent prompt: engaging the stop dismisses
-        // this dialog as a deny (Decision stays Denied). Fires on the hook/pool thread; marshal.
-        _onEmergencyStop = stopped => {
-            if (!stopped) {
-                return;
-            }
-            try {
-                if (IsHandleCreated && !IsDisposed) {
-                    BeginInvoke(Close);
-                }
-            }
-            catch (InvalidOperationException) {
-                // Handle torn down between the check and the post; the dialog is already closing.
-            }
-        };
+        _onEmergencyStop = HandleEmergencyStop;
         EmergencyStop.StateChanged += _onEmergencyStop;
+    }
+
+    /// <summary>
+    /// The operator's panic hotkey wins over an open consent prompt, but it halts the SESSION; it
+    /// does not answer the consent question. So the dialog dismisses as
+    /// <see cref="CommandAccessDecision.TimedOut"/> (never a sticky operator deny; #308 review), and
+    /// the executor reports the standard <c>emergency-stopped</c> refusal while the latch is engaged,
+    /// leaving the command grantable again after the operator re-arms. Fires on the hook/pool thread;
+    /// marshals its own Close. Internal so tests can drive the dismissal without a message pump.
+    /// </summary>
+    internal void HandleEmergencyStop(bool stopped) {
+        if (!stopped) {
+            return;
+        }
+        Decision = CommandAccessDecision.TimedOut;
+        try {
+            if (IsHandleCreated && !IsDisposed) {
+                BeginInvoke(Close);
+            }
+        }
+        catch (InvalidOperationException) {
+            // Handle torn down between the check and the post; the dialog is already closing.
+        }
+    }
+
+    /// <summary>
+    /// Shows the consent prompt modally on <paramref name="marshal"/>'s UI thread and returns the
+    /// operator's decision; the ONE prompter body both hosts register (#308 review: the GUI and
+    /// headless channels must not drift). Null; fail closed, reported as <c>consent-unavailable</c>;
+    /// when the marshal control cannot host a dialog (null, disposed, no handle) or the show fails.
+    /// </summary>
+    internal static CommandAccessDecision? ShowVia(Control? marshal, string logContext, CommandAccessRequest request) {
+        if (marshal is null || marshal.IsDisposed || !marshal.IsHandleCreated) {
+            return null;
+        }
+        try {
+            return marshal.Invoke(() => {
+                using CommandAccessConsentDialog dialog = new(request);
+                _ = dialog.ShowDialog();
+                return dialog.Decision;
+            });
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Warn($"{logContext}: could not show the consent prompt: {e.Message}");
+            return null;
+        }
     }
 
     protected override void OnHandleCreated(EventArgs e) {

--- a/src/Dialogs/ProvisionedInstanceDialog.cs
+++ b/src/Dialogs/ProvisionedInstanceDialog.cs
@@ -10,12 +10,14 @@ namespace MCEControl;
 
 /// <summary>
 /// Shows the operator the handoff for an instance they just provisioned from the Agent tab's
-/// "Provision new…" button (#296): where the disposable copy lives, how to point an agent at it
-/// (the stdio <c>--mcp</c> launch line and, when enabled, the HTTP endpoint + bearer token), and how
-/// to tear it down. The whole handoff is one read-only, copyable text block; the operator's next act
-/// is pasting this into an MCP client config, so Copy-all is the primary affordance.
+/// "Provision new…" button (#296), in the two steps the operator actually performs (#307):
+/// step 1, register the instance as an MCP server (the stdio <c>--mcp</c> launch line and, when
+/// enabled, the HTTP endpoint + bearer token); step 2, paste a ready-made briefing prompt to the
+/// agent (session identity, token custody, rules of engagement, teardown duty). Each step is its own
+/// read-only text block with its own copy button; "Copy prompt" is the primary affordance because it
+/// is the last thing the operator does before talking to the agent.
 ///
-/// <para>SECURITY: the text includes the session token (#215). That is the point; the operator IS
+/// <para>SECURITY: both blocks include the session token (#215). That is the point; the operator IS
 /// the session owner and needs the credential to hand to their agent; and it is no wider an
 /// exposure than <c>provision-session</c> returning the same token to a connected agent.</para>
 /// </summary>
@@ -33,23 +35,50 @@ internal sealed class ProvisionedInstanceDialog : Form {
         AutoSize = true;
         AutoSizeMode = AutoSizeMode.GrowAndShrink;
 
-        TextBox handoff = new() {
+        Label setupLabel = new() {
+            AutoSize = true,
+            Margin = new Padding(4, 4, 4, 2),
+            Text = "Step 1 (you): register the instance as an MCP server:",
+        };
+        TextBox setup = new() {
             Multiline = true,
             ReadOnly = true,
             WordWrap = false,
             ScrollBars = ScrollBars.Both,
             Font = new Font(FontFamily.GenericMonospace, 9f),
             Text = BuildHandoffText(session),
-            Size = new Size(640, 320),
-            Margin = new Padding(4, 4, 4, 8),
+            Size = new Size(680, 150),
+            Margin = new Padding(4, 0, 4, 8),
             TabStop = false,
         };
 
-        Button copy = new() {
-            Text = "&Copy all",
+        Label promptLabel = new() {
+            AutoSize = true,
+            Margin = new Padding(4, 4, 4, 2),
+            Text = "Step 2 (you): paste this briefing to your agent as its first message:",
+        };
+        TextBox prompt = new() {
+            Multiline = true,
+            ReadOnly = true,
+            WordWrap = false,
+            ScrollBars = ScrollBars.Both,
+            Font = new Font(FontFamily.GenericMonospace, 9f),
+            Text = BuildAgentPrompt(session),
+            Size = new Size(680, 220),
+            Margin = new Padding(4, 0, 4, 8),
+            TabStop = false,
+        };
+
+        Button copySetup = new() {
+            Text = "Copy &setup",
             AutoSize = true,
         };
-        copy.Click += (_, _) => Clipboard.SetText(handoff.Text);
+        copySetup.Click += (_, _) => Clipboard.SetText(setup.Text);
+        Button copyPrompt = new() {
+            Text = "Copy &prompt",
+            AutoSize = true,
+        };
+        copyPrompt.Click += (_, _) => Clipboard.SetText(prompt.Text);
         Button close = new() {
             Text = "Close",
             DialogResult = DialogResult.OK,
@@ -63,19 +92,24 @@ internal sealed class ProvisionedInstanceDialog : Form {
             Anchor = AnchorStyles.Right,
             Margin = new Padding(0),
         };
-        // RightToLeft flow: first added lands right-most; Close sits right, Copy all beside it.
+        // RightToLeft flow: first added lands right-most; Close sits right, then Copy prompt (the
+        // primary affordance, nearest Close), then Copy setup.
         buttons.Controls.Add(close);
-        buttons.Controls.Add(copy);
+        buttons.Controls.Add(copyPrompt);
+        buttons.Controls.Add(copySetup);
 
         TableLayoutPanel layout = new() {
             ColumnCount = 1,
-            RowCount = 2,
+            RowCount = 5,
             AutoSize = true,
             AutoSizeMode = AutoSizeMode.GrowAndShrink,
             Padding = new Padding(12),
         };
-        layout.Controls.Add(handoff, 0, 0);
-        layout.Controls.Add(buttons, 0, 1);
+        layout.Controls.Add(setupLabel, 0, 0);
+        layout.Controls.Add(setup, 0, 1);
+        layout.Controls.Add(promptLabel, 0, 2);
+        layout.Controls.Add(prompt, 0, 3);
+        layout.Controls.Add(buttons, 0, 4);
         Controls.Add(layout);
 
         AcceptButton = close;
@@ -83,18 +117,15 @@ internal sealed class ProvisionedInstanceDialog : Form {
     }
 
     /// <summary>
-    /// Renders the copyable handoff: the same facts <see cref="ProvisionedSession.ToJsonObject"/>
-    /// hands a connected agent, phrased for the operator who will paste them into an MCP client
-    /// config. Static and internal so tests can verify the text without showing a window.
+    /// Renders step 1, the MCP-client setup block: the same facts
+    /// <see cref="ProvisionedSession.ToJsonObject"/> hands a connected agent, phrased for the
+    /// operator who will paste them into an MCP client config. Static and internal so tests can
+    /// verify the text without showing a window.
     /// </summary>
     internal static string BuildHandoffText(ProvisionedSession session) {
         StringBuilder sb = new();
         _ = sb.AppendLine("A fresh, disposable MCEC instance is ready. Agent commands are enabled ONLY");
         _ = sb.AppendLine("inside this copy; your installed MCEC is untouched.");
-        _ = sb.AppendLine();
-        _ = sb.AppendLine($"Directory:  {session.Directory}");
-        _ = sb.AppendLine($"Session id: {session.SessionId}");
-        _ = sb.AppendLine($"Token:      {session.Token}");
         _ = sb.AppendLine();
         _ = sb.AppendLine("Connect over stdio (recommended): configure your MCP client to spawn:");
         _ = sb.AppendLine($"  \"{session.ExePath}\" --mcp");
@@ -108,9 +139,57 @@ internal sealed class ProvisionedInstanceDialog : Form {
             _ = sb.AppendLine($"  with the header: Authorization: Bearer {session.Token}");
         }
         _ = sb.AppendLine();
-        _ = sb.AppendLine("Teardown: have the agent call end-session with the session id and token (after");
-        _ = sb.AppendLine("stopping the instance), or delete it from this Agent tab; stale instances are");
-        _ = sb.AppendLine("also cleaned up automatically.");
+        _ = sb.AppendLine("Teardown: the briefing below tells the agent to stop the instance and report");
+        _ = sb.AppendLine("done; you can then delete it from this Agent tab (or the agent calls");
+        _ = sb.AppendLine("end-session on the installed bootstrap). Stale instances are also cleaned up");
+        _ = sb.AppendLine("automatically.");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Renders step 2, the agent briefing prompt (#307): what the connect-time instructions cannot
+    /// know; the session identity, token custody, the operator's rules of engagement (ask via
+    /// request-command-access, never edit config files, stop on emergency-stopped, teardown duty);
+    /// and a task placeholder. It deliberately does NOT restate the tool playbook: that is the
+    /// server's connect-time instructions (AgentInstructions.md), the single source the prompt
+    /// points the agent at. Static and internal so tests can verify the text (and that every tool
+    /// name and error code it mentions exists on the served surface) without showing a window.
+    /// </summary>
+    internal static string BuildAgentPrompt(ProvisionedSession session) {
+        StringBuilder sb = new();
+        _ = sb.AppendLine("You have access to an MCP server named \"mcec\" (MCE Controller). It lets you");
+        _ = sb.AppendLine("observe and drive native Windows applications on my PC: enumerate windows, read");
+        _ = sb.AppendLine("UI Automation trees, capture screenshots, invoke controls, click, drag, type,");
+        _ = sb.AppendLine("and launch apps.");
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("You are driving a DISPOSABLE, provisioned MCEC instance, not my installed copy:");
+        _ = sb.AppendLine($"  Session id: {session.SessionId}");
+        _ = sb.AppendLine($"  Directory:  {session.Directory}");
+        _ = sb.AppendLine($"  Token:      {session.Token}");
+        _ = sb.AppendLine("Keep the token: it is the session credential, required for teardown"
+            + (session.McpServerEnabled ? " and as the" : "."));
+        if (session.McpServerEnabled) {
+            _ = sb.AppendLine($"'Authorization: Bearer <token>' header on any HTTP call to http://{session.BindAddress}:{session.Port}/mcp.");
+        }
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("Before acting, read the server's connect-time instructions; they define the");
+        _ = sb.AppendLine("observe -> target -> act -> verify loop and every tool's contract. Follow them.");
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("Rules of engagement:");
+        _ = sb.AppendLine("1. If a tool or command is refused with error.code \"command-disabled\", call the");
+        _ = sb.AppendLine("   request-command-access tool with the command name(s) and a one-line reason. I");
+        _ = sb.AppendLine("   will approve or deny in a dialog on my screen; the call waits for my answer.");
+        _ = sb.AppendLine("   NEVER edit mcec.commands, mcec.settings, or any file in the session directory");
+        _ = sb.AppendLine("   to grant yourself access.");
+        _ = sb.AppendLine("2. If any call fails with error.code \"emergency-stopped\", I halted you on");
+        _ = sb.AppendLine("   purpose. Stop immediately and check in with me; do not retry.");
+        _ = sb.AppendLine("3. When your task is complete: stop the instance (send_command mcec:exit over");
+        _ = sb.AppendLine("   its stdio connection ends it cleanly), then tell me it is finished so I can");
+        _ = sb.AppendLine("   delete the session from Settings > Agent. If you are also connected to my");
+        _ = sb.AppendLine("   installed MCEC's bootstrap server, instead call its end-session tool with the");
+        _ = sb.AppendLine("   session id and token above.");
+        _ = sb.AppendLine();
+        _ = sb.Append("My task for you: <describe the task here>");
         return sb.ToString();
     }
 }

--- a/src/Dialogs/ProvisionedInstanceDialog.cs
+++ b/src/Dialogs/ProvisionedInstanceDialog.cs
@@ -127,6 +127,13 @@ internal sealed class ProvisionedInstanceDialog : Form {
         _ = sb.AppendLine("A fresh, disposable MCEC instance is ready. Agent commands are enabled ONLY");
         _ = sb.AppendLine("inside this copy; your installed MCEC is untouched.");
         _ = sb.AppendLine();
+        // The identity + credential ALWAYS ride this block too (#308 review): the operator may only
+        // ever copy/keep this one, and a stdio-only session would otherwise show the token nowhere
+        // outside the briefing.
+        _ = sb.AppendLine($"Directory:  {session.Directory}");
+        _ = sb.AppendLine($"Session id: {session.SessionId}");
+        _ = sb.AppendLine($"Token:      {session.Token}");
+        _ = sb.AppendLine();
         _ = sb.AppendLine("Connect over stdio (recommended): configure your MCP client to spawn:");
         _ = sb.AppendLine($"  \"{session.ExePath}\" --mcp");
         _ = sb.AppendLine();
@@ -140,9 +147,9 @@ internal sealed class ProvisionedInstanceDialog : Form {
         }
         _ = sb.AppendLine();
         _ = sb.AppendLine("Teardown: the briefing below tells the agent to stop the instance and report");
-        _ = sb.AppendLine("done; you can then delete it from this Agent tab (or the agent calls");
-        _ = sb.AppendLine("end-session on the installed bootstrap). Stale instances are also cleaned up");
-        _ = sb.AppendLine("automatically.");
+        _ = sb.AppendLine("done; you can then delete it from this Agent tab (or an agent connected to");
+        _ = sb.AppendLine("the installed bootstrap calls end-session with the session id and token");
+        _ = sb.AppendLine("above). Stale instances are also cleaned up automatically.");
         return sb.ToString();
     }
 
@@ -183,11 +190,15 @@ internal sealed class ProvisionedInstanceDialog : Form {
         _ = sb.AppendLine("   to grant yourself access.");
         _ = sb.AppendLine("2. If any call fails with error.code \"emergency-stopped\", I halted you on");
         _ = sb.AppendLine("   purpose. Stop immediately and check in with me; do not retry.");
-        _ = sb.AppendLine("3. When your task is complete: stop the instance (send_command mcec:exit over");
-        _ = sb.AppendLine("   its stdio connection ends it cleanly), then tell me it is finished so I can");
-        _ = sb.AppendLine("   delete the session from Settings > Agent. If you are also connected to my");
-        _ = sb.AppendLine("   installed MCEC's bootstrap server, instead call its end-session tool with the");
-        _ = sb.AppendLine("   session id and token above.");
+        // Teardown must work UNATTENDED, so the briefing never routes it through a command that
+        // needs a consent round-trip: the raw mcec: built-in is disabled in every provisioned
+        // instance (#308 review). Disconnecting ends a stdio instance (the server stops at EOF).
+        _ = sb.AppendLine("3. When your task is complete: disconnect from this instance (removing it from");
+        _ = sb.AppendLine("   your MCP client stops it; the server exits when its stdio connection closes),");
+        _ = sb.AppendLine("   then tell me it is finished so I can delete the session from Settings > Agent.");
+        _ = sb.AppendLine("   If you are also connected to my installed MCEC's bootstrap server, instead");
+        _ = sb.AppendLine("   call its end-session tool with the session id and token above once this");
+        _ = sb.AppendLine("   instance has stopped.");
         _ = sb.AppendLine();
         _ = sb.Append("My task for you: <describe the task here>");
         return sb.ToString();

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -703,28 +703,12 @@ public partial class MainWindow : Form, IAppHost {
 
     /// <summary>
     /// The GUI consent-prompt channel for <c>request-command-access</c> (#307), registered as
-    /// <see cref="AgentConsent.Prompter"/> in <see cref="ApplySettings"/>. Marshals the modal
-    /// <see cref="CommandAccessConsentDialog"/> onto the UI thread (unowned: this window may be
-    /// hidden in the tray; the dialog is TopMost + CenterScreen) and blocks the calling MCP worker
-    /// for the operator's decision. Null; reported as <c>consent-unavailable</c>, fail closed; when
-    /// the window cannot host a dialog (torn down, no handle).
+    /// <see cref="AgentConsent.Prompter"/> in <see cref="ApplySettings"/>: the shared
+    /// <see cref="CommandAccessConsentDialog.ShowVia"/> body marshaled onto this window's UI thread
+    /// (unowned: this window may be hidden in the tray; the dialog is TopMost + CenterScreen).
     /// </summary>
-    private CommandAccessDecision? PromptCommandAccess(CommandAccessRequest request) {
-        if (IsDisposed || !IsHandleCreated) {
-            return null;
-        }
-        try {
-            return Invoke(() => {
-                using CommandAccessConsentDialog dialog = new(request);
-                _ = dialog.ShowDialog();
-                return dialog.Decision;
-            });
-        }
-        catch (Exception e) {
-            Logger.Instance.Log4.Warn($"MainWindow: could not show the consent prompt: {e.Message}");
-            return null;
-        }
-    }
+    private CommandAccessDecision? PromptCommandAccess(CommandAccessRequest request) =>
+        CommandAccessConsentDialog.ShowVia(this, nameof(MainWindow), request);
 
     // ShutDown() self-marshals (BeginInvoke when InvokeRequired), so this is callable from any
     // thread; the invoker's dispatcher (mcec:exit) and the updater's async download path both do.

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -701,6 +701,31 @@ public partial class MainWindow : Form, IAppHost {
     // IAppHost (#209); the GUI half of the AgentRuntime host seam (non-explicit; CA1033 forbids
     // explicit-only implementations on an unsealed type). SendLine below already matches.
 
+    /// <summary>
+    /// The GUI consent-prompt channel for <c>request-command-access</c> (#307), registered as
+    /// <see cref="AgentConsent.Prompter"/> in <see cref="ApplySettings"/>. Marshals the modal
+    /// <see cref="CommandAccessConsentDialog"/> onto the UI thread (unowned: this window may be
+    /// hidden in the tray; the dialog is TopMost + CenterScreen) and blocks the calling MCP worker
+    /// for the operator's decision. Null; reported as <c>consent-unavailable</c>, fail closed; when
+    /// the window cannot host a dialog (torn down, no handle).
+    /// </summary>
+    private CommandAccessDecision? PromptCommandAccess(CommandAccessRequest request) {
+        if (IsDisposed || !IsHandleCreated) {
+            return null;
+        }
+        try {
+            return Invoke(() => {
+                using CommandAccessConsentDialog dialog = new(request);
+                _ = dialog.ShowDialog();
+                return dialog.Decision;
+            });
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Warn($"MainWindow: could not show the consent prompt: {e.Message}");
+            return null;
+        }
+    }
+
     // ShutDown() self-marshals (BeginInvoke when InvokeRequired), so this is callable from any
     // thread; the invoker's dispatcher (mcec:exit) and the updater's async download path both do.
     public void RequestShutdown() => ShutDown();
@@ -902,6 +927,9 @@ public partial class MainWindow : Form, IAppHost {
         // handle) on the same seam, in the same place the settings are published. Idempotent;
         // the dialog-OK path re-runs this with the same instance.
         AgentRuntime.Host = this;
+
+        // #307: the request-command-access consent prompt shows on this window's UI thread.
+        AgentConsent.Prompter = PromptCommandAccess;
 
         // LevelMap's indexer returns null for a name it does not know (e.g. a hand-edited
         // settings file); keep the current threshold instead of dereferencing the miss.

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -348,6 +348,11 @@ internal static class Program {
         // (bounded) for arming, so by the time the protocol serves, the hotkey is live.
         HeadlessOperatorUi.Start(settings);
 
+        // #307: the request-command-access consent prompt rides the same pump thread. If the pump is
+        // not hosting (no interactive desktop, or overlay + e-stop both disabled), the channel returns
+        // null and the tool fails closed with consent-unavailable.
+        AgentConsent.Prompter = HeadlessOperatorUi.PromptCommandAccess;
+
         Logger.Instance.Log4.Info("MCEC: headless MCP mode.");
         LogAgentState(settings);
 

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -96,31 +96,33 @@ public sealed class AgentToolExecutor {
         tool == "send_command" || (ToolCatalog.TryGet(tool, out ToolDescriptor descriptor) && descriptor.SerializesOnInput);
 
     /// <summary>
-    /// The tools still served while an operator consent prompt is open (#307): pure observation plus
-    /// <c>record</c>. An ALLOW-list, not a deny-list, so a future actuation tool can never slip past
-    /// the consent freeze by not being enumerated. The in-process session lifecycle and the
-    /// provisioning meta-tools are handled before the consent guard in <see cref="CallTool"/> and are
-    /// unaffected (none of them can reach the prompt); everything else; every actuator, raw
-    /// <c>send_command</c>, <c>clipboard</c>, and a second <c>request-command-access</c>; is refused
-    /// with <c>consent-pending</c>.
+    /// Whether <paramref name="tool"/> is still served while an operator consent prompt is open
+    /// (#307): exactly the <see cref="ToolDescriptor.ServedDuringConsent"/> catalog members (pure
+    /// observation). Derived, not hand-listed (#308 review; the #205 lesson): a new tool defaults to
+    /// FROZEN, and the meta-tools (never in the catalog; <c>provision-session</c> especially, which
+    /// could mint a second, unfrozen instance to answer the prompt) are frozen by construction.
     /// </summary>
     internal static bool ServedWhileConsentPending(string tool) =>
-        tool is "capture" or "query" or "displays" or "windows" or "find" or "wait-for" or "record";
+        ToolCatalog.TryGet(tool, out ToolDescriptor descriptor) && descriptor.ServedDuringConsent;
+
+    /// <summary>The served-during-consent tool names for refusal text, from the same catalog flag.</summary>
+    private static string ConsentServedNames() =>
+        string.Join("/", ToolCatalog.All.Where(d => d.ServedDuringConsent).Select(d => d.Name));
 
     /// <summary>
     /// The consent-freeze refusal (#307), or null when the call may proceed (no prompt is open, or
     /// <paramref name="name"/> is served while one is).
     /// </summary>
-    private static JsonObject? ConsentPendingRefusal(string name, AgentSession session) {
+    private JsonObject? ConsentPendingRefusal(string name) {
         if (!AgentConsent.IsPending || ServedWhileConsentPending(name)) {
             return null;
         }
         AgentRuntime.Audit(name, "BLOCKED; an operator consent prompt (request-command-access) is open");
         return ToolError(
             "An operator consent prompt (request-command-access) is open; actuation is paused until the operator answers. " +
-            "Only observation tools (capture/query/displays/windows/find/wait-for/record) are served right now. " +
+            $"Only observation tools ({ConsentServedNames()}) are served right now. " +
             "Wait for the pending request-command-access call to return, then retry.",
-            "consent-pending", AgentErrorCategory.Internal, session.SessionId);
+            "consent-pending", AgentErrorCategory.Internal, DefaultSessionId());
     }
 
     // -------------------------------------------------------------------------------------------
@@ -157,6 +159,17 @@ public sealed class AgentToolExecutor {
                 "MCEC instance (it returns the directory, exePath, sessionId, and token), launch that " +
                 "instance's mcec.exe --mcp (or use its HTTP mcpEndpoint), and drive it instead.",
                 "bootstrap-only", AgentErrorCategory.Internal, DefaultSessionId());
+        }
+
+        // Operator consent in progress (#307): while a request-command-access prompt is on the
+        // operator's screen, everything except the flagged observation tools is refused; BEFORE every
+        // meta-tool branch below, so nothing dispatchable can reach or help answer the open prompt.
+        // This is one of the three layers that keep the agent from answering its own prompt: `invoke`
+        // is UIA-pattern actuation that deliberately never takes the input gate (#105), and
+        // provision-session could mint a SECOND instance whose input none of this process's
+        // protections block (#308 review); this dispatch refusal covers both.
+        if (ConsentPendingRefusal(name) is { } consentRefusal) {
+            return consentRefusal;
         }
 
         // Session lifecycle (#86 Phase 3): session-start/status/end. These read `sessionId` as an explicit
@@ -200,15 +213,6 @@ public sealed class AgentToolExecutor {
             return ToolError(
                 $"Unknown sessionId '{routeId}'. It was never started or has ended. Call session-start to get a fresh sessionId, or omit sessionId to use the default session.",
                 "unknown-session", AgentErrorCategory.InvalidArgument, routeId!);
-        }
-
-        // Operator consent in progress (#307): while a request-command-access prompt is on the
-        // operator's screen, every actuation-capable call is refused. This is one of the three layers
-        // that keep the agent from answering its own prompt: `invoke` is UIA-pattern actuation that
-        // deliberately never takes the input gate (#105), so the gate hold around the prompt cannot
-        // stop it; this dispatch refusal does. Observation stays served (the agent may look, not touch).
-        if (ConsentPendingRefusal(name, session) is { } consentRefusal) {
-            return consentRefusal;
         }
 
         // Command-access consent (#307): the agent asks, the OPERATOR decides, on MCEC's own dialog.
@@ -685,7 +689,15 @@ public sealed class AgentToolExecutor {
             return ToolError("Command engine is not available.", "engine-unavailable", AgentErrorCategory.Internal, session.SessionId);
         }
 
-        List<string>? names = StrArray(args["commands"] as JsonArray);
+        // STRICT parsing (#308 review): unlike StrArray (which tolerantly skips junk for
+        // provision-session's optional list), a malformed entry here must refuse the WHOLE request;
+        // silently dropping one would let the operator adjudicate a subset the agent never sees.
+        List<string>? names = StrictCommandNames(args["commands"], out string? namesError);
+        if (namesError is not null) {
+            return ToolError(
+                $"request-command-access 'commands' is malformed: {namesError} Every entry must be a non-empty command-name string; nothing was asked of the operator.",
+                "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
+        }
         if (names is null) {
             return ToolError(
                 "request-command-access requires a non-empty 'commands' array (the command names to enable).",
@@ -790,17 +802,32 @@ public sealed class AgentToolExecutor {
         }
 
         AgentConsent.RecordDecision(decision.Value, needed.Select(p => p.Key));
-        switch (decision.Value) {
+        return ApplyConsentDecision(decision.Value, needed, alreadyEnabled, session);
+    }
+
+    /// <summary>Turns the operator's decision into the tool result (grants applied, refusals shaped).</summary>
+    private static JsonObject ApplyConsentDecision(
+        CommandAccessDecision decision, List<KeyValuePair<string, Command>> needed, List<string> alreadyEnabled, AgentSession session) {
+        switch (decision) {
             case CommandAccessDecision.AllowRequested:
             case CommandAccessDecision.AllowAny:
-                EnableGranted(needed, decision.Value == CommandAccessDecision.AllowAny
+                EnableGranted(needed, decision == CommandAccessDecision.AllowAny
                     ? "granted by the operator (and any-command auto-grant armed)"
                     : "granted by the operator", session.SessionId);
                 return McpResult(AgentToolResult.Success(
-                    AccessResult([.. needed.Select(p => p.Key)], alreadyEnabled, decision.Value == CommandAccessDecision.AllowAny ? "any" : "requested"),
+                    AccessResult([.. needed.Select(p => p.Key)], alreadyEnabled, decision == CommandAccessDecision.AllowAny ? "any" : "requested"),
                     session.SessionId));
 
             case CommandAccessDecision.TimedOut:
+                // The panic hotkey engaging mid-prompt dismisses the dialog as TimedOut (not an
+                // operator ANSWER, so never a sticky deny; #308 review). Report it as the standard
+                // emergency-stopped signal so the agent stops entirely instead of re-asking.
+                if (AgentRuntime.EmergencyStopped) {
+                    AgentRuntime.Audit("request-command-access", $"DISMISSED by the emergency stop; not recorded as a deny for [{string.Join(",", needed.Select(p => p.Key))}]");
+                    return ToolError(
+                        "Emergency stop is engaged; the operator halted this session while your consent prompt was open (that is not a deny). All tool calls are refused until they re-arm. Stop and tell the user; do not retry.",
+                        "emergency-stopped", AgentErrorCategory.Internal, session.SessionId);
+                }
                 AgentRuntime.Audit("request-command-access", $"TIMEOUT; the operator did not answer for [{string.Join(",", needed.Select(p => p.Key))}]");
                 CommandEventHub.Publish(new CommandEvent("request-command-access", "consent request timed out (denied)", CommandOutcome.Failed, session.SessionId));
                 return ToolError(
@@ -826,6 +853,9 @@ public sealed class AgentToolExecutor {
     private static void EnableGranted(List<KeyValuePair<string, Command>> granted, string how, string sessionId) {
         foreach ((string key, Command cmd) in granted) {
             cmd.Enabled = true;
+            // Recorded so persistence shields it: CommandInvoker.Save serializes a consent-granted
+            // command as disabled, keeping the grant process-lifetime-only (#308 review).
+            AgentConsent.RecordGrantedKey(key);
             AgentRuntime.Audit("request-command-access", $"ENABLED '{key}' ({how}); in-memory, this instance only");
             CommandEventHub.Publish(new CommandEvent("request-command-access", $"enabled {key} ({how})", CommandOutcome.Ok, sessionId));
         }
@@ -844,44 +874,49 @@ public sealed class AgentToolExecutor {
     }
 
     /// <summary>
-    /// Resolves a requested command name to its loaded-table key using the invoker's OWN rules,
-    /// in the invoker's OWN order: <see cref="CommandInvoker.Enqueue"/> parses any
-    /// <c>prefix:args</c> spelling as the bare prefix command FIRST (so <c>mcec:exit</c> executes
-    /// the <c>mcec:</c> entry with args <c>exit</c>), and only a string without that shape is looked
-    /// up whole. A grant must enable the entry the invoker will actually gate on; the table also
-    /// holds full spellings like <c>mcec:exit</c> that Enqueue never resolves, and granting one of
-    /// those would leave the very next <c>send_command</c> still refused (PR #308 review). Null when
-    /// nothing in the table matches.
+    /// Resolves a requested command name to the loaded-table key the invoker will actually gate on,
+    /// via <see cref="CommandInvoker.ResolveGateKey"/>; the ONE resolver Enqueue's rules and both
+    /// consumers here share (#308 review), so a grant can never land on an entry (a full spelling
+    /// like <c>mcec:exit</c>, or a single character that rides <c>chars:</c>) the gate never reads.
     /// </summary>
-    private static string? ResolveTableKey(CommandInvoker invoker, string requested) {
-        string name = requested.Trim().ToLowerInvariant();
-        if (name.Length == 0) {
-            return null;
-        }
-        Match match = Regex.Match(name, @"(\w+:)(.+)");
-        string key = match.Success ? match.Groups[1].Value : name;
-        return invoker[key] is Command ? key : null;
-    }
+    private static string? ResolveTableKey(CommandInvoker invoker, string requested) =>
+        invoker.ResolveGateKey(requested);
 
     /// <summary>
-    /// Resolves which loaded-table command a raw <c>send_command</c> string would execute (the same
-    /// name/prefix/single-character rules Enqueue applies) and returns its key when that command
-    /// exists but is DISABLED; null when the command would run, is unknown (Enqueue reports that
-    /// honestly already), or a single character rides an enabled <c>chars:</c>.
+    /// The loaded-table key a raw <c>send_command</c> string resolves to when that command exists but
+    /// is DISABLED; null when it would run, or is unknown (Enqueue reports that honestly already).
     /// </summary>
-    private static string? DisabledSendCommandKey(CommandInvoker invoker, string command) {
-        if (command.Length == 1) {
-            if (invoker["chars:"] is Command { Enabled: true }) {
-                return null; // runs as a chars:-gated keypress
-            }
-            if (invoker[command.ToLowerInvariant()] is Command single) {
-                return single.Enabled ? null : command.ToLowerInvariant();
-            }
-            return invoker["chars:"] is Command ? "chars:" : null; // chars: exists but is disabled
+    private static string? DisabledSendCommandKey(CommandInvoker invoker, string command) =>
+        invoker.ResolveGateKey(command) is { } key && invoker[key] is Command { Enabled: false } ? key : null;
+
+    /// <summary>
+    /// Parses the <c>request-command-access</c> 'commands' argument STRICTLY (#308 review): every
+    /// entry must be a non-empty string, and any junk entry sets <paramref name="error"/> (naming the
+    /// offender) so the whole request is refused rather than silently adjudicated on a subset the
+    /// agent thinks was covered. Returns null (with no error) when the array is absent or empty.
+    /// </summary>
+    private static List<string>? StrictCommandNames(JsonNode? node, out string? error) {
+        error = null;
+        if (node is null) {
+            return null;
         }
-        Match match = Regex.Match(command, @"(\w+:)(.+)");
-        string key = (match.Success ? match.Groups[1].Value : command).ToLowerInvariant();
-        return invoker[key] is Command { Enabled: false } ? key : null;
+        if (node is not JsonArray array) {
+            error = "'commands' must be an array of command-name strings.";
+            return null;
+        }
+        List<string> names = [];
+        for (int i = 0; i < array.Count; i++) {
+            if (array[i] is not JsonValue v || !v.TryGetValue(out string? s)) {
+                error = $"entry {i} ({array[i]?.ToJsonString(AgentJson.Options) ?? "null"}) is not a string.";
+                return null;
+            }
+            if (string.IsNullOrWhiteSpace(s)) {
+                error = $"entry {i} is empty.";
+                return null;
+            }
+            names.Add(s.Trim());
+        }
+        return names.Count > 0 ? names : null;
     }
 
     /// <summary>
@@ -900,9 +935,11 @@ public sealed class AgentToolExecutor {
     }
 
     /// <summary>
-    /// Sanitizes the agent's stated reason for operator display: newlines/control characters collapse
-    /// to spaces (one visual line; no fake dialog paragraphs), embedded double quotes soften so the
-    /// dialog's own quoting stays unambiguous, and length is capped.
+    /// Sanitizes the agent's stated reason for operator display: control characters, Unicode line/
+    /// paragraph separators (U+2028/U+2029; Label honors them as line breaks), and format characters
+    /// (Cf; bidi overrides like U+202E RLO that could visually reorder text out of the dialog's
+    /// quoting; #308 review) all collapse to spaces so the reason stays ONE honest visual line;
+    /// embedded double quotes soften so the dialog's own quoting stays unambiguous; length is capped.
     /// </summary>
     private static string SanitizeReason(string? reason) {
         if (string.IsNullOrWhiteSpace(reason)) {
@@ -910,7 +947,10 @@ public sealed class AgentToolExecutor {
         }
         StringBuilder sb = new(Math.Min(reason.Length, AgentConsent.MaxReasonLength + 1));
         foreach (char c in reason) {
-            sb.Append(char.IsControl(c) ? ' ' : c == '"' ? '\'' : c);
+            UnicodeCategory category = char.GetUnicodeCategory(c);
+            bool neutralized = char.IsControl(c)
+                || category is UnicodeCategory.Format or UnicodeCategory.LineSeparator or UnicodeCategory.ParagraphSeparator;
+            sb.Append(neutralized ? ' ' : c == '"' ? '\'' : c);
             if (sb.Length > AgentConsent.MaxReasonLength) {
                 break;
             }

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -844,21 +844,23 @@ public sealed class AgentToolExecutor {
     }
 
     /// <summary>
-    /// Resolves a requested command name to its loaded-table key using the invoker's own rules: a
-    /// direct (lower-cased) lookup first, then the <c>prefix:args</c> spelling (so requesting
-    /// <c>chars:hello</c> resolves to the <c>chars:</c> command, matching how Enqueue parses it).
-    /// Null when nothing in the table matches.
+    /// Resolves a requested command name to its loaded-table key using the invoker's OWN rules,
+    /// in the invoker's OWN order: <see cref="CommandInvoker.Enqueue"/> parses any
+    /// <c>prefix:args</c> spelling as the bare prefix command FIRST (so <c>mcec:exit</c> executes
+    /// the <c>mcec:</c> entry with args <c>exit</c>), and only a string without that shape is looked
+    /// up whole. A grant must enable the entry the invoker will actually gate on; the table also
+    /// holds full spellings like <c>mcec:exit</c> that Enqueue never resolves, and granting one of
+    /// those would leave the very next <c>send_command</c> still refused (PR #308 review). Null when
+    /// nothing in the table matches.
     /// </summary>
     private static string? ResolveTableKey(CommandInvoker invoker, string requested) {
         string name = requested.Trim().ToLowerInvariant();
         if (name.Length == 0) {
             return null;
         }
-        if (invoker[name] is Command) {
-            return name;
-        }
         Match match = Regex.Match(name, @"(\w+:)(.+)");
-        return match.Success && invoker[match.Groups[1].Value] is Command ? match.Groups[1].Value : null;
+        string key = match.Success ? match.Groups[1].Value : name;
+        return invoker[key] is Command ? key : null;
     }
 
     /// <summary>

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -4,7 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -92,6 +95,34 @@ public sealed class AgentToolExecutor {
     public static bool SerializesOnInputLock(string tool) =>
         tool == "send_command" || (ToolCatalog.TryGet(tool, out ToolDescriptor descriptor) && descriptor.SerializesOnInput);
 
+    /// <summary>
+    /// The tools still served while an operator consent prompt is open (#307): pure observation plus
+    /// <c>record</c>. An ALLOW-list, not a deny-list, so a future actuation tool can never slip past
+    /// the consent freeze by not being enumerated. The in-process session lifecycle and the
+    /// provisioning meta-tools are handled before the consent guard in <see cref="CallTool"/> and are
+    /// unaffected (none of them can reach the prompt); everything else; every actuator, raw
+    /// <c>send_command</c>, <c>clipboard</c>, and a second <c>request-command-access</c>; is refused
+    /// with <c>consent-pending</c>.
+    /// </summary>
+    internal static bool ServedWhileConsentPending(string tool) =>
+        tool is "capture" or "query" or "displays" or "windows" or "find" or "wait-for" or "record";
+
+    /// <summary>
+    /// The consent-freeze refusal (#307), or null when the call may proceed (no prompt is open, or
+    /// <paramref name="name"/> is served while one is).
+    /// </summary>
+    private static JsonObject? ConsentPendingRefusal(string name, AgentSession session) {
+        if (!AgentConsent.IsPending || ServedWhileConsentPending(name)) {
+            return null;
+        }
+        AgentRuntime.Audit(name, "BLOCKED; an operator consent prompt (request-command-access) is open");
+        return ToolError(
+            "An operator consent prompt (request-command-access) is open; actuation is paused until the operator answers. " +
+            "Only observation tools (capture/query/displays/windows/find/wait-for/record) are served right now. " +
+            "Wait for the pending request-command-access call to return, then retry.",
+            "consent-pending", AgentErrorCategory.Internal, session.SessionId);
+    }
+
     // -------------------------------------------------------------------------------------------
     // tools/call
     // -------------------------------------------------------------------------------------------
@@ -169,6 +200,20 @@ public sealed class AgentToolExecutor {
             return ToolError(
                 $"Unknown sessionId '{routeId}'. It was never started or has ended. Call session-start to get a fresh sessionId, or omit sessionId to use the default session.",
                 "unknown-session", AgentErrorCategory.InvalidArgument, routeId!);
+        }
+
+        // Operator consent in progress (#307): while a request-command-access prompt is on the
+        // operator's screen, every actuation-capable call is refused. This is one of the three layers
+        // that keep the agent from answering its own prompt: `invoke` is UIA-pattern actuation that
+        // deliberately never takes the input gate (#105), so the gate hold around the prompt cannot
+        // stop it; this dispatch refusal does. Observation stays served (the agent may look, not touch).
+        if (ConsentPendingRefusal(name, session) is { } consentRefusal) {
+            return consentRefusal;
+        }
+
+        // Command-access consent (#307): the agent asks, the OPERATOR decides, on MCEC's own dialog.
+        if (name == "request-command-access") {
+            return RunRequestCommandAccess(args, transport, session);
         }
 
         if (name == "send_command") {
@@ -352,7 +397,12 @@ public sealed class AgentToolExecutor {
         // the operator opts in per-command via mcec.commands). Fail closed if the table/command is missing.
         if ((_invoker()?[name] as Command)?.Enabled != true) {
             AgentRuntime.Audit(name, "BLOCKED; command is disabled in mcec.commands");
-            return ToolError($"The '{name}' command is disabled. Enable it in mcec.commands (set Enabled=\"true\").", "command-disabled", AgentErrorCategory.Internal, session.SessionId);
+            // #307: the recovery is asking the OPERATOR, never editing config files; an agent must
+            // not widen its own permissions, and in a provisioned session the config is off-limits.
+            return ToolError(
+                $"The '{name}' command is disabled. Call request-command-access with the command name and a one-line reason; " +
+                "the operator will be asked on screen. Do not edit mcec.commands or any config file.",
+                "command-disabled", AgentErrorCategory.Internal, session.SessionId);
         }
 
         CapturingReply reply = new();
@@ -472,6 +522,17 @@ public sealed class AgentToolExecutor {
             return ToolError("Command engine is not available.", "engine-unavailable", AgentErrorCategory.Internal, session.SessionId);
         }
 
+        // #307: fail fast (and honestly) on a DISABLED command. Without this the clone enqueued fine
+        // and the dispatcher silently skipped it (the per-command gate), so the call reported "ok"
+        // while nothing executed; the agent had no command-disabled signal to recover from.
+        if (DisabledSendCommandKey(invoker, command) is { } disabledKey) {
+            AgentRuntime.Audit("send_command", $"BLOCKED; the '{disabledKey}' command is disabled in mcec.commands");
+            return ToolError(
+                $"The '{disabledKey}' command is disabled; nothing was executed. Call request-command-access with the " +
+                "command name and a one-line reason; the operator will be asked on screen. Do not edit mcec.commands or any config file.",
+                "command-disabled", AgentErrorCategory.Internal, session.SessionId);
+        }
+
         AgentRuntime.Audit("send_command", command);
 
         // #195: enqueue-and-await. send_command is a PRODUCER into the invoker's single
@@ -589,6 +650,271 @@ public sealed class AgentToolExecutor {
             result["note"] = "The session directory could not be deleted; its mcec.exe may still be running. Stop it and retry, or MCEC will reap it on a later launch.";
         }
         return McpResult(AgentToolResult.Success(result, session.SessionId));
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // request-command-access (#307)
+    // -------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// <c>request-command-access</c>: the agent asks the OPERATOR to enable disabled command(s); the
+    /// legitimate mid-session acquisition path the <c>command-disabled</c> refusal points at (an agent
+    /// must never widen its own permissions by editing config files). Shows MCEC's own consent dialog
+    /// on the operator's desktop via <see cref="AgentConsent.Prompter"/> and blocks this MCP worker
+    /// for the answer (bounded by the dialog's own timeout). Grants flip <see cref="Command.Enabled"/>
+    /// on the LOADED table only; in-memory, this process only, never persisted; and every grant
+    /// (including auto-grants under a standing "allow any" choice) is audited and narrated on the
+    /// overlay. A deny is sticky for the process (anti-nag); a timeout is not (the operator did not
+    /// decide). While the prompt is up this call holds <see cref="AgentRuntime.InputGate"/> so no
+    /// queued or synthesized input can reach the dialog; only physical input can answer it.
+    /// </summary>
+    private JsonObject RunRequestCommandAccess(JsonObject args, AgentTransport transport, AgentSession session) {
+        // Mirrors send_command's transport-sensitive gate (#153): over the network-facing HTTP floor
+        // it requires the AgentCommandsEnabled opt-in; over local stdio it is available alongside the
+        // documented send_command pass-through (whose per-command Enabled refusals are exactly what
+        // this tool exists to recover from).
+        if (transport == AgentTransport.Http && !AgentCommandsEnabled) {
+            AgentRuntime.Audit("request-command-access", "BLOCKED; agent commands disabled; request-command-access over HTTP requires AgentCommandsEnabled");
+            return ToolError(
+                "request-command-access over HTTP requires AgentCommandsEnabled=true. Enable the agent surface to opt in, or drive it over the local stdio transport (mcec.exe --mcp).",
+                "agent-commands-disabled", AgentErrorCategory.Internal, session.SessionId);
+        }
+
+        CommandInvoker? invoker = _invoker();
+        if (invoker is null) {
+            return ToolError("Command engine is not available.", "engine-unavailable", AgentErrorCategory.Internal, session.SessionId);
+        }
+
+        List<string>? names = StrArray(args["commands"] as JsonArray);
+        if (names is null) {
+            return ToolError(
+                "request-command-access requires a non-empty 'commands' array (the command names to enable).",
+                "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
+        }
+        if (names.Count > AgentConsent.MaxCommandsPerRequest) {
+            return ToolError(
+                $"request-command-access accepts at most {AgentConsent.MaxCommandsPerRequest} commands per request (got {names.Count}); ask for what this step needs.",
+                "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
+        }
+        string reason = SanitizeReason(Str(args, "reason"));
+        if (reason.Length == 0) {
+            return ToolError(
+                "request-command-access requires a non-empty 'reason'; the operator reads it to decide.",
+                "bad-arguments", AgentErrorCategory.InvalidArgument, session.SessionId);
+        }
+
+        // Resolve every requested name against the loaded table (the same name/prefix rules the
+        // invoker applies), refusing the WHOLE request on any unknown name; the operator must never
+        // be asked to adjudicate a typo.
+        Dictionary<string, Command> resolved = new(StringComparer.OrdinalIgnoreCase);
+        List<string> unknown = [];
+        foreach (string requested in names) {
+            string? key = ResolveTableKey(invoker, requested);
+            if (key is null || invoker[key] is not Command cmd) {
+                unknown.Add(requested);
+                continue;
+            }
+            resolved[key] = cmd;
+        }
+        if (unknown.Count > 0) {
+            return ToolError(
+                $"Unknown command(s): {string.Join(", ", unknown)}. They are not in the loaded command table; nothing was asked of the operator. Fix the names and retry.",
+                "unknown-command", AgentErrorCategory.InvalidArgument, session.SessionId);
+        }
+
+        List<string> alreadyEnabled = [.. resolved.Where(p => p.Value.Enabled).Select(p => p.Key)];
+        List<KeyValuePair<string, Command>> needed = [.. resolved.Where(p => !p.Value.Enabled)];
+        if (needed.Count == 0) {
+            AgentRuntime.Audit("request-command-access", $"no-op; already enabled: [{string.Join(",", alreadyEnabled)}]");
+            return McpResult(AgentToolResult.Success(AccessResult([], alreadyEnabled, "requested"), session.SessionId));
+        }
+
+        // Sticky deny (#307): the operator already said no to one of these this process; do not
+        // re-prompt (consent fatigue is how consent UIs get worn down into approval).
+        List<string> denied = [.. needed.Select(p => p.Key).Where(AgentConsent.IsDenied)];
+        if (denied.Count > 0) {
+            AgentRuntime.Audit("request-command-access", $"BLOCKED; operator already denied: [{string.Join(",", denied)}]");
+            return ToolError(
+                $"The operator already denied: {string.Join(", ", denied)}. A deny is final for this instance; do not ask again. If you believe it is essential, tell the user why and let them enable it themselves.",
+                "consent-denied", AgentErrorCategory.Internal, session.SessionId);
+        }
+
+        // Standing "allow any later requests" grant: auto-approve WITHOUT a prompt, but still one
+        // audit line and one overlay narration per command; the operator sees every grant land.
+        if (AgentConsent.AnyCommandGrantActive) {
+            EnableGranted(needed, "auto-granted under the operator's allow-any choice", session.SessionId);
+            return McpResult(AgentToolResult.Success(AccessResult([.. needed.Select(p => p.Key)], alreadyEnabled, "any"), session.SessionId));
+        }
+
+        Func<CommandAccessRequest, CommandAccessDecision?>? prompter = AgentConsent.Prompter;
+        if (prompter is null) {
+            AgentRuntime.Audit("request-command-access", "BLOCKED; no operator prompt surface is available (fail closed)");
+            return ToolError(
+                "No operator consent prompt can be shown here (no interactive operator surface). The request fails closed; ask the user to run the command-enable themselves.",
+                "consent-unavailable", AgentErrorCategory.Internal, session.SessionId);
+        }
+        if (!AgentConsent.TryBeginPrompt()) {
+            return ToolError(
+                "Another request-command-access prompt is already on the operator's screen; one at a time. Wait for it to resolve, then retry.",
+                "consent-pending", AgentErrorCategory.Internal, session.SessionId);
+        }
+
+        CommandAccessDecision? decision;
+        try {
+            CommandAccessRequest request = new() {
+                Commands = [.. needed.Select(p => p.Key)],
+                DisplayLines = [.. needed.Select(p => DescribeCommand(p.Key, p.Value))],
+                Reason = reason,
+            };
+            AgentRuntime.Audit("request-command-access", $"asking the operator to enable [{string.Join(",", request.Commands)}]; agent's reason: {reason}");
+            CommandEventHub.Publish(new CommandEvent("request-command-access",
+                $"asking you: enable {string.Join(", ", request.Commands)}?", CommandOutcome.Pending, session.SessionId));
+
+            // Hold the input gate for the prompt's whole lifetime (#307): the same gate every queued
+            // command's Execute and every direct actuation takes, so synthesized input cannot land on
+            // the dialog; only physical input can. A deliberate, documented exception to the
+            // "leaf lock, never wait while holding it" rule; see AgentRuntime.InputGate.
+            lock (AgentRuntime.InputGate) {
+                decision = prompter(request);
+            }
+        }
+        finally {
+            AgentConsent.EndPrompt();
+        }
+
+        if (decision is null) {
+            AgentRuntime.Audit("request-command-access", "BLOCKED; the operator prompt could not be shown (fail closed)");
+            return ToolError(
+                "The operator consent prompt could not be shown (no interactive desktop, or the operator surface is gone). The request fails closed.",
+                "consent-unavailable", AgentErrorCategory.Internal, session.SessionId);
+        }
+
+        AgentConsent.RecordDecision(decision.Value, needed.Select(p => p.Key));
+        switch (decision.Value) {
+            case CommandAccessDecision.AllowRequested:
+            case CommandAccessDecision.AllowAny:
+                EnableGranted(needed, decision.Value == CommandAccessDecision.AllowAny
+                    ? "granted by the operator (and any-command auto-grant armed)"
+                    : "granted by the operator", session.SessionId);
+                return McpResult(AgentToolResult.Success(
+                    AccessResult([.. needed.Select(p => p.Key)], alreadyEnabled, decision.Value == CommandAccessDecision.AllowAny ? "any" : "requested"),
+                    session.SessionId));
+
+            case CommandAccessDecision.TimedOut:
+                AgentRuntime.Audit("request-command-access", $"TIMEOUT; the operator did not answer for [{string.Join(",", needed.Select(p => p.Key))}]");
+                CommandEventHub.Publish(new CommandEvent("request-command-access", "consent request timed out (denied)", CommandOutcome.Failed, session.SessionId));
+                return ToolError(
+                    "The operator did not answer the consent prompt in time; the request is denied. They may be away; tell the user what you need and why, and retry only if they say so.",
+                    "consent-timeout", AgentErrorCategory.Internal, session.SessionId);
+
+            case CommandAccessDecision.Denied:
+            default:
+                AgentRuntime.Audit("request-command-access", $"DENIED by the operator: [{string.Join(",", needed.Select(p => p.Key))}]");
+                CommandEventHub.Publish(new CommandEvent("request-command-access", $"you denied: {string.Join(", ", needed.Select(p => p.Key))}", CommandOutcome.Failed, session.SessionId));
+                return ToolError(
+                    $"The operator denied enabling: {string.Join(", ", needed.Select(p => p.Key))}. This deny is final for this instance; do not ask again for these commands.",
+                    "consent-denied", AgentErrorCategory.Internal, session.SessionId);
+        }
+    }
+
+    /// <summary>
+    /// Applies a grant: flips <see cref="Command.Enabled"/> on each LOADED-table instance (the enqueue
+    /// path clones from the table, and the per-command gates read the table, so future calls see it),
+    /// with one audit line and one overlay narration per command so every grant is operator-visible.
+    /// In-memory only; nothing is ever written back to mcec.commands.
+    /// </summary>
+    private static void EnableGranted(List<KeyValuePair<string, Command>> granted, string how, string sessionId) {
+        foreach ((string key, Command cmd) in granted) {
+            cmd.Enabled = true;
+            AgentRuntime.Audit("request-command-access", $"ENABLED '{key}' ({how}); in-memory, this instance only");
+            CommandEventHub.Publish(new CommandEvent("request-command-access", $"enabled {key} ({how})", CommandOutcome.Ok, sessionId));
+        }
+    }
+
+    private static JsonObject AccessResult(List<string> granted, List<string> alreadyEnabled, string scope) {
+        JsonObject result = new() {
+            ["granted"] = new JsonArray([.. granted.Select(n => (JsonNode)n)]),
+            ["alreadyEnabled"] = new JsonArray([.. alreadyEnabled.Select(n => (JsonNode)n)]),
+            ["scope"] = scope,
+        };
+        if (scope == "any") {
+            result["note"] = "The operator's allow-any grant is active for this instance; future request-command-access calls auto-approve (each grant is still audited).";
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Resolves a requested command name to its loaded-table key using the invoker's own rules: a
+    /// direct (lower-cased) lookup first, then the <c>prefix:args</c> spelling (so requesting
+    /// <c>chars:hello</c> resolves to the <c>chars:</c> command, matching how Enqueue parses it).
+    /// Null when nothing in the table matches.
+    /// </summary>
+    private static string? ResolveTableKey(CommandInvoker invoker, string requested) {
+        string name = requested.Trim().ToLowerInvariant();
+        if (name.Length == 0) {
+            return null;
+        }
+        if (invoker[name] is Command) {
+            return name;
+        }
+        Match match = Regex.Match(name, @"(\w+:)(.+)");
+        return match.Success && invoker[match.Groups[1].Value] is Command ? match.Groups[1].Value : null;
+    }
+
+    /// <summary>
+    /// Resolves which loaded-table command a raw <c>send_command</c> string would execute (the same
+    /// name/prefix/single-character rules Enqueue applies) and returns its key when that command
+    /// exists but is DISABLED; null when the command would run, is unknown (Enqueue reports that
+    /// honestly already), or a single character rides an enabled <c>chars:</c>.
+    /// </summary>
+    private static string? DisabledSendCommandKey(CommandInvoker invoker, string command) {
+        if (command.Length == 1) {
+            if (invoker["chars:"] is Command { Enabled: true }) {
+                return null; // runs as a chars:-gated keypress
+            }
+            if (invoker[command.ToLowerInvariant()] is Command single) {
+                return single.Enabled ? null : command.ToLowerInvariant();
+            }
+            return invoker["chars:"] is Command ? "chars:" : null; // chars: exists but is disabled
+        }
+        Match match = Regex.Match(command, @"(\w+:)(.+)");
+        string key = (match.Success ? match.Groups[1].Value : command).ToLowerInvariant();
+        return invoker[key] is Command { Enabled: false } ? key : null;
+    }
+
+    /// <summary>
+    /// One consent-dialog display line for a command: its name plus what enabling it permits (the
+    /// catalog tool's description when it is an agent tool, else its command type), so the operator
+    /// judges the capability rather than the name.
+    /// </summary>
+    private static string DescribeCommand(string key, Command cmd) {
+        if (ToolCatalog.TryGet(key, out ToolDescriptor descriptor)
+            && descriptor.BuildSchema()["description"] is JsonValue v && v.TryGetValue(out string? desc)
+            && !string.IsNullOrWhiteSpace(desc)) {
+            int cut = desc.IndexOf(". ", StringComparison.Ordinal);
+            return $"{key}: {(cut > 0 ? desc[..(cut + 1)] : desc)}";
+        }
+        return $"{key}: a raw MCEC command ({cmd.GetType().Name})";
+    }
+
+    /// <summary>
+    /// Sanitizes the agent's stated reason for operator display: newlines/control characters collapse
+    /// to spaces (one visual line; no fake dialog paragraphs), embedded double quotes soften so the
+    /// dialog's own quoting stays unambiguous, and length is capped.
+    /// </summary>
+    private static string SanitizeReason(string? reason) {
+        if (string.IsNullOrWhiteSpace(reason)) {
+            return "";
+        }
+        StringBuilder sb = new(Math.Min(reason.Length, AgentConsent.MaxReasonLength + 1));
+        foreach (char c in reason) {
+            sb.Append(char.IsControl(c) ? ' ' : c == '"' ? '\'' : c);
+            if (sb.Length > AgentConsent.MaxReasonLength) {
+                break;
+            }
+        }
+        string clean = string.Join(" ", sb.ToString().Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        return clean.Length > AgentConsent.MaxReasonLength ? clean[..AgentConsent.MaxReasonLength] + "..." : clean;
     }
 
     /// <summary>Reads a JSON array of strings into a list, or null when the node is absent/empty.</summary>

--- a/src/Services/JsonRpcDispatcher.cs
+++ b/src/Services/JsonRpcDispatcher.cs
@@ -152,6 +152,29 @@ public sealed class JsonRpcDispatcher {
             new JsonObject { ["sessionId"] = ToolCatalog.PropSchema("string", "The session to end (from session-start)") },
             ["sessionId"]));
 
+        // Command-access consent (#307): the agent asks, the operator decides on MCEC's own dialog.
+        // Full surface only; the bootstrap list above stays exactly provision-session/end-session.
+        JsonObject requestAccessSchema = ToolCatalog.Tool("request-command-access",
+            "Ask the OPERATOR to enable disabled MCEC command(s) in this instance; the recovery for error.code:command-disabled. " +
+            "Shows a consent dialog on their screen and BLOCKS until they answer (up to ~2 minutes): allow exactly these commands, " +
+            "allow these plus any future requests, or deny. On a grant the commands are immediately usable (enabled in-memory, this " +
+            "instance only; nothing is written to config files; never edit them yourself). A deny is FINAL for this instance: " +
+            "re-requesting a denied command returns consent-denied without a prompt, so ask once, honestly. No answer within the " +
+            "timeout returns consent-timeout (the operator may be away; you may ask again later). While the dialog is up only " +
+            "observation tools are served; anything else returns consent-pending. Keep the reason to one short, specific sentence; " +
+            "the operator reads it verbatim.",
+            new JsonObject {
+                ["commands"] = new JsonObject {
+                    ["type"] = "array",
+                    ["description"] = $"The command name(s) to enable (max {AgentConsent.MaxCommandsPerRequest}); the names command-disabled refusals report (e.g. 'launch', 'chars:')",
+                    ["items"] = new JsonObject { ["type"] = "string" },
+                },
+                ["reason"] = ToolCatalog.PropSchema("string", "One short sentence saying why you need these commands; shown to the operator verbatim"),
+            },
+            ["commands", "reason"]);
+        AddSessionArg(requestAccessSchema);
+        tools.Add(requestAccessSchema);
+
         // Isolated session provisioning (#138). Requires the operator to have opted in
         // (AllowSessionProvisioning); it never mutates the installed config.
         tools.Add(BuildProvisionSessionTool());

--- a/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
+++ b/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
@@ -23,7 +23,7 @@ public class ToolCatalogTests {
 
     /// <summary>The meta-tools that are deliberately NOT in the catalog (no 1:1 Command mapping), in tools/list order.</summary>
     private static readonly string[] _metaToolNames = [
-        "send_command", "session-start", "session-status", "session-end", "provision-session", "end-session",
+        "send_command", "session-start", "session-status", "session-end", "request-command-access", "provision-session", "end-session",
     ];
 
     [Fact]

--- a/tests/MCEControl.xUnit/Dialogs/AgentSettingsTabTests.cs
+++ b/tests/MCEControl.xUnit/Dialogs/AgentSettingsTabTests.cs
@@ -137,12 +137,17 @@ public class AgentSettingsTabTests : IDisposable {
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void ProvisionedInstanceDialog_HandoffText_HasLaunchAndConditionalEndpoint(bool mcpServerEnabled) {
+    public void ProvisionedInstanceDialog_HandoffText_HasLaunchTokenAndConditionalEndpoint(bool mcpServerEnabled) {
         string text = ProvisionedInstanceDialog.BuildHandoffText(SampleSession(mcpServerEnabled));
 
-        // Always: the stdio launch line and the MCP-client registration example.
+        // Always: the stdio launch line, the MCP-client registration example, AND the session
+        // identity + teardown token (#308 review: a stdio-only handoff must still carry the
+        // credential; the operator may only ever copy this block).
         Assert.Contains(@"C:\sessions\0123456789ab\mcec.exe"" --mcp", text);
         Assert.Contains("claude mcp add mcec", text);
+        Assert.Contains("Session id: 0123456789ab", text);
+        Assert.Contains(@"C:\sessions\0123456789ab", text);
+        Assert.Contains("deadbeefcafef00d", text);
         // The HTTP endpoint + bearer line only when the session's MCP server is enabled.
         Assert.Equal(mcpServerEnabled, text.Contains("http://127.0.0.1:51515/mcp"));
         Assert.Equal(mcpServerEnabled, text.Contains("Authorization: Bearer deadbeefcafef00d"));
@@ -165,8 +170,10 @@ public class AgentSettingsTabTests : IDisposable {
         Assert.Contains("command-disabled", prompt);
         Assert.Contains("NEVER edit mcec.commands", prompt);
         Assert.Contains("emergency-stopped", prompt);
-        Assert.Contains("mcec:exit", prompt);
         Assert.Contains("end-session", prompt);
+        // #308 review: mcec:exit is DISABLED in every provisioned instance (not ProvisionedByDefault),
+        // so the briefing must not instruct it as the teardown path; disconnecting stops stdio.
+        Assert.DoesNotContain("mcec:exit", prompt);
 
         // A template the operator appends their task to.
         Assert.EndsWith("<describe the task here>", prompt);
@@ -186,7 +193,9 @@ public class AgentSettingsTabTests : IDisposable {
         var tools = AgentServer.Dispatch(listRequest)!["result"]!.AsObject()["tools"]!.AsArray();
         var served = new HashSet<string>(tools.Select(t => t!["name"]!.GetValue<string>()));
 
-        foreach (string tool in (string[])["request-command-access", "send_command", "end-session"]) {
+        // send_command dropped out of the briefing when teardown moved to disconnect + end-session
+        // (#308 review: mcec:exit is disabled in provisioned instances), so it is no longer pinned.
+        foreach (string tool in (string[])["request-command-access", "end-session"]) {
             Assert.Contains(tool, prompt);
             Assert.Contains(tool, served);
         }

--- a/tests/MCEControl.xUnit/Dialogs/AgentSettingsTabTests.cs
+++ b/tests/MCEControl.xUnit/Dialogs/AgentSettingsTabTests.cs
@@ -2,7 +2,9 @@
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using MCEControl;
 using Xunit;
@@ -122,29 +124,72 @@ public class AgentSettingsTabTests : IDisposable {
         Assert.True(FindControl<Button>(tab, "_buttonProvision").Enabled);
     }
 
+    private static ProvisionedSession SampleSession(bool mcpServerEnabled) => new() {
+        SessionId = "0123456789ab",
+        Directory = @"C:\sessions\0123456789ab",
+        ExePath = @"C:\sessions\0123456789ab\mcec.exe",
+        McpServerEnabled = mcpServerEnabled,
+        BindAddress = "127.0.0.1",
+        Port = 51515,
+        Token = "deadbeefcafef00d",
+    };
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void ProvisionedInstanceDialog_HandoffText_HasLaunchTokenAndConditionalEndpoint(bool mcpServerEnabled) {
-        var session = new ProvisionedSession {
-            SessionId = "0123456789ab",
-            Directory = @"C:\sessions\0123456789ab",
-            ExePath = @"C:\sessions\0123456789ab\mcec.exe",
-            McpServerEnabled = mcpServerEnabled,
-            BindAddress = "127.0.0.1",
-            Port = 51515,
-            Token = "deadbeefcafef00d",
-        };
+    public void ProvisionedInstanceDialog_HandoffText_HasLaunchAndConditionalEndpoint(bool mcpServerEnabled) {
+        string text = ProvisionedInstanceDialog.BuildHandoffText(SampleSession(mcpServerEnabled));
 
-        string text = ProvisionedInstanceDialog.BuildHandoffText(session);
-
-        // Always: the stdio launch line, the directory, and the teardown token.
+        // Always: the stdio launch line and the MCP-client registration example.
         Assert.Contains(@"C:\sessions\0123456789ab\mcec.exe"" --mcp", text);
-        Assert.Contains("0123456789ab", text);
-        Assert.Contains("deadbeefcafef00d", text);
+        Assert.Contains("claude mcp add mcec", text);
         // The HTTP endpoint + bearer line only when the session's MCP server is enabled.
         Assert.Equal(mcpServerEnabled, text.Contains("http://127.0.0.1:51515/mcp"));
         Assert.Equal(mcpServerEnabled, text.Contains("Authorization: Bearer deadbeefcafef00d"));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ProvisionedInstanceDialog_AgentPrompt_CarriesSessionFactsAndRulesOfEngagement(bool mcpServerEnabled) {
+        string prompt = ProvisionedInstanceDialog.BuildAgentPrompt(SampleSession(mcpServerEnabled));
+
+        // The session identity and token custody the connect-time instructions cannot know.
+        Assert.Contains("0123456789ab", prompt);
+        Assert.Contains(@"C:\sessions\0123456789ab", prompt);
+        Assert.Contains("deadbeefcafef00d", prompt);
+        Assert.Equal(mcpServerEnabled, prompt.Contains("http://127.0.0.1:51515/mcp"));
+
+        // The rules of engagement (#307): consent path, never edit config files, e-stop, teardown.
+        Assert.Contains("request-command-access", prompt);
+        Assert.Contains("command-disabled", prompt);
+        Assert.Contains("NEVER edit mcec.commands", prompt);
+        Assert.Contains("emergency-stopped", prompt);
+        Assert.Contains("mcec:exit", prompt);
+        Assert.Contains("end-session", prompt);
+
+        // A template the operator appends their task to.
+        Assert.EndsWith("<describe the task here>", prompt);
+    }
+
+    [Fact]
+    public void ProvisionedInstanceDialog_AgentPrompt_MentionsOnlyToolsTheFullSurfaceServes() {
+        // The prompt must never drift from the served surface: every tool name it tells the agent to
+        // call has to exist in the full tools/list.
+        string prompt = ProvisionedInstanceDialog.BuildAgentPrompt(SampleSession(true));
+        var listRequest = new System.Text.Json.Nodes.JsonObject {
+            ["jsonrpc"] = "2.0",
+            ["id"] = 1,
+            ["method"] = "tools/list",
+            ["params"] = new System.Text.Json.Nodes.JsonObject(),
+        };
+        var tools = AgentServer.Dispatch(listRequest)!["result"]!.AsObject()["tools"]!.AsArray();
+        var served = new HashSet<string>(tools.Select(t => t!["name"]!.GetValue<string>()));
+
+        foreach (string tool in (string[])["request-command-access", "send_command", "end-session"]) {
+            Assert.Contains(tool, prompt);
+            Assert.Contains(tool, served);
+        }
     }
 
     [Fact]

--- a/tests/MCEControl.xUnit/Dialogs/CommandAccessConsentDialogTests.cs
+++ b/tests/MCEControl.xUnit/Dialogs/CommandAccessConsentDialogTests.cs
@@ -1,0 +1,48 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Dialogs;
+
+/// <summary>
+/// Headless tests for the <c>request-command-access</c> consent prompt body (#307): the operator must
+/// see what capability each command grants, the agent's reason framed as untrusted, the in-memory /
+/// this-instance-only scope, the sticky-deny consequence, and the auto-deny timeout; verified via the
+/// static <see cref="CommandAccessConsentDialog.BuildBody"/> without showing a window.
+/// </summary>
+public class CommandAccessConsentDialogTests {
+    private static CommandAccessRequest SampleRequest() => new() {
+        Commands = ["launch", "chars:"],
+        DisplayLines = ["launch: Start a program.", "chars: a raw MCEC command (CharsCommand)"],
+        Reason = "need to launch notepad to edit the export",
+    };
+
+    [Fact]
+    public void Body_ListsEveryRequestedCommandWithItsCapability() {
+        string body = CommandAccessConsentDialog.BuildBody(SampleRequest(), 120);
+        Assert.Contains("launch: Start a program.", body);
+        Assert.Contains("chars: a raw MCEC command (CharsCommand)", body);
+    }
+
+    [Fact]
+    public void Body_FramesTheReasonAsUntrustedQuotedText() {
+        string body = CommandAccessConsentDialog.BuildBody(SampleRequest(), 120);
+        Assert.Contains("The agent says (unverified):", body);
+        Assert.Contains("\"need to launch notepad to edit the export\"", body);
+    }
+
+    [Fact]
+    public void Body_StatesScopeStickyDenyAndTimeout() {
+        string body = CommandAccessConsentDialog.BuildBody(SampleRequest(), 90);
+        // In-memory, this instance only; never persisted.
+        Assert.Contains("THIS instance only", body);
+        Assert.Contains("nothing is written to any config file", body);
+        // The allow-any choice still audits every grant.
+        Assert.Contains("audit-logged", body);
+        // Deny is final; doing nothing denies at the timeout.
+        Assert.Contains("Deny is final for this instance", body);
+        Assert.Contains("90 seconds", body);
+    }
+}

--- a/tests/MCEControl.xUnit/Dialogs/CommandAccessConsentDialogTests.cs
+++ b/tests/MCEControl.xUnit/Dialogs/CommandAccessConsentDialogTests.cs
@@ -34,6 +34,16 @@ public class CommandAccessConsentDialogTests {
     }
 
     [Fact]
+    public void EmergencyStopDismissal_ReportsTimedOut_NotAnOperatorDeny() {
+        // #308 review: the panic hotkey halts the session; it does not answer the consent question.
+        // Dismissing as Denied would record a sticky per-command deny the operator never chose.
+        using var dialog = new CommandAccessConsentDialog(SampleRequest());
+        Assert.Equal(CommandAccessDecision.Denied, dialog.Decision); // the fail-safe default
+        dialog.HandleEmergencyStop(stopped: true);
+        Assert.Equal(CommandAccessDecision.TimedOut, dialog.Decision);
+    }
+
+    [Fact]
     public void Body_StatesScopeStickyDenyAndTimeout() {
         string body = CommandAccessConsentDialog.BuildBody(SampleRequest(), 90);
         // In-memory, this instance only; never persisted.

--- a/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
+++ b/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
@@ -1,0 +1,300 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Services;
+
+/// <summary>
+/// Tests the <c>request-command-access</c> consent flow (#307) at the MCP dispatch boundary: argument
+/// validation, the prompter seam (grant/deny/timeout/unavailable), in-memory-only grants, the sticky
+/// deny, the standing allow-any grant, the consent-pending actuation freeze (with the input gate held),
+/// the transport gate, the bootstrap exclusion, and the honest <c>command-disabled</c> refusal on the
+/// <c>send_command</c> path. Uses a real (never-dispatching) <see cref="CommandInvoker"/> with the
+/// built-in table (every command disabled by default) and a test prompter instead of the dialog.
+/// </summary>
+[Collection("AgentSerial")]
+public class RequestCommandAccessTests : IDisposable {
+    public RequestCommandAccessTests() {
+        // A real command table (built-ins, all disabled) that can never start a dispatcher thread.
+        // The standard test pattern: a temp file name whose parent directory exists (LoadCommands
+        // writes a default file there); a nonexistent directory wedges the loader.
+        string tempCommandsFile = Path.GetTempFileName();
+        File.Delete(tempCommandsFile);
+        CommandInvoker invoker = CommandInvoker.Create(tempCommandsFile, "9.9.9", disableInternalCommands: false);
+        invoker.SuppressDispatcherForTests = true;
+        AgentRuntime.Invoker = invoker;
+        AgentConsent.ResetForTests();
+        AgentConsent.Prompter = null;
+    }
+
+    public void Dispose() {
+        AgentConsent.ResetForTests();
+        AgentConsent.Prompter = null;
+        AgentRuntime.Invoker = null;
+        AgentRuntime.Settings = null;
+        AgentRuntime.ResetSession();
+    }
+
+    private static JsonObject Request(int id, string method, JsonObject? prms = null) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"] = id,
+        ["method"] = method,
+        ["params"] = prms ?? [],
+    };
+
+    private static JsonObject Call(int id, string tool, JsonObject args, AgentTransport transport = AgentTransport.Stdio) =>
+        AgentServer.Dispatch(Request(id, "tools/call", new JsonObject { ["name"] = tool, ["arguments"] = args }), transport)!;
+
+    private static JsonObject Envelope(JsonObject resp) =>
+        JsonNode.Parse(FirstTextBlock(resp["result"]!.AsObject()))!.AsObject();
+
+    private static string FirstTextBlock(JsonObject toolResult) {
+        foreach (JsonNode? block in toolResult["content"]!.AsArray()) {
+            if (block?["type"]?.GetValue<string>() == "text") {
+                return block["text"]!.GetValue<string>();
+            }
+        }
+        Assert.Fail("no text content block in tool result");
+        return "";
+    }
+
+    private static JsonObject Ask(int id, string reason = "test reason", params string[] commands) {
+        JsonArray names = [.. commands];
+        return Envelope(Call(id, "request-command-access", new JsonObject { ["commands"] = names, ["reason"] = reason }));
+    }
+
+    private static string ErrorCode(JsonObject env) => env["error"]!.AsObject()["code"]!.GetValue<string>();
+
+    private static List<string> Strings(JsonObject env, string key) =>
+        [.. env["result"]!.AsObject()[key]!.AsArray().Select(n => n!.GetValue<string>())];
+
+    // ---------------------------------------------------------------------------------------------
+    // Argument validation (nothing reaches the operator on a malformed request)
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void MissingCommands_IsBadArguments() {
+        JsonObject env = Envelope(Call(1, "request-command-access", new JsonObject { ["reason"] = "r" }));
+        Assert.Equal("bad-arguments", ErrorCode(env));
+    }
+
+    [Fact]
+    public void MissingReason_IsBadArguments() {
+        JsonObject env = Envelope(Call(2, "request-command-access", new JsonObject { ["commands"] = new JsonArray("chars:") }));
+        Assert.Equal("bad-arguments", ErrorCode(env));
+    }
+
+    [Fact]
+    public void TooManyCommands_IsBadArguments() {
+        string[] names = [.. Enumerable.Range(0, AgentConsent.MaxCommandsPerRequest + 1).Select(i => $"cmd{i}")];
+        Assert.Equal("bad-arguments", ErrorCode(Ask(3, "r", names)));
+    }
+
+    [Fact]
+    public void UnknownCommand_RefusesWholeRequest_WithoutPrompting() {
+        int prompts = 0;
+        AgentConsent.Prompter = _ => { prompts++; return CommandAccessDecision.AllowRequested; };
+        JsonObject env = Ask(4, "r", "chars:", "definitely-not-a-command");
+        Assert.Equal("unknown-command", ErrorCode(env));
+        Assert.Equal("invalid-argument", env["error"]!.AsObject()["category"]!.GetValue<string>());
+        Assert.Contains("definitely-not-a-command", env["error"]!.AsObject()["detail"]!.GetValue<string>());
+        Assert.Equal(0, prompts);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Decisions
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Granted_EnablesInMemory_AndPrefixSpellingResolves() {
+        CommandAccessRequest? seen = null;
+        AgentConsent.Prompter = req => { seen = req; return CommandAccessDecision.AllowRequested; };
+
+        // The 'chars:hello' spelling resolves to the table's 'chars:' entry, like Enqueue parses it.
+        JsonObject env = Ask(10, "need to type a path", "chars:hello");
+        Assert.True(env["ok"]!.GetValue<bool>());
+        Assert.Equal(["chars:"], Strings(env, "granted"));
+        Assert.Equal("requested", env["result"]!.AsObject()["scope"]!.GetValue<string>());
+        Assert.True((AgentRuntime.Invoker!["chars:"] as Command)!.Enabled);
+        Assert.Equal(["chars:"], seen!.Commands);
+
+        // Second ask is a no-op success; nothing to grant, no prompt.
+        AgentConsent.Prompter = _ => throw new InvalidOperationException("must not prompt again");
+        JsonObject again = Ask(11, "still typing", "chars:");
+        Assert.True(again["ok"]!.GetValue<bool>());
+        Assert.Empty(Strings(again, "granted"));
+        Assert.Equal(["chars:"], Strings(again, "alreadyEnabled"));
+    }
+
+    [Fact]
+    public void Denied_IsSticky_NoSecondPrompt() {
+        int prompts = 0;
+        AgentConsent.Prompter = _ => { prompts++; return CommandAccessDecision.Denied; };
+
+        Assert.Equal("consent-denied", ErrorCode(Ask(20, "r", "launch")));
+        Assert.Equal("consent-denied", ErrorCode(Ask(21, "r", "launch")));
+        Assert.Equal(1, prompts);
+        Assert.False((AgentRuntime.Invoker!["launch"] as Command)!.Enabled);
+    }
+
+    [Fact]
+    public void Timeout_IsNotSticky_AllowsAskingAgain() {
+        int prompts = 0;
+        AgentConsent.Prompter = _ => { prompts++; return CommandAccessDecision.TimedOut; };
+
+        Assert.Equal("consent-timeout", ErrorCode(Ask(30, "r", "launch")));
+        Assert.Equal("consent-timeout", ErrorCode(Ask(31, "r", "launch")));
+        Assert.Equal(2, prompts);
+    }
+
+    [Fact]
+    public void AllowAny_AutoApprovesLaterRequests_WithoutPrompting() {
+        int prompts = 0;
+        AgentConsent.Prompter = _ => { prompts++; return CommandAccessDecision.AllowAny; };
+
+        JsonObject first = Ask(40, "r", "launch");
+        Assert.True(first["ok"]!.GetValue<bool>());
+        Assert.Equal("any", first["result"]!.AsObject()["scope"]!.GetValue<string>());
+
+        JsonObject second = Ask(41, "r", "chars:");
+        Assert.True(second["ok"]!.GetValue<bool>());
+        Assert.Equal("any", second["result"]!.AsObject()["scope"]!.GetValue<string>());
+        Assert.True((AgentRuntime.Invoker!["chars:"] as Command)!.Enabled);
+        Assert.Equal(1, prompts); // the standing grant answered the second ask
+    }
+
+    [Fact]
+    public void NoPrompter_FailsClosed_ConsentUnavailable() {
+        AgentConsent.Prompter = null;
+        Assert.Equal("consent-unavailable", ErrorCode(Ask(50, "r", "launch")));
+        Assert.False((AgentRuntime.Invoker!["launch"] as Command)!.Enabled);
+    }
+
+    [Fact]
+    public void PrompterReturningNull_FailsClosed_ConsentUnavailable() {
+        AgentConsent.Prompter = _ => null;
+        Assert.Equal("consent-unavailable", ErrorCode(Ask(51, "r", "launch")));
+        Assert.False((AgentRuntime.Invoker!["launch"] as Command)!.Enabled);
+    }
+
+    [Fact]
+    public void Reason_IsSanitizedBeforeDisplay() {
+        CommandAccessRequest? seen = null;
+        AgentConsent.Prompter = req => { seen = req; return CommandAccessDecision.Denied; };
+        _ = Ask(60, "line one\r\nline \"two\"\tend", "launch");
+        Assert.Equal("line one line 'two' end", seen!.Reason);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // The consent freeze: while the prompt is up, the agent may look but not touch, and the input
+    // gate is held so nothing synthesized can land on the dialog.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void WhilePromptPending_ActuationIsRefused_AndInputGateIsHeld() {
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        string? clickCode = null;
+        bool gateWasHeld = false;
+        AgentConsent.Prompter = _ => {
+            Assert.True(AgentConsent.IsPending);
+            // The gate is held by the calling worker for the prompt's whole lifetime. Probe from a
+            // DIFFERENT thread: Monitor is reentrant, so a same-thread TryEnter would succeed.
+            Thread probe = new(() => {
+                if (Monitor.TryEnter(AgentRuntime.InputGate, 0)) {
+                    Monitor.Exit(AgentRuntime.InputGate);
+                }
+                else {
+                    gateWasHeld = true;
+                }
+            });
+            probe.Start();
+            probe.Join();
+            // An actuation call arriving mid-prompt is refused before any gate/catalog dispatch.
+            clickCode = ErrorCode(Envelope(Call(71, "click", new JsonObject {
+                ["window"] = "x",
+                ["at"] = new JsonObject { ["x"] = 1, ["y"] = 1 },
+            })));
+            // A second consent ask mid-prompt is refused the same way.
+            Assert.Equal("consent-pending", ErrorCode(Ask(72, "r", "chars:")));
+            return CommandAccessDecision.Denied;
+        };
+
+        _ = Ask(70, "r", "launch");
+        Assert.True(gateWasHeld, "InputGate was not held while the prompt was up");
+        Assert.Equal("consent-pending", clickCode);
+        Assert.False(AgentConsent.IsPending); // released after the decision
+    }
+
+    [Fact]
+    public void ServedWhilePending_IsAnObservationOnlyAllowList() {
+        foreach (string tool in (string[])["capture", "query", "displays", "windows", "find", "wait-for", "record"]) {
+            Assert.True(AgentToolExecutor.ServedWhileConsentPending(tool), tool);
+        }
+        foreach (string tool in (string[])["invoke", "drag", "click", "focus", "clipboard", "launch", "send_command", "request-command-access"]) {
+            Assert.False(AgentToolExecutor.ServedWhileConsentPending(tool), tool);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Gates: transport, bootstrap, tools/list
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void OverHttp_RequiresAgentCommandsEnabled() {
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = false };
+        JsonObject env = Envelope(Call(80, "request-command-access",
+            new JsonObject { ["commands"] = new JsonArray("launch"), ["reason"] = "r" }, AgentTransport.Http));
+        Assert.Equal("agent-commands-disabled", ErrorCode(env));
+    }
+
+    [Fact]
+    public void BootstrapOnly_RefusesRequestCommandAccess_AndOmitsItFromToolsList() {
+        Program.IsProgramFilesInstallOverrideForTests = true;
+        try {
+            Assert.Equal("bootstrap-only", ErrorCode(Ask(90, "r", "launch")));
+            JsonArray tools = AgentServer.Dispatch(Request(91, "tools/list"))!["result"]!.AsObject()["tools"]!.AsArray();
+            Assert.DoesNotContain(tools, t => t!["name"]!.GetValue<string>() == "request-command-access");
+        }
+        finally {
+            Program.IsProgramFilesInstallOverrideForTests = null;
+        }
+    }
+
+    [Fact]
+    public void FullToolsList_AdvertisesRequestCommandAccess() {
+        JsonArray tools = AgentServer.Dispatch(Request(92, "tools/list"))!["result"]!.AsObject()["tools"]!.AsArray();
+        Assert.Contains(tools, t => t!["name"]!.GetValue<string>() == "request-command-access");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // send_command now reports command-disabled honestly (it used to silently no-op)
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void SendCommand_DisabledCommand_IsRefusedWithRecoveryPointer() {
+        JsonObject env = Envelope(Call(100, "send_command", new JsonObject { ["command"] = "chars:hello" }));
+        Assert.Equal("command-disabled", ErrorCode(env));
+        Assert.Contains("request-command-access", env["error"]!.AsObject()["detail"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void SendCommand_SingleCharWithDisabledChars_IsRefusedAsCharsDisabled() {
+        JsonObject env = Envelope(Call(101, "send_command", new JsonObject { ["command"] = "a" }));
+        Assert.Equal("command-disabled", ErrorCode(env));
+        Assert.Contains("chars:", env["error"]!.AsObject()["detail"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void SendCommand_UnknownCommand_StillReportsUnknown() {
+        JsonObject env = Envelope(Call(102, "send_command", new JsonObject { ["command"] = "definitely-not-a-command" }));
+        Assert.Equal("unknown-command", ErrorCode(env));
+    }
+}

--- a/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
+++ b/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
@@ -261,6 +261,132 @@ public class RequestCommandAccessTests : IDisposable {
     }
 
     // ---------------------------------------------------------------------------------------------
+    // Review findings (#308): grant persistence, the widened consent freeze, e-stop vs sticky deny,
+    // reason sanitization depth, strict argument validation, single-char resolution
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Grant_DoesNotPersistThroughCommandsSave() {
+        // Finding 1: the dialog promises 'nothing is written to any config file', so a consent grant
+        // must not ride the Commands window's Save into mcec.commands. An enable the OPERATOR made
+        // by hand still persists; only consent-granted enables serialize as disabled.
+        AgentConsent.Prompter = _ => CommandAccessDecision.AllowRequested;
+        _ = Ask(120, "need to launch", "launch");
+        Assert.True((AgentRuntime.Invoker!["launch"] as Command)!.Enabled);
+        (AgentRuntime.Invoker!["mcec:ver"] as Command)!.Enabled = true; // operator-made, not consent
+
+        string path = Path.GetTempFileName();
+        try {
+            AgentRuntime.Invoker!.Save(path);
+            CommandInvoker reloaded = CommandInvoker.Create(path, "9.9.9", disableInternalCommands: false);
+            Assert.False((reloaded["launch"] as Command)!.Enabled);
+            Assert.True((reloaded["mcec:ver"] as Command)!.Enabled);
+            // The live, in-memory grant is untouched by saving.
+            Assert.True((AgentRuntime.Invoker!["launch"] as Command)!.Enabled);
+        }
+        finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WhilePromptPending_ProvisioningAndSessionLifecycle_AreRefused() {
+        // Finding 2: provision-session mid-prompt would mint a SECOND instance whose input is not
+        // blocked by this process's protections (input gate, never-a-target, dispatch freeze), so the
+        // consent freeze must cover the meta-tools too, not just the catalog.
+        string origRoot = SessionProvisioner.SessionsRoot;
+        string origBin = SessionProvisioner.BinariesDir;
+        string baseTemp = Path.Combine(Path.GetTempPath(), "mcec-consent-freeze-test", Path.GetRandomFileName());
+        string fakeBin = Path.Combine(baseTemp, "install");
+        Directory.CreateDirectory(fakeBin);
+        File.WriteAllText(Path.Combine(fakeBin, "mcec.exe"), "stub");
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true, AllowSessionProvisioning = true };
+        SessionProvisioner.SessionsRoot = Path.Combine(baseTemp, "sessions");
+        SessionProvisioner.BinariesDir = fakeBin;
+        try {
+            JsonObject? provision = null;
+            JsonObject? sessionStart = null;
+            AgentConsent.Prompter = _ => {
+                provision = Envelope(Call(130, "provision-session", []));
+                sessionStart = Envelope(Call(131, "session-start", []));
+                return CommandAccessDecision.Denied;
+            };
+            _ = Ask(129, "r", "launch");
+
+            Assert.False(provision!["ok"]!.GetValue<bool>());
+            Assert.Equal("consent-pending", ErrorCode(provision));
+            Assert.False(sessionStart!["ok"]!.GetValue<bool>());
+            Assert.Equal("consent-pending", ErrorCode(sessionStart));
+        }
+        finally {
+            SessionProvisioner.SessionsRoot = origRoot;
+            SessionProvisioner.BinariesDir = origBin;
+            try { if (Directory.Exists(baseTemp)) { Directory.Delete(baseTemp, recursive: true); } }
+            catch (IOException) { /* best-effort temp cleanup */ }
+            catch (UnauthorizedAccessException) { /* best-effort temp cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void EmergencyStopDuringPrompt_IsEmergencyStopped_NotAStickyDeny() {
+        // Finding 3: the panic hotkey halts the session; it does not answer the consent question.
+        // The dialog dismisses as TimedOut, and with the latch engaged the agent must get the
+        // standard emergency-stopped signal; and the command must NOT be sticky-denied.
+        AgentConsent.Prompter = _ => {
+            AgentRuntime.SetEmergencyStopped(true); // the hotkey engaging mid-prompt
+            return CommandAccessDecision.TimedOut;  // how the dialog now reports that dismissal
+        };
+        try {
+            Assert.Equal("emergency-stopped", ErrorCode(Ask(140, "r", "launch")));
+        }
+        finally {
+            AgentRuntime.SetEmergencyStopped(false);
+        }
+
+        AgentConsent.Prompter = _ => CommandAccessDecision.AllowRequested;
+        JsonObject env = Ask(141, "r", "launch");
+        Assert.True(env["ok"]!.GetValue<bool>()); // re-armed; prompts again and grants
+    }
+
+    [Fact]
+    public void Reason_NeutralizesBidiAndUnicodeSeparators() {
+        // Finding 5: char.IsControl misses Cf (bidi overrides like U+202E), Zl (U+2028), and
+        // Zp (U+2029); untrusted text must not reorder or line-break its way out of the quoting.
+        // Built from char codes so no invisible/bidi character rides in this source file.
+        CommandAccessRequest? seen = null;
+        AgentConsent.Prompter = req => { seen = req; return CommandAccessDecision.Denied; };
+        string hostile = "ok " + (char)0x202E + "evil" + (char)0x2028 + " " + (char)0x2029 + "stuff end";
+        _ = Ask(150, hostile, "launch");
+        Assert.DoesNotContain((char)0x202E, seen!.Reason);
+        Assert.DoesNotContain((char)0x2028, seen.Reason);
+        Assert.DoesNotContain((char)0x2029, seen.Reason);
+        Assert.Equal("ok evil stuff end", seen.Reason);
+    }
+
+    [Fact]
+    public void NonStringCommandEntry_IsBadArguments_NotSilentlyDropped() {
+        // Finding 7: a malformed entry must refuse the whole request, not shrink it to a silent
+        // subset the operator never saw.
+        AgentConsent.Prompter = _ => throw new InvalidOperationException("must not prompt");
+        JsonObject env = Envelope(Call(160, "request-command-access", new JsonObject {
+            ["commands"] = new JsonArray("launch", 1),
+            ["reason"] = "r",
+        }));
+        Assert.Equal("bad-arguments", ErrorCode(env));
+    }
+
+    [Fact]
+    public void SingleCharRequest_GrantsTheCharsGate() {
+        // Finding 8: Enqueue runs a single character as a chars:-gated keypress, so requesting "a"
+        // must grant 'chars:' (the entry the invoker actually gates on), same as the prefix rule.
+        AgentConsent.Prompter = _ => CommandAccessDecision.AllowRequested;
+        JsonObject env = Ask(170, "type a letter", "a");
+        Assert.True(env["ok"]!.GetValue<bool>());
+        Assert.Equal(["chars:"], Strings(env, "granted"));
+        Assert.True((AgentRuntime.Invoker!["chars:"] as Command)!.Enabled);
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // Gates: transport, bootstrap, tools/list
     // ---------------------------------------------------------------------------------------------
 

--- a/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
+++ b/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
@@ -135,6 +135,23 @@ public class RequestCommandAccessTests : IDisposable {
     }
 
     [Fact]
+    public void PrefixSpelledCommand_GrantsTheKeyEnqueueWillExecute() {
+        // PR #308 review (Codex): the table holds BOTH a blank prefix entry ('mcec:') and full
+        // spellings ('mcec:exit'), but CommandInvoker.Enqueue parses any 'prefix:args' string as the
+        // bare prefix FIRST, so the prefix entry is what a send_command will actually gate on.
+        // A grant for 'mcec:exit' must therefore enable 'mcec:', not the (never-executed) full entry;
+        // otherwise the operator approves and the very next send_command still fails command-disabled.
+        AgentConsent.Prompter = _ => CommandAccessDecision.AllowRequested;
+
+        JsonObject env = Ask(110, "need to exit the instance", "mcec:exit");
+
+        Assert.True(env["ok"]!.GetValue<bool>());
+        Assert.Equal(["mcec:"], Strings(env, "granted"));
+        Assert.True((AgentRuntime.Invoker!["mcec:"] as Command)!.Enabled);
+        Assert.False((AgentRuntime.Invoker!["mcec:exit"] as Command)!.Enabled);
+    }
+
+    [Fact]
     public void Denied_IsSticky_NoSecondPrompt() {
         int prompts = 0;
         AgentConsent.Prompter = _ => { prompts++; return CommandAccessDecision.Denied; };


### PR DESCRIPTION
## What & why

Closes #307: the provision handoff stopped at MCP client setup (the operator had to improvise the agent briefing), and a session that hit a disabled command (`launch`, `chars:`, ...) had no legitimate way to acquire it; the `command-disabled` refusal literally told agents to edit `mcec.commands`, the one thing they must never do.

## (a) Two-step handoff in "Provision new..."

`ProvisionedInstanceDialog` now shows **Step 1: setup** (the `--mcp` launch line / `claude mcp add`, HTTP endpoint + bearer when enabled) and **Step 2: a briefing prompt to paste to the agent** (`BuildAgentPrompt`): session id, directory, token custody, the rules of engagement (recover from `command-disabled` via `request-command-access`, never edit config files, stop on `emergency-stopped`), the teardown duty, and a task placeholder. Each step has its own copy button. The prompt defers to the connect-time instructions for the tool playbook; a test pins that every tool name it mentions exists on the served surface, so it cannot drift.

## (b) `request-command-access`: the agent asks, the operator decides

New meta-tool on the full surface (bootstrap mode still serves exactly `provision-session`/`end-session`). The agent names 1..8 commands plus a one-line reason; MCEC shows the **operator** a consent dialog (GUI: MainWindow thread; headless `--mcp`: the `HeadlessOperatorUi` pump, the re-arm prompt pattern) and the call blocks for the answer:

1. **Allow these commands**
2. **Allow these + any later requests** (future asks auto-approve; every grant still audited and narrated on the overlay)
3. **Deny** (default button, Esc, close box, ~120s timeout, and e-stop all deny; a deny is sticky for the instance)

Refusals ride `error.code`: `consent-denied`, `consent-timeout` (not sticky), `consent-pending` (one prompt at a time), `consent-unavailable` (no operator surface; fail closed), `unknown-command` (whole request refused before prompting).

**Why the agent can't answer its own prompt** (three layers): the call holds `AgentRuntime.InputGate` for the dialog's lifetime, so queued/synthesized input can't land; dispatch refuses every actuation-capable tool with `consent-pending` while a prompt is open (an observation-only **allow-list**, which covers `invoke`; UIA actuation that never takes the gate); and the dialog registers with `WindowResolver` as never-a-target (the overlay's mechanism). The reason is rendered visibly quoted and attributed as unverified, with mnemonics disabled.

**Why grants are in-memory only**: they flip `Enabled` on the loaded table, never touch `mcec.commands`/`mcec.settings`; a leaked session directory never carries widened permissions, and a respawned instance resets to provisioned defaults. Consent is deliberately MCEC's own out-of-band dialog, not MCP elicitation (which routes the question through the agent's own client).

**Honesty fix on the same gate**: `send_command` of a disabled command used to enqueue, be silently skipped by the dispatcher, and report `ok`. It now fails fast with `command-disabled` plus the recovery pointer; the `command-disabled` detail everywhere now points at `request-command-access` instead of telling agents to edit config files.

Guidance updated with the feature (the standing rule): `AgentInstructions.md` (new COMMAND ACCESS section, PACING/SECURITY/PROVISION updates), `docs/safety-emergency-stop-and-provisioning.md` (new section 3), `docs/configuration.md`, `docs/environment-controller.md`, `AGENTS.md`.

## Tests

- 28 new: consent envelope shapes; sticky deny; allow-any auto-approve (still audited); timeout not sticky; `InputGate` provably held during the prompt (probed from another thread); the consent-pending allow-list; HTTP transport gate; bootstrap exclusion (tool refused and absent from the bootstrap `tools/list`); `send_command` `command-disabled` (incl. the single-char `chars:` case); consent-dialog body; handoff + agent-prompt text; prompt-mentions-exist-on-surface sync.
- Full suite: **1014 passed, 22 skipped** (was 985/22; one pinning test updated for the new meta-tool in `tools/list`).

## Verified end-to-end against the real `mcec.exe --mcp` (stdio)

- `initialize` serves the COMMAND ACCESS guidance; `tools/list` advertises the tool.
- `send_command chars:hello` returns `command-disabled` with the recovery pointer (was a silent `ok`).
- Unknown-name and missing-reason requests refused with **no dialog shown**.
- A live ask opened the real consent dialog; a concurrent `invoke` was refused `consent-pending` while a concurrent `query` fell through to the ordinary `agent-commands-disabled` gate (observation exempt from the freeze, as designed).
- Left unanswered, the dialog auto-closed at 120s, the call returned `consent-timeout`, and the process exited cleanly.
- With overlay + e-stop disabled (no operator pump), the ask failed closed instantly with `consent-unavailable`.

Noted for a possible follow-up: client disconnect (stdin EOF) does not cancel an open consent prompt; it lives out its timeout and denies. Harmless (default deny, reply goes nowhere), but dismissing on transport EOF would be tidier.

Fixes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kCGB6jvQ12FiX4wfV1QQF
