### PR TITLE
fix(update): only show the update dialog on explicit Help-menu request (#309)

### DIFF
--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -374,12 +374,14 @@ public partial class MainWindow : Form, IAppHost {
                     $"Could not access {UpdateService.Instance.ReleasePageUri} to see if a newer version is available. {UpdateService.Instance.ErrorMessage}");
             }
             else if (UpdateService.Instance.CompareVersions() < 0) {
+                // A newer version is available: enable the Help ▸ "Install Latest Version..." menu item so
+                // the operator can choose to update, but do NOT pop the update dialog automatically. The
+                // background/periodic check must stay silent — an unattended popup lands over kiosk/exhibit
+                // apps and interrupts users who must never see MCEC's UI (#309). The dialog is shown only on
+                // explicit request via updatesMenuItem_Click.
                 installLatestVersionMenuItem.Enabled = true;
                 Logger.Instance.Log4.Info("A newer version is available at");
                 Logger.Instance.Log4.Info($"   {UpdateService.Instance.ReleasePageUri}");
-
-                if (!Settings.DisableUpdatePopup)
-                    UpdateDialog.Instance.ShowDialog(this);
             }
             else if (UpdateService.Instance.CompareVersions() > 0) {
                 Logger.Instance.Log4.Info(

--- a/src/Services/AppSettings.cs
+++ b/src/Services/AppSettings.cs
@@ -108,9 +108,6 @@ public class AppSettings : ICloneable {
     [SafeForTelemetry]
     public bool UserPresenceDetection { get; set; }
 
-    [SafeForTelemetry]
-    public bool DisableUpdatePopup { get; set; }
-
     // TELEMETRY: NOT SAFE FOR PII - MUST DEFAULT TO FALSE
     public bool LogUserActivity { get; set; }
 

--- a/tests/MCEControl.xUnit/Integration/AgentDesktopE2ETests.cs
+++ b/tests/MCEControl.xUnit/Integration/AgentDesktopE2ETests.cs
@@ -277,7 +277,6 @@ public class AgentDesktopE2ETests {
         "  <AgentCommandsEnabled>true</AgentCommandsEnabled>\r\n" +
         "  <McpServerEnabled>false</McpServerEnabled>\r\n" +
         "  <ActAsServer>false</ActAsServer>\r\n" +
-        "  <DisableUpdatePopup>true</DisableUpdatePopup>\r\n" +
         "</AppSettings>\r\n";
 
     private static string CommandsXml() =>


### PR DESCRIPTION
Fixes #309.

## Problem
The background version check (on startup and on the 24h periodic timer) automatically popped the "a newer version is available" dialog. On kiosk/exhibit computers that popup lands **over the interactive application**, interrupting users who are never supposed to see MCEC's UI. After they run the update, the operator then has to redo reboot/settings config and re-disable the new "this computer is being controlled by MCEC" affordances.

## Change
Make the update check **silent**. When a newer version is found, MCEC now only:
- enables the **Help ▸ "Install Latest Version..."** menu item (a non-intrusive affordance), and
- logs that an update is available.

The update dialog is shown **solely on explicit operator request** via `updatesMenuItem_Click` (the Help-menu item). No automatic popup on startup or from the periodic check.

The reporter suggested a settings checkbox to disable update checks; showing the dialog only on demand addresses the underlying problem more directly (the check still runs — so the menu affordance lights up — it just never interrupts).

## Details
- `MainWindow.UpdateService_GotLatestVersion`: removed the automatic `UpdateDialog.Instance.ShowDialog(this)`; kept enabling the menu item + logging.
- Removed the now-unused `AppSettings.DisableUpdatePopup` flag (its only consumer was the auto-popup gate) and dropped it from the E2E test's settings XML.

## Testing
Windows-only WinForms app — can't build on macOS; relying on CI. The change removes an auto-shown dialog and a dead setting; the on-demand path (`updatesMenuItem_Click`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)