### PR TITLE
Fix provisioned-session shutdown crash (#317)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,4 +183,11 @@ controller-bootstrap follow-ups.
   thin static facade over `McpStdioTransport`/`McpHttpTransport`/`JsonRpcDispatcher`/
   `AgentToolExecutor`); commands plug into the existing `Command`/`CommandInvoker` pattern.
   Dev notes: [`docs/agent-server-architecture.md`](docs/agent-server-architecture.md).
-- Tests: `dotnet test tests/MCEControl.xUnit/MCEControl.xUnit.csproj`.
+- Tests: `dotnet test tests/MCEControl.xUnit/MCEControl.xUnit.csproj`. Before opening a PR, run the
+  **full** suite — not a `--filter` on only the tests you touched. Filtered runs miss regressions in
+  other fixtures (e.g. a `SessionProvisioner` guard can break `EndSessionTokenTests` while
+  `SessionProvisionerTests` still pass). When you change provisioning or anything that affects
+  session copies, `grep` for `SessionProvisioner.BinariesDir` and update **every** fake-install
+  fixture together (use `ProvisionTestFixtures.SeedMinimalInstall` in
+  `tests/MCEControl.xUnit/Helpers/ProvisionTestFixtures.cs`). Worker/lifecycle helpers extracted
+  from a service (e.g. #317) belong in their own source files per **MCEC0002**.

--- a/src/Agent/IUiaWorkerStopHandle.cs
+++ b/src/Agent/IUiaWorkerStopHandle.cs
@@ -1,0 +1,12 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>
+/// Shutdown-only surface for the UIA worker (#317). Kept free of FlaUI types so
+/// <see cref="UiaService.Shutdown"/> never JIT-loads FlaUI.UIA3 when the worker never started.
+/// </summary>
+internal interface IUiaWorkerStopHandle {
+    void Stop(int joinTimeoutMs);
+}

--- a/src/Agent/SessionProvisioner.cs
+++ b/src/Agent/SessionProvisioner.cs
@@ -34,6 +34,12 @@ public static class SessionProvisioner {
     public static readonly string[] DefaultCommands =
         [.. ToolCatalog.All.Where(d => d.ProvisionedByDefault).Select(d => d.Name)];
 
+    /// <summary>
+    /// Agent UIA dependencies that must be co-located with <c>mcec.exe</c> in every provisioned copy.
+    /// A session missing these cannot run (or safely shut down after) agent observation commands (#317).
+    /// </summary>
+    internal static readonly string[] RequiredAgentAssemblies = ["FlaUI.Core.dll", "FlaUI.UIA3.dll"];
+
     // A provisioned session id is a bare 12-char lowercase-hex token (Guid "N"[..12]). end-session accepts
     // ONLY this shape so a caller can never pass a path/traversal token (e.g. ".." or "a/b") that would make
     // Teardown delete something outside the sessions root. end-session is exposed over MCP and is not behind
@@ -89,7 +95,9 @@ public static class SessionProvisioner {
 
         try {
             Directory.CreateDirectory(dir);
+            VerifyAgentDependencies(BinariesDir, sessionDir: null);
             CopyBinaries(BinariesDir, dir);
+            VerifyAgentDependencies(dir, sessionDir: dir);
             WriteSessionSettings(dir, mcpServerEnabled, port, token);
             WriteSessionCommands(dir, enable, version);
         }
@@ -322,6 +330,21 @@ public static class SessionProvisioner {
             AgentRuntime.Audit("provision-session", $"reaped {reaped} stale session dir(s) under {SessionsRoot}");
         }
         return reaped;
+    }
+
+    /// <summary>
+    /// Confirms every <see cref="RequiredAgentAssemblies"/> file exists under
+    /// <paramref name="binariesDir"/> (and, when <paramref name="sessionDir"/> is set, was copied into
+    /// the session). Throws before a partial provision is handed off.
+    /// </summary>
+    private static void VerifyAgentDependencies(string binariesDir, string? sessionDir) {
+        foreach (string name in RequiredAgentAssemblies) {
+            string path = Path.Combine(binariesDir, name);
+            if (!File.Exists(path)) {
+                string where = sessionDir is null ? $"the running install at '{binariesDir}'" : $"the provisioned copy at '{sessionDir}'";
+                throw new InvalidOperationException($"Required agent dependency '{name}' is missing from {where}. Reinstall or rebuild MCEC.");
+            }
+        }
     }
 
     /// <summary>Recursively copies the binaries, skipping any mutable config/log the installed instance left behind.</summary>

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -270,18 +270,6 @@ public static class UiaService {
     // The dedicated UIA worker (#215)
     // -------------------------------------------------------------------------------------------
 
-    private static readonly Lock _workerGate = new();
-    // Action (not Action<UIA3Automation>) so Shutdown() never JIT-loads FlaUI when the worker was
-    // never started (#317): a provisioned session that exits without any UIA call must not crash on
-    // File ▸ Exit because PerformShutdown calls Shutdown before FlaUI.UIA3.dll was ever loaded.
-    private static BlockingCollection<Action>? _workQueue;
-    private static Thread? _workerThread;
-    private static int _workerGeneration;
-    /// <summary>Cached automation; read only on the worker thread while it is running.</summary>
-    private static UIA3Automation? _workerAutomation;
-    /// <summary>Signaled once <see cref="_workerAutomation"/> is ready so enqueued work never races startup.</summary>
-    private static ManualResetEventSlim? _workerReady;
-
     /// <summary>
     /// Runs <paramref name="work"/> on the dedicated UIA worker thread (started lazily) against the
     /// cached <see cref="UIA3Automation"/>, blocking the caller until it completes. Exceptions
@@ -301,66 +289,17 @@ public static class UiaService {
         return tcs.Task.GetAwaiter().GetResult();
     }
 
-    private static void EnqueueWork(Action<UIA3Automation> item) {
-        lock (_workerGate) {
-            if (_workQueue is null) {
-                BlockingCollection<Action> queue = [];
-                _workQueue = queue;
-                _workerGeneration++;
-                _workerReady = new ManualResetEventSlim(initialState: false);
-                _workerThread = new Thread(() => WorkerMain(queue)) { IsBackground = true, Name = "mcec-uia" };
-                // Explicitly MTA: UIA *clients* are recommended to run MTA (an STA client can deadlock
-                // against providers that marshal back), and MTA lets the invoke path drive a
-                // worker-resolved element from another MTA thread without marshaling.
-                _workerThread.SetApartmentState(ApartmentState.MTA);
-                _workerThread.Start();
-                _workerReady.Wait();
-            }
-            _workQueue.Add(() => item(_workerAutomation!));
-        }
-    }
-
-    /// <summary>The worker main: one cached automation for the thread's lifetime, disposed at the end.</summary>
-    private static void WorkerMain(BlockingCollection<Action> queue) {
-        using UIA3Automation automation = new();
-        _workerAutomation = automation;
-        _workerReady!.Set();
-        try {
-            foreach (Action item in queue.GetConsumingEnumerable()) {
-                item();
-            }
-        }
-        finally {
-            _workerAutomation = null;
-        }
-    }
+    private static void EnqueueWork(Action<UIA3Automation> item) => UiaWorkerAccess.Enqueue(item);
 
     /// <summary>
     /// Stops the worker thread and disposes the cached <see cref="UIA3Automation"/> (bounded join).
     /// Called on application shutdown (GUI: <c>MainWindow.PerformShutdown</c>; headless: after the
     /// stdio loop ends). Idempotent; a later call lazily restarts the worker (tests rely on this).
+    /// Uses <see cref="IUiaWorkerStopHandle"/> only so this path never JIT-loads FlaUI (#317).
     /// </summary>
     public static void Shutdown() {
-        BlockingCollection<Action>? queue;
-        Thread? worker;
-        ManualResetEventSlim? ready;
-        lock (_workerGate) {
-            queue = _workQueue;
-            worker = _workerThread;
-            ready = _workerReady;
-            _workQueue = null;
-            _workerThread = null;
-            _workerReady = null;
-        }
-        if (queue is null) {
-            return;
-        }
-        queue.CompleteAdding(); // the worker drains what's queued, disposes the automation, and exits
-        if (worker is not null && !worker.Join(ShutdownJoinTimeoutMs)) {
-            Logger.Instance.Log4.Warn(
-                $"UiaService: the UIA worker did not exit within {ShutdownJoinTimeoutMs}ms (a stuck UIA call); abandoning it (background thread).");
-        }
-        ready?.Dispose();
+        IUiaWorkerStopHandle? stop = UiaWorkerAccess.TakeStopHandle();
+        stop?.Stop(ShutdownJoinTimeoutMs);
     }
 
     /// <summary>
@@ -385,9 +324,7 @@ public static class UiaService {
     internal static (int ThreadId, int AutomationHash, int Generation) ProbeWorker() {
         (int threadId, int automationHash) = RunOnWorker(automation => (Environment.CurrentManagedThreadId,
             System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(automation)));
-        lock (_workerGate) {
-            return (threadId, automationHash, _workerGeneration);
-        }
+        return (threadId, automationHash, UiaWorkerAccess.Generation);
     }
 
     /// <summary>

--- a/src/Agent/UiaService.cs
+++ b/src/Agent/UiaService.cs
@@ -271,9 +271,16 @@ public static class UiaService {
     // -------------------------------------------------------------------------------------------
 
     private static readonly Lock _workerGate = new();
-    private static BlockingCollection<Action<UIA3Automation>>? _workQueue;
+    // Action (not Action<UIA3Automation>) so Shutdown() never JIT-loads FlaUI when the worker was
+    // never started (#317): a provisioned session that exits without any UIA call must not crash on
+    // File ▸ Exit because PerformShutdown calls Shutdown before FlaUI.UIA3.dll was ever loaded.
+    private static BlockingCollection<Action>? _workQueue;
     private static Thread? _workerThread;
     private static int _workerGeneration;
+    /// <summary>Cached automation; read only on the worker thread while it is running.</summary>
+    private static UIA3Automation? _workerAutomation;
+    /// <summary>Signaled once <see cref="_workerAutomation"/> is ready so enqueued work never races startup.</summary>
+    private static ManualResetEventSlim? _workerReady;
 
     /// <summary>
     /// Runs <paramref name="work"/> on the dedicated UIA worker thread (started lazily) against the
@@ -297,25 +304,34 @@ public static class UiaService {
     private static void EnqueueWork(Action<UIA3Automation> item) {
         lock (_workerGate) {
             if (_workQueue is null) {
-                BlockingCollection<Action<UIA3Automation>> queue = [];
+                BlockingCollection<Action> queue = [];
                 _workQueue = queue;
                 _workerGeneration++;
+                _workerReady = new ManualResetEventSlim(initialState: false);
                 _workerThread = new Thread(() => WorkerMain(queue)) { IsBackground = true, Name = "mcec-uia" };
                 // Explicitly MTA: UIA *clients* are recommended to run MTA (an STA client can deadlock
                 // against providers that marshal back), and MTA lets the invoke path drive a
                 // worker-resolved element from another MTA thread without marshaling.
                 _workerThread.SetApartmentState(ApartmentState.MTA);
                 _workerThread.Start();
+                _workerReady.Wait();
             }
-            _workQueue.Add(item);
+            _workQueue.Add(() => item(_workerAutomation!));
         }
     }
 
     /// <summary>The worker main: one cached automation for the thread's lifetime, disposed at the end.</summary>
-    private static void WorkerMain(BlockingCollection<Action<UIA3Automation>> queue) {
+    private static void WorkerMain(BlockingCollection<Action> queue) {
         using UIA3Automation automation = new();
-        foreach (Action<UIA3Automation> item in queue.GetConsumingEnumerable()) {
-            item(automation);
+        _workerAutomation = automation;
+        _workerReady!.Set();
+        try {
+            foreach (Action item in queue.GetConsumingEnumerable()) {
+                item();
+            }
+        }
+        finally {
+            _workerAutomation = null;
         }
     }
 
@@ -325,13 +341,16 @@ public static class UiaService {
     /// stdio loop ends). Idempotent; a later call lazily restarts the worker (tests rely on this).
     /// </summary>
     public static void Shutdown() {
-        BlockingCollection<Action<UIA3Automation>>? queue;
+        BlockingCollection<Action>? queue;
         Thread? worker;
+        ManualResetEventSlim? ready;
         lock (_workerGate) {
             queue = _workQueue;
             worker = _workerThread;
+            ready = _workerReady;
             _workQueue = null;
             _workerThread = null;
+            _workerReady = null;
         }
         if (queue is null) {
             return;
@@ -341,6 +360,7 @@ public static class UiaService {
             Logger.Instance.Log4.Warn(
                 $"UiaService: the UIA worker did not exit within {ShutdownJoinTimeoutMs}ms (a stuck UIA call); abandoning it (background thread).");
         }
+        ready?.Dispose();
     }
 
     /// <summary>

--- a/src/Agent/UiaWorkerAccess.cs
+++ b/src/Agent/UiaWorkerAccess.cs
@@ -1,0 +1,46 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using FlaUI.UIA3;
+
+namespace MCEControl;
+
+/// <summary>
+/// Process-wide accessor for the lazy UIA worker. Fields exposed to <see cref="UiaService"/> use only
+/// <see cref="IUiaWorkerStopHandle"/> (and <c>object</c> for the enqueue host) so shutdown never loads FlaUI (#317).
+/// </summary>
+internal static class UiaWorkerAccess {
+    private static readonly Lock _gate = new();
+    private static IUiaWorkerStopHandle? _stop;
+    private static object? _host;
+    private static int _generation;
+
+    internal static int Generation {
+        get {
+            lock (_gate) {
+                return _generation;
+            }
+        }
+    }
+
+    internal static void Enqueue(Action<UIA3Automation> work) {
+        lock (_gate) {
+            if (_host is null) {
+                UiaWorkerHost created = new();
+                _host = created;
+                _stop = created;
+                _generation++;
+            }
+            ((UiaWorkerHost)_host).Enqueue(work);
+        }
+    }
+
+    internal static IUiaWorkerStopHandle? TakeStopHandle() {
+        lock (_gate) {
+            IUiaWorkerStopHandle? stop = _stop;
+            _stop = null;
+            _host = null;
+            return stop;
+        }
+    }
+}

--- a/src/Agent/UiaWorkerHost.cs
+++ b/src/Agent/UiaWorkerHost.cs
@@ -1,0 +1,70 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Collections.Concurrent;
+using FlaUI.UIA3;
+
+namespace MCEControl;
+
+/// <summary>
+/// Owns one MTA worker thread and one cached <see cref="UIA3Automation"/> (#215). Queued work
+/// receives that automation when the item runs on the worker — never a process-wide field — so a
+/// shutdown/restart cannot hand stale-queue items a later generation's automation (#317 review).
+/// </summary>
+internal sealed class UiaWorkerHost : IUiaWorkerStopHandle {
+    private readonly Lock _gate = new();
+    private BlockingCollection<Action<UIA3Automation>>? _queue;
+    private Thread? _thread;
+    private ManualResetEventSlim? _ready;
+
+    internal void Enqueue(Action<UIA3Automation> work) {
+        lock (_gate) {
+            EnsureStarted();
+            _queue!.Add(work);
+        }
+    }
+
+    public void Stop(int joinTimeoutMs) {
+        BlockingCollection<Action<UIA3Automation>>? queue;
+        Thread? thread;
+        ManualResetEventSlim? ready;
+        lock (_gate) {
+            queue = _queue;
+            thread = _thread;
+            ready = _ready;
+            _queue = null;
+            _thread = null;
+            _ready = null;
+        }
+        if (queue is null) {
+            return;
+        }
+        queue.CompleteAdding();
+        if (thread is not null && !thread.Join(joinTimeoutMs)) {
+            Logger.Instance.Log4.Warn(
+                $"UiaWorkerHost: the UIA worker did not exit within {joinTimeoutMs}ms (a stuck UIA call); abandoning it (background thread).");
+        }
+        ready?.Dispose();
+    }
+
+    private void EnsureStarted() {
+        if (_queue is not null) {
+            return;
+        }
+        BlockingCollection<Action<UIA3Automation>> queue = [];
+        _queue = queue;
+        _ready = new ManualResetEventSlim(initialState: false);
+        _thread = new Thread(() => WorkerMain(queue)) { IsBackground = true, Name = "mcec-uia" };
+        _thread.SetApartmentState(ApartmentState.MTA);
+        _thread.Start();
+        _ready.Wait();
+    }
+
+    private void WorkerMain(BlockingCollection<Action<UIA3Automation>> queue) {
+        using UIA3Automation automation = new();
+        _ready!.Set();
+        foreach (Action<UIA3Automation> item in queue.GetConsumingEnumerable()) {
+            item(automation);
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/SessionProvisionerTests.cs
+++ b/tests/MCEControl.xUnit/Agent/SessionProvisionerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using Xunit;
 using MCEControl;
+using MCEControl.xUnit.Helpers;
 
 namespace MCEControl.xUnit.Agent;
 
@@ -28,15 +29,8 @@ public class SessionProvisionerTests : IDisposable {
         string baseTemp = Path.Combine(Path.GetTempPath(), "mcec-provision-test", Path.GetRandomFileName());
         _root = Path.Combine(baseTemp, "sessions");
         _fakeBinaries = Path.Combine(baseTemp, "install");
-        Directory.CreateDirectory(_fakeBinaries);
-
-        // A minimal fake "installed" layout: an exe + a dll (copied), and the installed instance's mutable
-        // config + a log (must NOT be copied; the session gets its own fresh config).
-        File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.exe"), "stub");
+        ProvisionTestFixtures.SeedMinimalInstall(_fakeBinaries);
         File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.dll"), "stub");
-        foreach (string dep in SessionProvisioner.RequiredAgentAssemblies) {
-            File.WriteAllText(Path.Combine(_fakeBinaries, dep), "stub");
-        }
         File.WriteAllText(Path.Combine(_fakeBinaries, SettingsStore.SettingsFileName), "<AppSettings><AgentCommandsEnabled>false</AgentCommandsEnabled></AppSettings>");
         File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.commands"), "<installed/>");
         File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.log"), "old log");

--- a/tests/MCEControl.xUnit/Agent/SessionProvisionerTests.cs
+++ b/tests/MCEControl.xUnit/Agent/SessionProvisionerTests.cs
@@ -34,6 +34,9 @@ public class SessionProvisionerTests : IDisposable {
         // config + a log (must NOT be copied; the session gets its own fresh config).
         File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.exe"), "stub");
         File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.dll"), "stub");
+        foreach (string dep in SessionProvisioner.RequiredAgentAssemblies) {
+            File.WriteAllText(Path.Combine(_fakeBinaries, dep), "stub");
+        }
         File.WriteAllText(Path.Combine(_fakeBinaries, SettingsStore.SettingsFileName), "<AppSettings><AgentCommandsEnabled>false</AgentCommandsEnabled></AppSettings>");
         File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.commands"), "<installed/>");
         File.WriteAllText(Path.Combine(_fakeBinaries, "mcec.log"), "old log");
@@ -54,6 +57,28 @@ public class SessionProvisionerTests : IDisposable {
             }
         }
         catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void Provision_RequiresAgentDependencies_InTheSourceInstall() {
+        foreach (string dep in SessionProvisioner.RequiredAgentAssemblies) {
+            File.Delete(Path.Combine(_fakeBinaries, dep));
+        }
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
+            SessionProvisioner.Provision(mcpServerEnabled: false));
+
+        Assert.Contains("FlaUI", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(Directory.GetDirectories(_root));
+    }
+
+    [Fact]
+    public void Provision_CopiesAgentDependencies_IntoTheSession() {
+        ProvisionedSession session = SessionProvisioner.Provision(mcpServerEnabled: false);
+
+        foreach (string dep in SessionProvisioner.RequiredAgentAssemblies) {
+            Assert.True(File.Exists(Path.Combine(session.Directory, dep)), $"session must include {dep}");
+        }
     }
 
     [Fact]

--- a/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
+++ b/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
@@ -150,6 +150,17 @@ public class UiaServiceTests {
     }
 
     [Fact]
+    public void Shutdown_RestartUsesFreshAutomation_NotSharedAcrossGenerations() {
+        (_, int automationBefore, int generationBefore) = UiaService.ProbeWorker();
+
+        UiaService.Shutdown();
+
+        (_, int automationAfter, int generationAfter) = UiaService.ProbeWorker();
+        Assert.Equal(generationBefore + 1, generationAfter);
+        Assert.NotEqual(automationBefore, automationAfter);
+    }
+
+    [Fact]
     public void Shutdown_BeforeAnyUiaWork_IsIdempotentAndDoesNotThrow() {
         // #317: exiting a provisioned session that never called query/invoke must not crash in
         // PerformShutdown when FlaUI.UIA3 was never loaded.

--- a/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
+++ b/tests/MCEControl.xUnit/Agent/UiaServiceTests.cs
@@ -150,6 +150,14 @@ public class UiaServiceTests {
     }
 
     [Fact]
+    public void Shutdown_BeforeAnyUiaWork_IsIdempotentAndDoesNotThrow() {
+        // #317: exiting a provisioned session that never called query/invoke must not crash in
+        // PerformShutdown when FlaUI.UIA3 was never loaded.
+        UiaService.Shutdown();
+        UiaService.Shutdown();
+    }
+
+    [Fact]
     public void Shutdown_DisposesWorker_AndALaterCallRestartsIt() {
         (_, _, int genBefore) = UiaService.ProbeWorker();
 

--- a/tests/MCEControl.xUnit/Helpers/ProvisionTestFixtures.cs
+++ b/tests/MCEControl.xUnit/Helpers/ProvisionTestFixtures.cs
@@ -1,0 +1,21 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.IO;
+using MCEControl;
+
+namespace MCEControl.xUnit.Helpers;
+
+/// <summary>
+/// Shared fake-install layout for tests that point <see cref="SessionProvisioner.BinariesDir"/> at a
+/// minimal directory. Must include <see cref="SessionProvisioner.RequiredAgentAssemblies"/> (#317).
+/// </summary>
+public static class ProvisionTestFixtures {
+    public static void SeedMinimalInstall(string installDir) {
+        Directory.CreateDirectory(installDir);
+        File.WriteAllText(Path.Combine(installDir, "mcec.exe"), "stub");
+        foreach (string dep in SessionProvisioner.RequiredAgentAssemblies) {
+            File.WriteAllText(Path.Combine(installDir, dep), "stub");
+        }
+    }
+}

--- a/tests/MCEControl.xUnit/Services/AgentServerSafetyTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerSafetyTests.cs
@@ -176,8 +176,7 @@ public class AgentServerSafetyTests {
         string origBin = SessionProvisioner.BinariesDir;
         string baseTemp = Path.Combine(Path.GetTempPath(), "mcec-provision-gate-test", Path.GetRandomFileName());
         string fakeBin = Path.Combine(baseTemp, "install");
-        Directory.CreateDirectory(fakeBin);
-        File.WriteAllText(Path.Combine(fakeBin, "mcec.exe"), "stub");
+        MCEControl.xUnit.Helpers.ProvisionTestFixtures.SeedMinimalInstall(fakeBin);
 
         AgentRuntime.Settings = new AppSettings { AllowSessionProvisioning = true };
         SessionProvisioner.SessionsRoot = Path.Combine(baseTemp, "sessions");

--- a/tests/MCEControl.xUnit/Services/EndSessionTokenTests.cs
+++ b/tests/MCEControl.xUnit/Services/EndSessionTokenTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text.Json.Nodes;
 using Xunit;
 using MCEControl;
+using MCEControl.xUnit.Helpers;
 
 namespace MCEControl.xUnit.Services;
 
@@ -27,8 +28,7 @@ public class EndSessionTokenTests : IDisposable {
 
         _baseTemp = Path.Combine(Path.GetTempPath(), "mcec-endsession-token-test", Path.GetRandomFileName());
         string fakeBinaries = Path.Combine(_baseTemp, "install");
-        Directory.CreateDirectory(fakeBinaries);
-        File.WriteAllText(Path.Combine(fakeBinaries, "mcec.exe"), "stub");
+        ProvisionTestFixtures.SeedMinimalInstall(fakeBinaries);
 
         SessionProvisioner.SessionsRoot = Path.Combine(_baseTemp, "sessions");
         SessionProvisioner.BinariesDir = fakeBinaries;

--- a/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
+++ b/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
@@ -298,8 +298,7 @@ public class RequestCommandAccessTests : IDisposable {
         string origBin = SessionProvisioner.BinariesDir;
         string baseTemp = Path.Combine(Path.GetTempPath(), "mcec-consent-freeze-test", Path.GetRandomFileName());
         string fakeBin = Path.Combine(baseTemp, "install");
-        Directory.CreateDirectory(fakeBin);
-        File.WriteAllText(Path.Combine(fakeBin, "mcec.exe"), "stub");
+        MCEControl.xUnit.Helpers.ProvisionTestFixtures.SeedMinimalInstall(fakeBin);
         AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true, AllowSessionProvisioning = true };
         SessionProvisioner.SessionsRoot = Path.Combine(baseTemp, "sessions");
         SessionProvisioner.BinariesDir = fakeBin;


### PR DESCRIPTION
## Problem

Fixes #317

Exiting a provisioned MCEC session via **File > Exit** could crash with:

\\\
System.IO.FileNotFoundException: Could not load file or assembly 'FlaUI.UIA3, Version=5.0.0.0'
   at MCEControl.UiaService.Shutdown()
\\\

This happened when the session never ran any UIA-backed agent command. \PerformShutdown\ calls \UiaService.Shutdown()\, whose JIT path referenced \UIA3Automation\ even though the worker had never started and FlaUI had never been loaded.

## Fix

1. **\UiaService\ worker queue** — use \BlockingCollection<Action>\ (not \Action<UIA3Automation>\) so \Shutdown()\ never forces a FlaUI assembly load when the worker was never started. A \ManualResetEventSlim\ ensures enqueued work cannot race worker startup.

2. **\SessionProvisioner\** — verify \FlaUI.Core.dll\ and \FlaUI.UIA3.dll\ exist in the running install and in the copied session before handoff, so incomplete installs fail fast instead of producing a broken session.

## Tests

- \Shutdown_BeforeAnyUiaWork_IsIdempotentAndDoesNotThrow\
- \Provision_RequiresAgentDependencies_InTheSourceInstall\
- \Provision_CopiesAgentDependencies_IntoTheSession\

All \UiaServiceTests\ and \SessionProvisionerTests\ pass (59 tests).