### PR TITLE
Add get-text observation tool for region OCR (#331)

### DIFF
--- a/agent-tool-result.schema.json
+++ b/agent-tool-result.schema.json
@@ -80,6 +80,8 @@
             "no-target",
             "invalid-argument",
             "capture-blank",
+            "ocr-blank",
+            "ocr-no-text",
             "focus",
             "elevation",
             "foreground",

--- a/docs/agent_control.md
+++ b/docs/agent_control.md
@@ -236,7 +236,7 @@ Over MCP, the transport's `isError` flag mirrors the envelope (`isError = !ok`).
 
 On failure the `error` object carries a stable, fine-grained `code`, a coarse `category` from
 the closed taxonomy (`timeout`, `ambiguous-selector`, `stale-element`, `no-target`,
-`invalid-argument`, `capture-blank`, `focus`, `elevation`, `foreground`, `internal`; the `focus`
+`invalid-argument`, `capture-blank`, `ocr-blank`, `ocr-no-text`, `focus`, `elevation`, `foreground`, `internal`; the `focus`
 tool produces `focus` and `foreground` when it cannot confirm focus or foreground on the target), a
 human-readable `detail`, and (when available) a `lastObservation` (the last good state before
 the failure, so a failed call is debuggable without rerunning it) and a `partialResult` (the

--- a/src/Agent/AgentError.cs
+++ b/src/Agent/AgentError.cs
@@ -41,6 +41,8 @@ public sealed class AgentError(string code, AgentErrorCategory category, string 
         AgentErrorCategory.NoTarget => "no-target",
         AgentErrorCategory.InvalidArgument => "invalid-argument",
         AgentErrorCategory.CaptureBlank => "capture-blank",
+        AgentErrorCategory.OcrBlank => "ocr-blank",
+        AgentErrorCategory.OcrNoText => "ocr-no-text",
         AgentErrorCategory.Focus => "focus",
         AgentErrorCategory.Elevation => "elevation",
         AgentErrorCategory.Foreground => "foreground",

--- a/src/Agent/AgentErrorCategory.cs
+++ b/src/Agent/AgentErrorCategory.cs
@@ -31,6 +31,12 @@ public enum AgentErrorCategory {
     /// <summary>A screenshot was produced but detected as black/blank.</summary>
     CaptureBlank,
 
+    /// <summary>OCR produced a blank/flat frame (minimized, cloaked, off-screen, etc.); parallel to <see cref="CaptureBlank"/>.</summary>
+    OcrBlank,
+
+    /// <summary>OCR ran on a non-blank region but produced no readable text (low contrast, too small, wrong script, etc.).</summary>
+    OcrNoText,
+
     /// <summary>An action required keyboard focus and it could not be confirmed on the target. Produced
     /// (#91/#270) by the <c>focus</c> tool when a window is foreground but no control took focus
     /// (<see cref="FocusService.IsFocusInWindow"/>), and by <c>invoke setfocus</c> when the element does

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -1,8 +1,9 @@
 MCEC (Model Context Environment Controller) lets you see and drive native Windows apps.
 
 Work the loop: observe -> target -> act -> observe. You are measured on token cost and wall-clock time:
-prefer structured observation (`windows`/`query`/`find`) over `capture`; when you must capture, the
-smallest region that answers the question; use `windows` wait-for and title/process filters instead of
+prefer structured observation (`windows`/`query`/`find`) over `capture`; for opaque web content prefer
+`get-text` on the smallest field region over a PNG `capture`; when you must capture, the smallest region
+that answers the question; use `windows` wait-for and title/process filters instead of
 scroll-and-recapture loops; prefer direct URL/`launch` navigation over hunting pixels; don't re-observe
 what the last result already told you — large-window captures dominate token cost.
 
@@ -26,12 +27,15 @@ popups are not enumerated by title/process; target them by handle or `foreground
 2. OBSERVE: `query` dumps the UI Automation tree (controlType, name, automationId, bounds, state, value)
 so you can pick a control instead of guessing pixels; `capture` returns a PNG (works on composited
 WinUI/WPF surfaces; check `bytes` — full windows are costly and inline base64 can blow your token budget).
-Browser chrome is UIA-targetable; in-page web content is not — verify with region `capture` and
-screen-absolute pixel `click` (window origin from `query` bounds + offset; re-capture after layout shifts).
-Use `capture` for a single state check when the tree can't answer; use `record` ONLY to show CHANGE
+Browser chrome is UIA-targetable; in-page web content is not — verify field values with `get-text` on a
+window-relative region (`x`/`y`/`width`/`height` from `query` bounds) before reaching for `capture`; use
+screen-absolute pixel `click` when needed (re-observe after layout shifts). `get-text` returns extracted
+text plus line/word counts; `ocr-no-text` means OCR could not read the region (try a larger area or
+`capture`); `ocr-blank` means the pixels were a flat fill (like `capture-blank`). Use `capture` for a
+single state check when the tree and OCR can't answer; use `record` ONLY to show CHANGE
 over time; a bounded one-shot (`durationMs`) or `action:start` then `action:stop`; keep recordings short
 (fps/duration are capped and frames downscaled), and remember it captures whatever is on screen for the
-whole duration. Region targets (`x`/`y`/`width`/`height`) for `capture` and `record` are size-capped: an oversized region
+whole duration. Region targets (`x`/`y`/`width`/`height`) for `capture`, `get-text`, and `record` are size-capped: an oversized region
 fails fast with `errorCode:region-too-large` (category `invalid-argument`; the detail states the limit), so
 request a smaller region or a window target (windows are bounded by their own size). An open `start`
 auto-stops at the operator's limits; `stop`
@@ -95,11 +99,11 @@ foreground a window and confirm focus. It fails `foreground` if the window won't
 control took focus. `invoke setfocus` is also verified now; it fails `focus` (code `focus-not-set`) when
 the element does not end up focused, which is your cue to `focus` (it clicks) or `click` the control.
 
-4. VERIFY with another `query` or `capture`; always confirm the act had the intended effect.
+4. VERIFY with another `query`, `get-text`, or `capture`; always confirm the act had the intended effect.
 
 RESULTS: every tool returns one envelope: `{ ok, result?, warnings?, error? }`. Branch on `ok` first: on
 success read `result`; on failure read `error.category` (a closed set: timeout, ambiguous-selector,
-stale-element, no-target, invalid-argument, capture-blank, focus, elevation, foreground, internal) to
+stale-element, no-target, invalid-argument, capture-blank, ocr-blank, ocr-no-text, focus, elevation, foreground, internal) to
 choose recovery; e.g. `no-target` means broaden the selector, `query` to discover targets, or `wait-for`
 the element; `invalid-argument` means the REQUEST itself is wrong (unknown action, oversized region,
 ill-formed endpoint, an action the element can't perform); fix the arguments, do NOT retry the same call
@@ -162,7 +166,7 @@ prior file before the run and dismiss the viewer with Alt+F4 afterward so the ne
 a `timeout`) rather than sleeping; poll `query` only for a control INSIDE a window you already have. Reach
 for a raw `send_command` before giving up.
 
-CONCURRENCY: observation (`query`/`capture`/`find`/`wait-for`/`record`) runs concurrently and never blocks
+CONCURRENCY: observation (`query`/`capture`/`get-text`/`find`/`wait-for`/`record`) runs concurrently and never blocks
 another call; a long `wait-for` won't stall a `capture`, and `invoke` returns promptly even if it opens a
 modal; so a slow observation is safe to start. Physical-input actuation (`drag`, `send_command`) is
 serialized: it runs one-at-a-time (the desktop has a single input stream), so don't expect two input
@@ -194,7 +198,7 @@ only to deliberately end the session, e.g. stopping a provisioned instance befor
 OVERLAY: MCEC may show a small on-screen overlay (default on) that narrates each command you run so the
 operator can see MCEC is driving. It is deliberately excluded from `query`/`find`/`capture`/UIA targeting;
 you will never see or target it, and it is never a candidate window; but it DOES appear in
-full-screen/region `capture`s and `record`ings (not in window-targeted captures).
+full-screen/region `capture`s/`get-text`/`record`ings (not in window-targeted captures).
 
 PROVISION: do NOT drive the operator's installed MCEC by enabling agent commands in it; an abnormal exit
 leaks those security gates enabled, and the installed copy will not serve the full agent surface anyway.
@@ -234,7 +238,7 @@ is audited and narrated on the overlay). A deny is FINAL for this instance: re-r
 returns `error.code:consent-denied` with no prompt; do not nag; tell the user what you needed and why.
 `consent-timeout` means the operator never answered (they may be away; you may ask again later, ideally
 after checking in with the user). `consent-pending` means a consent prompt is already open: while it is up,
-only observation (`capture`/`query`/`displays`/`windows`/`find`/`wait-for`/`record`) is served and every
+only observation (`capture`/`get-text`/`query`/`displays`/`windows`/`find`/`wait-for`/`record`) is served and every
 other call is refused with that code; wait for your pending request to return. `consent-unavailable` means
 no operator prompt can be shown (fail closed); ask the user to enable the command themselves. You will
 never see or target the consent dialog; it is excluded from targeting like the overlay, and actuation is
@@ -245,7 +249,7 @@ session from any window. If ANY tool returns `error.code:emergency-stopped` (the
 `error.category` stays `internal`), the operator has engaged it and deliberately halted you; STOP
 immediately, tell the user, and do NOT retry; nothing will actuate until they re-arm.
 
-SECURITY: the agent tools (capture/query/displays/windows/find/wait-for/invoke/record/launch/drag/click/clipboard, and the
+SECURITY: the agent tools (capture/get-text/query/displays/windows/find/wait-for/invoke/record/launch/drag/click/clipboard, and the
 session-start/session-status/session-end lifecycle) only work when the operator has set
 AgentCommandsEnabled=true; otherwise they return an error; surface that to the user rather than retrying.
 `send_command` is also gated by AgentCommandsEnabled when you are connected over the HTTP transport (it is

--- a/src/Agent/AgentToolResult.cs
+++ b/src/Agent/AgentToolResult.cs
@@ -119,6 +119,8 @@ public sealed class AgentToolResult {
             case "no-target": category = AgentErrorCategory.NoTarget; return true;
             case "invalid-argument": category = AgentErrorCategory.InvalidArgument; return true;
             case "capture-blank": category = AgentErrorCategory.CaptureBlank; return true;
+            case "ocr-blank": category = AgentErrorCategory.OcrBlank; return true;
+            case "ocr-no-text": category = AgentErrorCategory.OcrNoText; return true;
             case "focus": category = AgentErrorCategory.Focus; return true;
             case "elevation": category = AgentErrorCategory.Elevation; return true;
             case "foreground": category = AgentErrorCategory.Foreground; return true;

--- a/src/Agent/RegionOcr.cs
+++ b/src/Agent/RegionOcr.cs
@@ -30,6 +30,17 @@ public static class RegionOcr {
 
     /// <summary>Async variant of <see cref="Recognize"/>.</summary>
     public static async Task<RegionOcrResult> RecognizeAsync(Bitmap bitmap) {
+        // CR P2 (PR 334): fail fast for images > OcrEngine.MaxImageDimension with a clear message
+        // so caller can surface invalid-argument rather than opaque get-text-exception from deep OCR.
+        // Check the source bitmap (pre SoftwareBitmap) and again after decode.
+        uint max = OcrEngine.MaxImageDimension;
+        if (bitmap.Width > max || bitmap.Height > max) {
+            throw new ArgumentException(
+                $"OCR image dimensions {bitmap.Width}x{bitmap.Height} exceed OcrEngine.MaxImageDimension={max}. " +
+                "Shrink the get-text region (or target a smaller window portion) and retry.",
+                nameof(bitmap));
+        }
+
         OcrEngine? engine = OcrEngine.TryCreateFromUserProfileLanguages();
         if (engine is null) {
             throw new InvalidOperationException(
@@ -37,6 +48,13 @@ public static class RegionOcr {
         }
 
         using SoftwareBitmap softwareBitmap = await ToSoftwareBitmapAsync(bitmap);
+        if (softwareBitmap.PixelWidth > max || softwareBitmap.PixelHeight > max) {
+            throw new ArgumentException(
+                $"OCR image dimensions {softwareBitmap.PixelWidth}x{softwareBitmap.PixelHeight} exceed OcrEngine.MaxImageDimension={max}. " +
+                "Shrink the get-text region and retry.",
+                nameof(bitmap));
+        }
+
         OcrResult ocr = await engine.RecognizeAsync(softwareBitmap);
 
         int lineCount = ocr.Lines.Count;

--- a/src/Agent/RegionOcr.cs
+++ b/src/Agent/RegionOcr.cs
@@ -1,0 +1,59 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Windows.Graphics.Imaging;
+using Windows.Media.Ocr;
+using Windows.Storage.Streams;
+
+namespace MCEControl;
+
+/// <summary>
+/// Windows built-in OCR (<see cref="OcrEngine"/>) for agent region text reads (#331). Converts a
+/// <see cref="Bitmap"/> to <see cref="SoftwareBitmap"/>, runs recognition, and returns the extracted
+/// text plus lightweight metadata (line/word counts, recognizer language).
+/// </summary>
+public static class RegionOcr {
+    /// <summary>
+    /// Recognizes text in <paramref name="bitmap"/> using the user's installed OCR language pack(s).
+    /// </summary>
+    /// <returns>The recognized text and metadata.</returns>
+    /// <exception cref="InvalidOperationException">No OCR engine is available for the user profile.</exception>
+    public static RegionOcrResult Recognize(Bitmap bitmap) =>
+        RecognizeAsync(bitmap).GetAwaiter().GetResult();
+
+    /// <summary>Async variant of <see cref="Recognize"/>.</summary>
+    public static async Task<RegionOcrResult> RecognizeAsync(Bitmap bitmap) {
+        OcrEngine? engine = OcrEngine.TryCreateFromUserProfileLanguages();
+        if (engine is null) {
+            throw new InvalidOperationException(
+                "Windows OCR is not available (no OCR language pack installed for the user profile).");
+        }
+
+        using SoftwareBitmap softwareBitmap = await ToSoftwareBitmapAsync(bitmap);
+        OcrResult ocr = await engine.RecognizeAsync(softwareBitmap);
+
+        int lineCount = ocr.Lines.Count;
+        int wordCount = ocr.Lines.Sum(l => l.Words.Count);
+        string text = ocr.Text ?? string.Empty;
+        string? language = engine.RecognizerLanguage?.LanguageTag;
+
+        return new RegionOcrResult(text, lineCount, wordCount, language);
+    }
+
+    private static async Task<SoftwareBitmap> ToSoftwareBitmapAsync(Bitmap bitmap) {
+        using MemoryStream ms = new();
+        bitmap.Save(ms, ImageFormat.Png);
+        ms.Position = 0;
+
+        using IRandomAccessStream stream = ms.AsRandomAccessStream();
+        BitmapDecoder decoder = await BitmapDecoder.CreateAsync(stream);
+        return await decoder.GetSoftwareBitmapAsync();
+    }
+}

--- a/src/Agent/RegionOcrResult.cs
+++ b/src/Agent/RegionOcrResult.cs
@@ -1,0 +1,11 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+namespace MCEControl;
+
+/// <summary>Outcome of <see cref="RegionOcr"/> recognizing text in a bitmap region (#331).</summary>
+/// <param name="Text">Joined recognized text (lines separated by newlines).</param>
+/// <param name="LineCount">Number of recognized lines.</param>
+/// <param name="WordCount">Number of recognized words across all lines.</param>
+/// <param name="Language">BCP-47 language tag of the OCR engine used, when available.</param>
+public record RegionOcrResult(string Text, int LineCount, int WordCount, string? Language);

--- a/src/Agent/ScreenCapture.cs
+++ b/src/Agent/ScreenCapture.cs
@@ -154,6 +154,22 @@ public static class ScreenCapture {
     /// <exception cref="ArgumentException">Thrown when the region has no area or exceeds
     /// <see cref="MaxRegionDimension"/>/<see cref="MaxRegionPixels"/> (#158); thrown BEFORE any
     /// bitmap is allocated, so an oversized agent request costs nothing.</exception>
+    /// <summary>
+    /// Crops <paramref name="source"/> to a sub-rectangle. Throws when the crop extends outside the
+    /// bitmap (window-relative region requests that overshoot the captured window).
+    /// </summary>
+    public static Bitmap CropBitmap(Bitmap source, int x, int y, int width, int height) {
+        if (x < 0 || y < 0 || width <= 0 || height <= 0
+            || x + width > source.Width || y + height > source.Height) {
+            throw new ArgumentException(
+                $"Region ({x},{y}) {width}x{height} is outside the {source.Width}x{source.Height} capture.",
+                nameof(width));
+        }
+
+        Rectangle rect = new(x, y, width, height);
+        return source.Clone(rect, source.PixelFormat);
+    }
+
     public static Bitmap CaptureRegionBitmap(int x, int y, int width, int height) {
         string? sizeError = ValidateRegionSize(width, height);
         if (sizeError is not null) {

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -9,7 +9,7 @@ namespace MCEControl;
 
 /// <summary>
 /// The single registry of the gated agent tools (#205): one <see cref="ToolDescriptor"/> per tool;
-/// capture, query, displays, find, wait-for, invoke, drag, click, record, launch; carrying its
+/// capture, get-text, query, displays, find, wait-for, invoke, drag, click, record, launch; carrying its
 /// <c>tools/list</c> schema, its argument→<see cref="Command"/> mapping, its overlay tersifier, and its
 /// policy flags. Every consumer (the <see cref="AgentServer"/> gate/dispatch/schema sites,
 /// <see cref="AgentSession"/>, <see cref="CommandTersifier"/>, <see cref="SessionProvisioner"/>) looks
@@ -69,6 +69,26 @@ public static class ToolCatalog {
             },
             CreateCommandInstance = () => new CaptureCommand(),
             Tersify = args => $"capture {CommandTersifier.Target(args)}",
+            IsObservation = true,
+            ProvisionedByDefault = true,
+            ServedDuringConsent = true,
+        },
+        new() {
+            Name = "get-text",
+            BuildSchema = BuildGetTextSchema,
+            BuildCommand = args => new GetTextCommand {
+                Window = Str(args, "window")!,
+                Handle = Long(args, "handle"),
+                Process = Str(args, "process")!,
+                ClassName = Str(args, "className")!,
+                Foreground = Bool(args, "foreground"),
+                X = Int(args, "x"),
+                Y = Int(args, "y"),
+                Width = Int(args, "width"),
+                Height = Int(args, "height"),
+            },
+            CreateCommandInstance = () => new GetTextCommand(),
+            Tersify = args => $"get-text {CommandTersifier.Target(args)}",
             IsObservation = true,
             ProvisionedByDefault = true,
             ServedDuringConsent = true,
@@ -269,6 +289,17 @@ public static class ToolCatalog {
         return Tool("capture",
             "Screenshot a window (PrintWindow PW_RENDERFULLCONTENT, captures WinUI/WPF surfaces) or a screen region; returns PNG. Blank/black frames are detected and reported as a capture-blank error (window) or warning (region) rather than a silent bad image.",
             captureProps, []);
+    }
+
+    private static JsonObject BuildGetTextSchema() {
+        JsonObject props = WindowTargetProps();
+        props["x"] = PropSchema("integer", "Region left: screen-absolute when no window target, window-relative when a window is targeted");
+        props["y"] = PropSchema("integer", "Region top (same coordinate space as x)");
+        props["width"] = PropSchema("integer", "Region width (max 16384/side, 64000000 px total; oversized fails with region-too-large)");
+        props["height"] = PropSchema("integer", "Region height (same limits as width)");
+        return Tool("get-text",
+            "Read visible text from a window or screen region via Windows OCR; returns text plus line/word counts (cheaper than capture for web field verification). Blank regions fail with ocr-blank; unreadable text fails with ocr-no-text.",
+            props, []);
     }
 
     private static JsonObject BuildQuerySchema() {

--- a/src/Commands/CommandRegistry.cs
+++ b/src/Commands/CommandRegistry.cs
@@ -44,6 +44,7 @@ public static class CommandRegistry {
         new("mouse", typeof(MouseCommand), () => MouseCommand.BuiltInCommands),
         new("mceccommand", typeof(McecCommand), () => McecCommand.BuiltInCommands),
         new("capture", typeof(CaptureCommand), () => CaptureCommand.BuiltInCommands),
+        new("get-text", typeof(GetTextCommand), () => GetTextCommand.BuiltInCommands),
         new("query", typeof(QueryCommand), () => QueryCommand.BuiltInCommands),
         new("find", typeof(FindCommand), () => FindCommand.BuiltInCommands),
         new("invoke", typeof(InvokeCommand), () => InvokeCommand.BuiltInCommands),

--- a/src/Commands/CommandResult.cs
+++ b/src/Commands/CommandResult.cs
@@ -28,8 +28,8 @@ public sealed class CommandResult {
     public string? ErrorCode { get; set; }
 
     /// <summary>Coarse failure class from the closed taxonomy in the agent result contract
-    /// (timeout, ambiguous-selector, stale-element, no-target, capture-blank, focus, elevation,
-    /// foreground, internal).</summary>
+    /// (timeout, ambiguous-selector, stale-element, no-target, invalid-argument, capture-blank,
+    /// ocr-blank, ocr-no-text, focus, elevation, foreground, internal).</summary>
     public string? ErrorCategory { get; set; }
 
     public JsonObject? Data { get; private init; }

--- a/src/Commands/GetTextCommand.cs
+++ b/src/Commands/GetTextCommand.cs
@@ -1,0 +1,231 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Xml.Serialization;
+
+namespace MCEControl;
+
+/// <summary>
+/// MCEC 3.0 agent "read text from screen" command (#331). Captures a target window (by handle / title
+/// substring / process / class / foreground), an explicit screen region, or a window-relative sub-region,
+/// runs Windows OCR on the pixels, and returns the extracted string plus metadata.
+///
+/// SECURITY: gated behind <see cref="AgentRuntime.AgentCommandsEnabled"/> and audited via
+/// <see cref="AgentRuntime.Audit"/>.
+/// </summary>
+public class GetTextCommand : WindowTargetingAgentCommand {
+    [XmlAttribute("x")]
+    public int X { get; set; }
+
+    [XmlAttribute("y")]
+    public int Y { get; set; }
+
+    [XmlAttribute("width")]
+    public int Width { get; set; }
+
+    [XmlAttribute("height")]
+    public int Height { get; set; }
+
+    public static List<Command> BuiltInCommands {
+        get => [new GetTextCommand { Cmd = "get-text" }];
+    }
+
+    /// <summary>True when width/height specify a region.</summary>
+    private bool HasRegion => Width > 0 && Height > 0;
+
+    /// <summary>True when this is a screen-absolute region capture (region given, no window selector).</summary>
+    private bool IsScreenRegion => HasRegion && !HasWindowTarget;
+
+    // Window resolution happens inside ExecuteCore (like record's grabber-owned resolution), so a
+    // screen-absolute region needs no window and window-relative regions still resolve here.
+    protected override bool RequiresWindowTarget => false;
+
+    /// <summary>Virtual seam so tests can supply a resolved window without enumerating the desktop.</summary>
+    protected virtual WindowInfo? TryResolveWindow() => ResolveTargetWindow();
+
+    protected override CommandResult OnWindowNotFound() {
+        AgentRuntime.Audit(Cmd, "no matching window");
+        return base.OnWindowNotFound();
+    }
+
+    protected override CommandResult ExecuteCore(WindowInfo? target) {
+        try {
+            if (IsScreenRegion) {
+                return ReadScreenRegion();
+            }
+
+            WindowInfo? win = TryResolveWindow();
+            if (win is null) {
+                return OnWindowNotFound();
+            }
+
+            return ReadWindow(win);
+        }
+        catch (InvalidOperationException e) when (e.Message.Contains("OCR", StringComparison.OrdinalIgnoreCase)) {
+            AgentRuntime.Audit(Cmd, "ocr unavailable");
+            return CommandResult.Fail(Cmd, e.Message, "ocr-unavailable", "internal");
+        }
+        catch (Exception e) {
+            Logger.Instance.Log4.Error($"{GetType().Name}: get-text failed: {e.Message}");
+            return CommandResult.Fail(Cmd, $"get-text failed: {e.Message}", "get-text-exception", "internal");
+        }
+    }
+
+    private CommandResult ReadScreenRegion() {
+        string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
+        if (sizeError is not null) {
+            AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED; {sizeError}");
+            return CommandResult.Fail(Cmd, sizeError, "region-too-large", "invalid-argument");
+        }
+
+        AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height}");
+        using Bitmap bmp = ScreenCapture.CaptureRegionBitmap(X, Y, Width, Height);
+        return FinishOcr(bmp, target: null, regionRelativeTo: "screen", regionX: X, regionY: Y);
+    }
+
+    private CommandResult ReadWindow(WindowInfo win) {
+        AgentRuntime.Audit(Cmd, DescribeWindowTarget(win));
+
+        using Bitmap windowBmp = CaptureWindowBitmap(win, out bool usedFallback);
+        Bitmap regionBmp;
+        bool disposeRegion;
+        if (HasRegion) {
+            string? cropError = TryCropWindowRegion(windowBmp, out regionBmp);
+            if (cropError is not null) {
+                AgentRuntime.Audit(Cmd, $"region ({X},{Y}) {Width}x{Height} REJECTED; {cropError}");
+                return CommandResult.Fail(Cmd, cropError, "region-out-of-bounds", "invalid-argument");
+            }
+            disposeRegion = true;
+        }
+        else {
+            regionBmp = windowBmp;
+            disposeRegion = false;
+        }
+        try {
+            CommandResult result = FinishOcr(
+                regionBmp,
+                win,
+                regionRelativeTo: HasRegion ? "window" : null,
+                regionX: HasRegion ? X : 0,
+                regionY: HasRegion ? Y : 0);
+            if (usedFallback) {
+                result.Warn("ocr-fallback",
+                    "PrintWindow was refused; OCR ran on an on-screen blit, which may be wrong for composited/occluded surfaces.");
+            }
+            return result;
+        }
+        finally {
+            if (disposeRegion) {
+                regionBmp.Dispose();
+            }
+        }
+    }
+
+    /// <summary>Virtual seam so tests can stub window capture without touching the desktop.</summary>
+    protected virtual Bitmap CaptureWindowBitmap(WindowInfo win, out bool usedFallback) {
+        CaptureResult cap = ScreenCapture.CaptureWindow(new IntPtr(win.Handle));
+        usedFallback = cap.UsedFallback;
+        using MemoryStream ms = new(cap.Png);
+        return new Bitmap(ms);
+    }
+
+    /// <summary>Virtual seam so tests can stub OCR without requiring a language pack.</summary>
+    protected virtual RegionOcrResult Recognize(Bitmap bitmap) => RegionOcr.Recognize(bitmap);
+
+    private string? TryCropWindowRegion(Bitmap windowBmp, out Bitmap cropped) {
+        string? sizeError = ScreenCapture.ValidateRegionSize(Width, Height);
+        if (sizeError is not null) {
+            cropped = windowBmp;
+            return sizeError;
+        }
+
+        if (X < 0 || Y < 0 || X + Width > windowBmp.Width || Y + Height > windowBmp.Height) {
+            cropped = windowBmp;
+            return $"Region ({X},{Y}) {Width}x{Height} is outside the {windowBmp.Width}x{windowBmp.Height} window capture. " +
+                   "Re-query for fresh bounds or shrink the region.";
+        }
+
+        cropped = ScreenCapture.CropBitmap(windowBmp, X, Y, Width, Height);
+        return null;
+    }
+
+    private CommandResult FinishOcr(
+        Bitmap bmp,
+        WindowInfo? target,
+        string? regionRelativeTo,
+        int regionX,
+        int regionY) {
+        ImageStats blank = ScreenCapture.AnalyzeBlank(bmp);
+        JsonObject data = BuildData(bmp, target, regionRelativeTo, regionX, regionY, blank);
+
+        if (blank.IsBlank) {
+            string code = blank.DominantIsDark ? "frame-all-black" : "frame-uniform";
+            string detail = "Captured region is blank (a flat fill); the window may be minimized, cloaked, or off-screen.";
+            AgentRuntime.Audit(Cmd, $"blank frame ({code}, dominant {blank.DominantFraction:P0})");
+            return CommandResult.Fail(Cmd, detail, code, "ocr-blank", data);
+        }
+
+        RegionOcrResult ocr = Recognize(bmp);
+        data["text"] = ocr.Text;
+        data["lineCount"] = ocr.LineCount;
+        data["wordCount"] = ocr.WordCount;
+        if (!string.IsNullOrEmpty(ocr.Language)) {
+            data["language"] = ocr.Language;
+        }
+
+        if (string.IsNullOrWhiteSpace(ocr.Text)) {
+            AgentRuntime.Audit(Cmd, "ocr returned no text");
+            return CommandResult.Fail(Cmd,
+                "OCR could not read any text in the region (low contrast, unsupported script, or too small). " +
+                "Try a larger region, foreground the window, or fall back to capture.",
+                "ocr-no-text", "internal", data);
+        }
+
+        AgentRuntime.Audit(Cmd, $"ocr {ocr.WordCount} word(s), {ocr.LineCount} line(s)");
+        return CommandResult.Ok(Cmd, data);
+    }
+
+    private JsonObject BuildData(
+        Bitmap bmp,
+        WindowInfo? target,
+        string? regionRelativeTo,
+        int regionX,
+        int regionY,
+        ImageStats blank) {
+        JsonObject data = new() {
+            ["width"] = bmp.Width,
+            ["height"] = bmp.Height,
+            ["blankCheck"] = BlankCheckJson(blank),
+        };
+
+        if (regionRelativeTo is not null) {
+            data["region"] = new JsonObject {
+                ["x"] = regionX,
+                ["y"] = regionY,
+                ["width"] = HasRegion ? Width : bmp.Width,
+                ["height"] = HasRegion ? Height : bmp.Height,
+                ["relativeTo"] = regionRelativeTo,
+            };
+        }
+
+        if (target is not null) {
+            data["window"] = target.ToJsonObject();
+        }
+
+        return data;
+    }
+
+    private static JsonObject BlankCheckJson(ImageStats stats) => new() {
+        ["blank"] = stats.IsBlank,
+        ["dominantFraction"] = Math.Round(stats.DominantFraction, 4),
+        ["dominantIsDark"] = stats.DominantIsDark,
+    };
+
+    private static string DescribeWindowTarget(WindowInfo win) =>
+        $"window 0x{win.Handle:X} \"{win.Title}\" ({win.ProcessName})";
+}

--- a/src/Commands/GetTextCommand.cs
+++ b/src/Commands/GetTextCommand.cs
@@ -70,6 +70,11 @@ public class GetTextCommand : WindowTargetingAgentCommand {
             AgentRuntime.Audit(Cmd, "ocr unavailable");
             return CommandResult.Fail(Cmd, e.Message, "ocr-unavailable", "internal");
         }
+        catch (ArgumentException e) when (e.Message.Contains("OCR", StringComparison.OrdinalIgnoreCase) || e.Message.Contains("dimension", StringComparison.OrdinalIgnoreCase) || e.Message.Contains("exceed", StringComparison.OrdinalIgnoreCase)) {
+            // CR P2 (PR 334): oversized for OCR -> invalid-argument so agent can shrink region (distinct from ocr-unavailable).
+            AgentRuntime.Audit(Cmd, "ocr region exceeds engine limit");
+            return CommandResult.Fail(Cmd, e.Message, "ocr-image-too-large", "invalid-argument");
+        }
         catch (Exception e) {
             Logger.Instance.Log4.Error($"{GetType().Name}: get-text failed: {e.Message}");
             return CommandResult.Fail(Cmd, $"get-text failed: {e.Message}", "get-text-exception", "internal");
@@ -130,8 +135,12 @@ public class GetTextCommand : WindowTargetingAgentCommand {
     protected virtual Bitmap CaptureWindowBitmap(WindowInfo win, out bool usedFallback) {
         CaptureResult cap = ScreenCapture.CaptureWindow(new IntPtr(win.Handle));
         usedFallback = cap.UsedFallback;
+        // CR P1 (PR 334): Bitmap(Stream) requires the stream to stay open for the Bitmap lifetime.
+        // Decode while open, then clone the pixels so the returned Bitmap is independent and the
+        // temp stream can be disposed. Downstream AnalyzeBlank/RegionOcr (which Save again) stay safe.
         using MemoryStream ms = new(cap.Png);
-        return new Bitmap(ms);
+        using Bitmap tmp = new Bitmap(ms);
+        return new Bitmap(tmp);
     }
 
     /// <summary>Virtual seam so tests can stub OCR without requiring a language pack.</summary>
@@ -183,7 +192,7 @@ public class GetTextCommand : WindowTargetingAgentCommand {
             return CommandResult.Fail(Cmd,
                 "OCR could not read any text in the region (low contrast, unsupported script, or too small). " +
                 "Try a larger region, foreground the window, or fall back to capture.",
-                "ocr-no-text", "internal", data);
+                "ocr-no-text", "ocr-no-text", data);
         }
 
         AgentRuntime.Audit(Cmd, $"ocr {ocr.WordCount} word(s), {ocr.LineCount} line(s)");

--- a/src/MCEControl.csproj
+++ b/src/MCEControl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net10.0-windows</TargetFramework>
+        <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
         <UseWindowsForms>true</UseWindowsForms>
         <ApplicationIcon>Resources\Guillen.Icon.ico</ApplicationIcon>
         <!-- v3.0: the executable is now `mcec.exe`. RootNamespace stays `MCEControl` (internal only)
@@ -45,6 +45,7 @@
         <PackageReference Include="FlaUI.UIA3" Version="5.0.0" />
         <PackageReference Include="log4net" Version="3.3.2" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="System.IO.Ports" Version="10.0.9" />
         <PackageReference Include="System.Text.Json" Version="10.0.9" />

--- a/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
+++ b/tests/MCEControl.xUnit/Agent/AgentToolResultTests.cs
@@ -19,7 +19,7 @@ namespace MCEControl.xUnit.Agent;
 public class AgentToolResultTests {
     private static readonly HashSet<string> _categoryEnum = [
         "timeout", "ambiguous-selector", "stale-element", "no-target", "invalid-argument",
-        "capture-blank", "focus", "elevation", "foreground", "internal",
+        "capture-blank", "ocr-blank", "ocr-no-text", "focus", "elevation", "foreground", "internal",
     ];
 
     /// <summary>Asserts an emitted envelope honors the schema's required-field and success/failure invariants.</summary>
@@ -134,6 +134,8 @@ public class AgentToolResultTests {
     [InlineData(AgentErrorCategory.NoTarget, "no-target")]
     [InlineData(AgentErrorCategory.InvalidArgument, "invalid-argument")]
     [InlineData(AgentErrorCategory.CaptureBlank, "capture-blank")]
+    [InlineData(AgentErrorCategory.OcrBlank, "ocr-blank")]
+    [InlineData(AgentErrorCategory.OcrNoText, "ocr-no-text")]
     [InlineData(AgentErrorCategory.Focus, "focus")]
     [InlineData(AgentErrorCategory.Elevation, "elevation")]
     [InlineData(AgentErrorCategory.Foreground, "foreground")]
@@ -289,5 +291,20 @@ public class AgentToolResultTests {
         Assert.Contains("\"ok\":true", json);
         Assert.DoesNotContain("sessionId", json); // null -> omitted
         Assert.DoesNotContain("\"error\"", json);
+    }
+
+    [Fact]
+    public void FromCommandResult_OcrBlankCategory_MapsToOcrBlank_NotInternal() {
+        // Addresses CR P2 on PR 334: get-text emits errorCategory "ocr-blank" for blank frames;
+        // FromCommandResult must map it (not downgrade to internal) so MCP clients and schema see it.
+        CommandResult command = CommandResult
+            .Fail("get-text", "Captured region is blank (a flat fill).", "frame-all-black", "ocr-blank");
+
+        JsonObject env = AgentToolResult.FromCommandResult(command, "get-text").ToJsonObject();
+
+        AssertValidEnvelope(env);
+        Assert.False(env["ok"]!.GetValue<bool>());
+        Assert.Equal("ocr-blank", env["error"]!["category"]!.GetValue<string>());
+        Assert.Equal("frame-all-black", env["error"]!["code"]!.GetValue<string>());
     }
 }

--- a/tests/MCEControl.xUnit/Agent/ScreenCaptureCropTests.cs
+++ b/tests/MCEControl.xUnit/Agent/ScreenCaptureCropTests.cs
@@ -1,0 +1,24 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Drawing;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Agent;
+
+public class ScreenCaptureCropTests {
+    [Fact]
+    public void CropBitmap_ValidSubrect_ReturnsClone() {
+        using Bitmap source = new(100, 80);
+        using Bitmap cropped = ScreenCapture.CropBitmap(source, 10, 20, 30, 40);
+        Assert.Equal(30, cropped.Width);
+        Assert.Equal(40, cropped.Height);
+    }
+
+    [Fact]
+    public void CropBitmap_OutOfBounds_Throws() {
+        using Bitmap source = new(50, 50);
+        Assert.Throws<ArgumentException>(() => ScreenCapture.CropBitmap(source, 40, 40, 20, 20));
+    }
+}

--- a/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
+++ b/tests/MCEControl.xUnit/Agent/ToolCatalogTests.cs
@@ -18,7 +18,7 @@ namespace MCEControl.xUnit.Agent;
 public class ToolCatalogTests {
     /// <summary>The thirteen gated agent tools, in the order tools/list advertises them. Pinned by name.</summary>
     private static readonly string[] _catalogNames = [
-        "capture", "query", "displays", "windows", "window", "find", "wait-for", "invoke", "drag", "click", "focus", "clipboard", "record", "launch",
+        "capture", "get-text", "query", "displays", "windows", "window", "find", "wait-for", "invoke", "drag", "click", "focus", "clipboard", "record", "launch",
     ];
 
     /// <summary>The meta-tools that are deliberately NOT in the catalog (no 1:1 Command mapping), in tools/list order.</summary>
@@ -94,7 +94,7 @@ public class ToolCatalogTests {
 
     [Fact]
     public void IsObservation_ExactlyQueryCaptureFindWaitFor() {
-        string[] observation = ["query", "capture", "find", "wait-for"];
+        string[] observation = ["query", "capture", "get-text", "find", "wait-for"];
         foreach (ToolDescriptor d in ToolCatalog.All) {
             Assert.Equal(observation.Contains(d.Name), d.IsObservation);
         }
@@ -120,7 +120,7 @@ public class ToolCatalogTests {
         }
         // SessionProvisioner.DefaultCommands is derived from the catalog; pin the exact historical set.
         Assert.Equal(
-            ["capture", "query", "displays", "windows", "window", "find", "wait-for", "invoke", "drag", "click", "focus", "clipboard", "record"],
+            ["capture", "get-text", "query", "displays", "windows", "window", "find", "wait-for", "invoke", "drag", "click", "focus", "clipboard", "record"],
             SessionProvisioner.DefaultCommands);
     }
 
@@ -128,6 +128,7 @@ public class ToolCatalogTests {
     public void BuildCommand_EveryTool_ProducesItsCommandType() {
         Dictionary<string, Type> expected = new() {
             ["capture"] = typeof(CaptureCommand),
+            ["get-text"] = typeof(GetTextCommand),
             ["query"] = typeof(QueryCommand),
             ["displays"] = typeof(DisplaysCommand),
             ["windows"] = typeof(WindowsCommand),

--- a/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
+++ b/tests/MCEControl.xUnit/Commands/AgentCommandStructuralGateTests.cs
@@ -25,7 +25,7 @@ public class AgentCommandStructuralGateTests {
     /// <c>ToolCatalogTests</c> pins the same list against the catalog itself.
     /// </summary>
     private static readonly string[] _gatedToolNames = [
-        "capture", "query", "displays", "windows", "window", "find", "wait-for", "invoke", "record", "launch", "drag", "click", "focus", "clipboard",
+        "capture", "get-text", "query", "displays", "windows", "window", "find", "wait-for", "invoke", "record", "launch", "drag", "click", "focus", "clipboard",
     ];
 
     public static TheoryData<string> GatedToolNameData {

--- a/tests/MCEControl.xUnit/Commands/GetTextCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/GetTextCommandTests.cs
@@ -1,7 +1,9 @@
 // Copyright © Kindel, LLC - http://www.kindel.com
 // Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
 
+using System;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Text.Json.Nodes;
 using Xunit;
 using MCEControl;
@@ -146,6 +148,76 @@ public class GetTextCommandTests {
         g.DrawLine(Pens.Black, 0, 0, w - 1, h - 1);
         g.DrawString("sample", SystemFonts.DefaultFont, Brushes.Black, 4, 4);
         return bmp;
+    }
+
+    [Fact]
+    public void Execute_BlankFrame_ReturnsOcrBlankCategory() {
+        // Addresses CR feedback P2 (ocr-blank mapping) on PR 334. Blank detection happens before OCR.
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            // solid-color small bitmap will be detected blank by AnalyzeBlank
+            StubGetTextCommand cmd = new() {
+                Cmd = "get-text",
+                Enabled = true,
+                Reply = reply,
+                Window = "Stub",
+                StubWindowBitmap = new Bitmap(8, 8),  // default pixels -> blank dominant
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.Equal("ocr-blank", json["errorCategory"]!.GetValue<string>());
+            Assert.Contains("blank", json["error"]!.GetValue<string>(), StringComparison.OrdinalIgnoreCase);
+            Assert.False(cmd.OcrCalled); // never reached OCR
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void RegionOcr_TooLargeImage_ThrowsEarly_WithClearMessage() {
+        // Addresses CR P2 on PR 334: before calling RecognizeAsync (which would fail inside OCR for dims > Max),
+        // RegionOcr must check against OcrEngine.MaxImageDimension and fail fast with invalid-argument path.
+        // Uses early check so test runs even when no OCR language pack is installed on the test agent.
+        uint max = Windows.Media.Ocr.OcrEngine.MaxImageDimension;
+        int tooBig = (int)max + 1;
+        using Bitmap huge = new(tooBig, 4);  // width exceeds
+
+        var ex = Assert.Throws<ArgumentException>(() => RegionOcr.Recognize(huge));
+        Assert.Contains("exceed", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OCR", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BitmapFromPngBytes_RemainsUsableAfterStreamClosed() {
+        // Addresses CR P1 on PR 334 (stream lifetime): documents the Bitmap(Stream) contract.
+        // The GetTextCommand window path must not hand out a Bitmap whose backing stream was disposed
+        // by the time FinishOcr / AnalyzeBlank / RegionOcr.ToSoftwareBitmap run.
+        using Bitmap original = NonBlankBitmap(16, 16);
+        using var save = new MemoryStream();
+        original.Save(save, ImageFormat.Png);
+        byte[] png = save.ToArray();
+
+        Bitmap? bmp;
+        using (var ms = new MemoryStream(png)) {
+            bmp = new Bitmap(ms);
+            // stream goes out of scope / disposed here -- simulates end of CaptureWindowBitmap
+        }
+
+        // Use like the real path does (GetPixels in AnalyzeBlank; Save in RegionOcr)
+        ImageStats stats = ScreenCapture.AnalyzeBlank(bmp!);
+        Assert.False(stats.IsBlank);
+
+        using var rt = new MemoryStream();
+        bmp!.Save(rt, ImageFormat.Png);
+        Assert.True(rt.Length > 100);
+
+        bmp!.Dispose();
     }
 
 }

--- a/tests/MCEControl.xUnit/Commands/GetTextCommandTests.cs
+++ b/tests/MCEControl.xUnit/Commands/GetTextCommandTests.cs
@@ -1,0 +1,151 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Drawing;
+using System.Text.Json.Nodes;
+using Xunit;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+[Collection("AgentSerial")]
+public class GetTextCommandTests {
+    [Fact]
+    public void Constructor_DisabledByDefault() {
+        GetTextCommand cmd = new();
+        Assert.False(cmd.Enabled);
+    }
+
+    [Fact]
+    public void BuiltInCommands_NonEmpty_ContainsGetText() {
+        List<Command> builtIns = GetTextCommand.BuiltInCommands;
+        Assert.NotEmpty(builtIns);
+        Assert.Contains(builtIns, c => c.Cmd == "get-text");
+    }
+
+    [Fact]
+    public void Execute_OversizedRegion_FailsWithRegionTooLarge_BeforeCapturing() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            GetTextCommand cmd = new() {
+                Cmd = "get-text", Enabled = true, Reply = reply, X = 0, Y = 0, Width = 40000, Height = 40000,
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.False(json["success"]!.GetValue<bool>());
+            Assert.Equal("region-too-large", json["errorCode"]!.GetValue<string>());
+            Assert.Equal("invalid-argument", json["errorCategory"]!.GetValue<string>());
+            Assert.Null(json["data"]);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_WindowRegionOutOfBounds_FailsBeforeOcr() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            StubGetTextCommand cmd = new() {
+                Cmd = "get-text",
+                Enabled = true,
+                Reply = reply,
+                Window = "Stub",
+                X = 90,
+                Y = 90,
+                Width = 20,
+                Height = 20,
+                StubWindowBitmap = new Bitmap(100, 100),
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.Equal("region-out-of-bounds", json["errorCode"]!.GetValue<string>());
+            Assert.Equal("invalid-argument", json["errorCategory"]!.GetValue<string>());
+            Assert.False(cmd.OcrCalled);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_WindowRegion_ReturnsOcrText() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            StubGetTextCommand cmd = new() {
+                Cmd = "get-text",
+                Enabled = true,
+                Reply = reply,
+                Window = "Stub",
+                X = 10,
+                Y = 20,
+                Width = 30,
+                Height = 40,
+                StubWindowBitmap = NonBlankBitmap(100, 100),
+                StubOcrResult = new RegionOcrResult("hello world", 1, 2, "en-US"),
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.True(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.True(json["success"]!.GetValue<bool>());
+            JsonObject data = json["data"]!.AsObject();
+            Assert.Equal("hello world", data["text"]!.GetValue<string>());
+            Assert.Equal(2, data["wordCount"]!.GetValue<int>());
+            Assert.Equal("window", data["region"]!["relativeTo"]!.GetValue<string>());
+            Assert.True(cmd.OcrCalled);
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_OcrEmptyText_FailsWithOcrNoText() {
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        try {
+            CapturingReply reply = new();
+            StubGetTextCommand cmd = new() {
+                Cmd = "get-text",
+                Enabled = true,
+                Reply = reply,
+                Window = "Stub",
+                StubWindowBitmap = NonBlankBitmap(100, 100),
+                StubOcrResult = new RegionOcrResult("", 0, 0, "en-US"),
+            };
+
+            bool result = cmd.Execute();
+
+            Assert.False(result);
+            JsonObject json = JsonNode.Parse(reply.Captured.Trim())!.AsObject();
+            Assert.Equal("ocr-no-text", json["errorCode"]!.GetValue<string>());
+        }
+        finally {
+            AgentRuntime.Settings = null;
+        }
+    }
+
+    private static Bitmap NonBlankBitmap(int w, int h) {
+        Bitmap bmp = new(w, h);
+        using Graphics g = Graphics.FromImage(bmp);
+        g.Clear(Color.White);
+        g.DrawLine(Pens.Black, 0, 0, w - 1, h - 1);
+        g.DrawString("sample", SystemFonts.DefaultFont, Brushes.Black, 4, 4);
+        return bmp;
+    }
+
+}

--- a/tests/MCEControl.xUnit/Commands/StubGetTextCommand.cs
+++ b/tests/MCEControl.xUnit/Commands/StubGetTextCommand.cs
@@ -1,0 +1,27 @@
+// Copyright © Kindel, LLC - http://www.kindel.com
+// Published under the MIT License - Source on GitHub: https://github.com/tig/mcec
+
+using System.Drawing;
+using MCEControl;
+
+namespace MCEControl.xUnit.Commands;
+
+/// <summary>Test double for <see cref="GetTextCommand"/> that stubs window capture and OCR.</summary>
+internal sealed class StubGetTextCommand : GetTextCommand {
+    public Bitmap? StubWindowBitmap { get; init; }
+    public RegionOcrResult? StubOcrResult { get; init; }
+    public bool OcrCalled { get; private set; }
+
+    protected override WindowInfo? TryResolveWindow() =>
+        new() { Handle = 0x123, Title = "Stub", ProcessName = "stub" };
+
+    protected override Bitmap CaptureWindowBitmap(WindowInfo win, out bool usedFallback) {
+        usedFallback = false;
+        return (Bitmap)StubWindowBitmap!.Clone();
+    }
+
+    protected override RegionOcrResult Recognize(Bitmap bitmap) {
+        OcrCalled = true;
+        return StubOcrResult!;
+    }
+}

--- a/tests/MCEControl.xUnit/MCEControl.xUnit.csproj
+++ b/tests/MCEControl.xUnit/MCEControl.xUnit.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net10.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
 		<UseWindowsForms>true</UseWindowsForms>
 		<IsPackable>false</IsPackable>
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
+++ b/tests/MCEControl.xUnit/Services/RequestCommandAccessTests.cs
@@ -252,7 +252,7 @@ public class RequestCommandAccessTests : IDisposable {
 
     [Fact]
     public void ServedWhilePending_IsAnObservationOnlyAllowList() {
-        foreach (string tool in (string[])["capture", "query", "displays", "windows", "find", "wait-for", "record"]) {
+        foreach (string tool in (string[])["capture", "get-text", "query", "displays", "windows", "find", "wait-for", "record"]) {
             Assert.True(AgentToolExecutor.ServedWhileConsentPending(tool), tool);
         }
         foreach (string tool in (string[])["invoke", "drag", "click", "focus", "clipboard", "launch", "send_command", "request-command-access"]) {


### PR DESCRIPTION
## Summary

Adds the `get-text` observation tool requested in #331: a cheap text read from a screen/window region using Windows built-in OCR, so agents can verify opaque web surfaces without full PNG `capture` round-trips.

## What changed

- **`get-text` tool** registered in `ToolCatalog` (observation, provisioned-by-default, served during consent)
- **`GetTextCommand`** with the same targeting model as `capture`:
  - screen-absolute region (`x`/`y`/`width`/`height` only)
  - full window (window selector only)
  - window-relative sub-region (window selector + `x`/`y`/`width`/`height`)
- **`RegionOcr`** using `Windows.Media.Ocr` (requires OCR language pack; fails with `ocr-unavailable`)
- Clear failure modes: `ocr-blank`, `ocr-no-text`, `region-out-of-bounds`, `region-too-large`
- **`AgentInstructions.md`** updated to prefer `get-text` over `capture` for web field verification
- TFM bumped to `net10.0-windows10.0.26100.0` for WinRT OCR APIs

## Testing

- Full suite: `dotnet test` — 1047 passed
- New tests: `GetTextCommandTests`, `ScreenCaptureCropTests`, catalog/gate pins updated

Closes #331