### PR TITLE
Expose enabled vs gated commands at connect time (#324)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,10 +104,12 @@ Three safety features layer on top (see [`docs/safety-emergency-stop-and-provisi
   constrained). Grants land on the key `CommandInvoker.ResolveGateKey` resolves (the entry Enqueue
   actually gates on); route any new name-resolution through that one resolver. To spare the agent
   discovering the gated set one `command-disabled` at a time (#324), the `initialize` result carries a
-  `commandAccess` map (`enabledTools`/`gatedTools`/`rawSendCommandGated`) derived from
+  `commandAccess` map (`enabledTools`/`gatedTools`/`enabledRawCommands`) derived from
   `ToolCatalog.CommandAccessDefaults` (the `ProvisionedByDefault` flags — single source of truth, so it
   never drifts as defaults change), and `session-status` stamps the LIVE table via
-  `AgentToolExecutor.LiveCommandAccess`; keep both derived, never a hand-typed list.
+  `AgentToolExecutor.LiveCommandAccess`; keep both derived, never a hand-typed list. `enabledRawCommands`
+  is an explicit list, not a canary boolean, so a partial raw grant (only `chars:`) can't read as the whole
+  raw `send_command` surface being open (#340 CR).
 
 ## Dogfood: test MCEC using MCEC (mcec drives mcec)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,12 @@ Three safety features layer on top (see [`docs/safety-emergency-stop-and-provisi
   as never-a-target. Do not weaken any of the three, do not persist grants, and do not replace the
   dialog with MCP elicitation (that routes consent through the agent's own client; the party being
   constrained). Grants land on the key `CommandInvoker.ResolveGateKey` resolves (the entry Enqueue
-  actually gates on); route any new name-resolution through that one resolver.
+  actually gates on); route any new name-resolution through that one resolver. To spare the agent
+  discovering the gated set one `command-disabled` at a time (#324), the `initialize` result carries a
+  `commandAccess` map (`enabledTools`/`gatedTools`/`rawSendCommandGated`) derived from
+  `ToolCatalog.CommandAccessDefaults` (the `ProvisionedByDefault` flags — single source of truth, so it
+  never drifts as defaults change), and `session-status` stamps the LIVE table via
+  `AgentToolExecutor.LiveCommandAccess`; keep both derived, never a hand-typed list.
 
 ## Dogfood: test MCEC using MCEC (mcec drives mcec)
 

--- a/docs/agent_control.md
+++ b/docs/agent_control.md
@@ -118,9 +118,11 @@ command whose `Enabled=false` is refused (`error.code: command-disabled`) even w
 instance only) only if you allow it; see
 [command-access consent](safety-emergency-stop-and-provisioning.md). So the agent need not discover the
 gated set by trial and error, the MCP `initialize` result carries a `commandAccess` map
-(`enabledTools`/`gatedTools`/`rawSendCommandGated`) derived from the tool catalog's provisioning defaults,
+(`enabledTools`/`gatedTools`/`enabledRawCommands`) derived from the tool catalog's provisioning defaults,
 and `session-status` reports the same shape live; an agent reads it at connect time and batches one
-`request-command-access` for everything it needs up front (#324).
+`request-command-access` for everything it needs up front (#324). `enabledRawCommands` is an explicit list
+(not a boolean), so a partial raw grant — say the operator enables only `chars:` — reports exactly that
+command and never implies `winr`/`mouse:`/VK/chord commands are open too.
 
 **`send_command` is transport-sensitive.** It is a raw pass-through to the existing command engine,
 so it is a command-injection surface. Over the **local stdio** transport (`mcec.exe --mcp`, launched by its
@@ -292,7 +294,7 @@ tools:
 - **`session-status`** returns a session's remembered state (active target, last
   observation/action/error, artifact dir, any emergency stop). Pass `sessionId` to inspect a
   specific session, or omit it for the default. Its result also carries a live `commandAccess`
-  block (`enabledTools`/`gatedTools`/`rawSendCommandGated`) reflecting the current command table, so
+  block (`enabledTools`/`gatedTools`/`enabledRawCommands`) reflecting the current command table, so
   an agent can confirm a grant landed (see [Command access](#command-access)).
 - **`session-end`** frees a session's server-side state. It is idempotent (ending an unknown or
   already-ended id reports `ended: false` rather than erroring). Afterward a tool call that still

--- a/docs/agent_control.md
+++ b/docs/agent_control.md
@@ -116,7 +116,11 @@ command whose `Enabled=false` is refused (`error.code: command-disabled`) even w
 `AgentCommandsEnabled=true`. An agent can recover from `command-disabled` mid-session with the
 `request-command-access` tool, which asks **you** on-screen and enables the command (in-memory, that
 instance only) only if you allow it; see
-[command-access consent](safety-emergency-stop-and-provisioning.md).
+[command-access consent](safety-emergency-stop-and-provisioning.md). So the agent need not discover the
+gated set by trial and error, the MCP `initialize` result carries a `commandAccess` map
+(`enabledTools`/`gatedTools`/`rawSendCommandGated`) derived from the tool catalog's provisioning defaults,
+and `session-status` reports the same shape live; an agent reads it at connect time and batches one
+`request-command-access` for everything it needs up front (#324).
 
 **`send_command` is transport-sensitive.** It is a raw pass-through to the existing command engine,
 so it is a command-injection surface. Over the **local stdio** transport (`mcec.exe --mcp`, launched by its
@@ -287,7 +291,9 @@ tools:
   echoed back on the result.
 - **`session-status`** returns a session's remembered state (active target, last
   observation/action/error, artifact dir, any emergency stop). Pass `sessionId` to inspect a
-  specific session, or omit it for the default.
+  specific session, or omit it for the default. Its result also carries a live `commandAccess`
+  block (`enabledTools`/`gatedTools`/`rawSendCommandGated`) reflecting the current command table, so
+  an agent can confirm a grant landed (see [Command access](#command-access)).
 - **`session-end`** frees a session's server-side state. It is idempotent (ending an unknown or
   already-ended id reports `ended: false` rather than erroring). Afterward a tool call that still
   echoes that id is refused with `error.code: unknown-session` (category `invalid-argument`); start

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -202,8 +202,10 @@ Recommended path: the operator enables "Allow agents to provision disposable ins
 > Agent, clicks "Provision new…", and hands you a disposable instance's directory, launch line, and
 token; connect to THAT copy's `mcec.exe --mcp` (or its HTTP endpoint when enabled) and do all work
 there. A provisioned session enables the standard observation/actuation tool set; `launch` and most
-`send_command` built-ins (e.g. `chars:`) start disabled — batch `request-command-access` for what you'll
-need up front (see COMMAND ACCESS), never by editing the session's files. The `token` is the
+`send_command` built-ins (e.g. `chars:`) start disabled — the `initialize` result's `commandAccess` field
+spells out the enabled vs gated set (and flags that raw `send_command` built-ins start gated), so read it
+and batch `request-command-access` for what you'll need up front (see COMMAND ACCESS), never by editing the
+session's files. The `token` is the
 session credential; keep it: every HTTP request to the session's `mcpEndpoint` must send the header
 `Authorization: Bearer <token>` (stdio needs no header), and `end-session` requires it when you tear down
 via the bootstrap server. When your task is done, tell the operator (they delete the instance from the Agent tab; you cannot remove
@@ -223,7 +225,11 @@ while `error.category` stays `internal`), the operator has not opted in; tell th
 on the Agent tab, then retry; do not retry blindly before they do. You own teardown: `end-session` every
 instance you provision.
 
-COMMAND ACCESS: any tool or raw command refused with `error.code:command-disabled` can be requested from
+COMMAND ACCESS: you do not have to discover the gated set by trial and error. The `initialize` result's
+`commandAccess` field lists `enabledTools` vs `gatedTools` and a `rawSendCommandGated` flag at connect time
+(and `session-status` reports the LIVE set, reflecting any grant already made), so read it and batch one
+request for everything your plan needs before the first actuation. Any tool or raw command refused with
+`error.code:command-disabled` can be requested from
 the OPERATOR with the `request-command-access` tool: pass the command name(s) the refusal reported (e.g.
 `launch`, `chars:`) and a one-line, honest `reason`; MCEC shows the operator a consent dialog on their
 screen and your call BLOCKS (up to ~2 minutes) for their answer. On a grant the commands are immediately

--- a/src/Agent/AgentInstructions.md
+++ b/src/Agent/AgentInstructions.md
@@ -226,9 +226,11 @@ on the Agent tab, then retry; do not retry blindly before they do. You own teard
 instance you provision.
 
 COMMAND ACCESS: you do not have to discover the gated set by trial and error. The `initialize` result's
-`commandAccess` field lists `enabledTools` vs `gatedTools` and a `rawSendCommandGated` flag at connect time
-(and `session-status` reports the LIVE set, reflecting any grant already made), so read it and batch one
-request for everything your plan needs before the first actuation. Any tool or raw command refused with
+`commandAccess` field lists `enabledTools` vs `gatedTools` and `enabledRawCommands` (the raw `send_command`
+built-ins enabled right now; empty until granted) at connect time — and `session-status` reports the LIVE
+set, reflecting any grant already made — so read it and batch one request for everything your plan needs
+before the first actuation. A raw command NOT in `enabledRawCommands` still needs a request; a partial grant
+does not open the whole raw surface. Any tool or raw command refused with
 `error.code:command-disabled` can be requested from
 the OPERATOR with the `request-command-access` tool: pass the command name(s) the refusal reported (e.g.
 `launch`, `chars:`) and a one-line, honest `reason`; MCEC shows the operator a consent dialog on their

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -52,8 +52,10 @@ public static class ToolCatalog {
     internal const string CommandAccessNote =
         "Gated commands need the operator's consent before first use: call request-command-access with the " +
         "names you need, batched in ONE call, then actuate. Raw send_command built-ins (chars:, winr, mouse:, " +
-        "VK_* keys, key chords) start gated too and are requested the same way. Never edit mcec.commands / " +
-        "mcec.settings to self-grant.";
+        "VK_* keys, key chords) start gated and are requested the same way; enabledRawCommands lists the ones " +
+        "enabled RIGHT NOW (empty until granted), and any raw command not in that list still needs a request " +
+        "— a partial grant does NOT open the whole raw surface. Never edit mcec.commands / mcec.settings to " +
+        "self-grant.";
 
     /// <summary>
     /// The connect-time command-access map (#324): which agent tools a freshly provisioned session enables
@@ -61,25 +63,28 @@ public static class ToolCatalog {
     /// from the actual provisioning defaults (today only <c>launch</c> is gated). Served on the MCP
     /// <c>initialize</c> result so an agent can batch a single <c>request-command-access</c> for everything it
     /// needs before its first actuation, instead of discovering the gated set one <c>command-disabled</c>
-    /// refusal at a time. Raw <c>send_command</c> built-ins are never provisioned by default, so the flag is
-    /// always set here; <see cref="AgentToolExecutor.LiveCommandAccess"/> reports the live table for a
-    /// re-check after a grant.
+    /// refusal at a time. No raw <c>send_command</c> built-in is provisioned by default, so
+    /// <c>enabledRawCommands</c> is empty here; <see cref="AgentToolExecutor.LiveCommandAccess"/> reports the
+    /// live table (which raw commands a grant has since enabled) for a re-check.
     /// </summary>
     public static JsonObject CommandAccessDefaults() => CommandAccessMap(
-        enabled: All.Where(d => d.ProvisionedByDefault).Select(d => d.Name),
-        gated: All.Where(d => !d.ProvisionedByDefault).Select(d => d.Name),
-        rawSendCommandGated: true);
+        enabledTools: All.Where(d => d.ProvisionedByDefault).Select(d => d.Name),
+        gatedTools: All.Where(d => !d.ProvisionedByDefault).Select(d => d.Name),
+        enabledRawCommands: []);
 
     /// <summary>
     /// Builds the <c>commandAccess</c> block shared by <c>initialize</c> (the provisioning defaults) and
-    /// <c>session-status</c> (the live table): the enabled/gated tool split, the raw-<c>send_command</c>
-    /// flag, and the shared recovery <see cref="CommandAccessNote"/>. One builder so both surfaces render the
-    /// exact same shape and guidance.
+    /// <c>session-status</c> (the live table): the enabled/gated tool split, the list of enabled raw
+    /// <c>send_command</c> built-ins, and the shared recovery <see cref="CommandAccessNote"/>. One builder so
+    /// both surfaces render the exact same shape and guidance. <paramref name="enabledRawCommands"/> is an
+    /// explicit list (not a boolean) so a PARTIAL raw grant — e.g. the operator enabled only <c>chars:</c> —
+    /// reports exactly that one and never implies <c>winr</c>/<c>mouse:</c>/VK/chord commands are open too
+    /// (#340 CR).
     /// </summary>
-    internal static JsonObject CommandAccessMap(IEnumerable<string> enabled, IEnumerable<string> gated, bool rawSendCommandGated) => new() {
-        ["enabledTools"] = NamesArray(enabled),
-        ["gatedTools"] = NamesArray(gated),
-        ["rawSendCommandGated"] = rawSendCommandGated,
+    internal static JsonObject CommandAccessMap(IEnumerable<string> enabledTools, IEnumerable<string> gatedTools, IEnumerable<string> enabledRawCommands) => new() {
+        ["enabledTools"] = NamesArray(enabledTools),
+        ["gatedTools"] = NamesArray(gatedTools),
+        ["enabledRawCommands"] = NamesArray(enabledRawCommands),
         ["note"] = CommandAccessNote,
     };
 

--- a/src/Agent/ToolCatalog.cs
+++ b/src/Agent/ToolCatalog.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
 
 namespace MCEControl;
@@ -41,6 +42,53 @@ public static class ToolCatalog {
         }
         descriptor = null!;
         return false;
+    }
+
+    /// <summary>
+    /// The one-line recovery note shared by every <c>commandAccess</c> block (#324): how to turn a gated
+    /// command into an enabled one. Held here (not typed into each surface) so the guidance can never drift
+    /// between <c>initialize</c> and <c>session-status</c>.
+    /// </summary>
+    internal const string CommandAccessNote =
+        "Gated commands need the operator's consent before first use: call request-command-access with the " +
+        "names you need, batched in ONE call, then actuate. Raw send_command built-ins (chars:, winr, mouse:, " +
+        "VK_* keys, key chords) start gated too and are requested the same way. Never edit mcec.commands / " +
+        "mcec.settings to self-grant.";
+
+    /// <summary>
+    /// The connect-time command-access map (#324): which agent tools a freshly provisioned session enables
+    /// vs leaves gated, derived from <see cref="ToolDescriptor.ProvisionedByDefault"/> so it can never drift
+    /// from the actual provisioning defaults (today only <c>launch</c> is gated). Served on the MCP
+    /// <c>initialize</c> result so an agent can batch a single <c>request-command-access</c> for everything it
+    /// needs before its first actuation, instead of discovering the gated set one <c>command-disabled</c>
+    /// refusal at a time. Raw <c>send_command</c> built-ins are never provisioned by default, so the flag is
+    /// always set here; <see cref="AgentToolExecutor.LiveCommandAccess"/> reports the live table for a
+    /// re-check after a grant.
+    /// </summary>
+    public static JsonObject CommandAccessDefaults() => CommandAccessMap(
+        enabled: All.Where(d => d.ProvisionedByDefault).Select(d => d.Name),
+        gated: All.Where(d => !d.ProvisionedByDefault).Select(d => d.Name),
+        rawSendCommandGated: true);
+
+    /// <summary>
+    /// Builds the <c>commandAccess</c> block shared by <c>initialize</c> (the provisioning defaults) and
+    /// <c>session-status</c> (the live table): the enabled/gated tool split, the raw-<c>send_command</c>
+    /// flag, and the shared recovery <see cref="CommandAccessNote"/>. One builder so both surfaces render the
+    /// exact same shape and guidance.
+    /// </summary>
+    internal static JsonObject CommandAccessMap(IEnumerable<string> enabled, IEnumerable<string> gated, bool rawSendCommandGated) => new() {
+        ["enabledTools"] = NamesArray(enabled),
+        ["gatedTools"] = NamesArray(gated),
+        ["rawSendCommandGated"] = rawSendCommandGated,
+        ["note"] = CommandAccessNote,
+    };
+
+    private static JsonArray NamesArray(IEnumerable<string> names) {
+        JsonArray arr = [];
+        foreach (string name in names) {
+            arr.Add(name);
+        }
+        return arr;
     }
 
     private static Dictionary<string, ToolDescriptor> BuildIndex() {

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -280,20 +280,34 @@ public sealed class AgentToolExecutor {
     /// <see cref="ToolCatalog.CommandAccessDefaults"/>, but read from the actual loaded command table so it
     /// reflects any command the operator has since granted (via <c>request-command-access</c>) as enabled.
     /// Stamped onto <c>session-start</c>/<c>session-status</c> results so an agent can re-check the gated set
-    /// after a grant, where <c>initialize</c> only ever shows the provisioning defaults. A tool whose table
-    /// entry is missing or disabled is gated; <c>chars:</c> is the canary for the raw <c>send_command</c>
-    /// built-ins (a provisioned session enables none of them).
+    /// after a grant, where <c>initialize</c> only ever shows the provisioning defaults. A catalog tool whose
+    /// table entry is missing or disabled is gated; the raw <c>send_command</c> built-ins that are enabled
+    /// right now are enumerated explicitly into <c>enabledRawCommands</c>, so a PARTIAL grant (e.g. only
+    /// <c>chars:</c>) reports exactly that command and never implies the rest of the raw surface is open
+    /// (#340 CR).
     /// </summary>
     public JsonObject LiveCommandAccess() {
         CommandInvoker? invoker = _invoker();
-        List<string> enabled = [];
-        List<string> gated = [];
+        List<string> enabledTools = [];
+        List<string> gatedTools = [];
         foreach (ToolDescriptor descriptor in ToolCatalog.All) {
             bool on = (invoker?[descriptor.Name] as Command)?.Enabled == true;
-            (on ? enabled : gated).Add(descriptor.Name);
+            (on ? enabledTools : gatedTools).Add(descriptor.Name);
         }
-        bool rawSendCommandGated = (invoker?["chars:"] as Command)?.Enabled != true;
-        return ToolCatalog.CommandAccessMap(enabled, gated, rawSendCommandGated);
+        // The raw send_command built-ins currently enabled: every enabled table entry whose key is NOT a
+        // catalog tool (those are already reported above). Enumerating the actual table — instead of probing
+        // a single canary — is what makes a partial raw grant honest: `winr` disabled while `chars:` is
+        // granted shows chars: present and winr absent, so the agent knows winr still needs a request.
+        List<string> enabledRawCommands = [];
+        if (invoker is not null) {
+            foreach (System.Collections.DictionaryEntry entry in invoker) {
+                if (entry.Key is string key && entry.Value is Command { Enabled: true } && !ToolCatalog.Contains(key)) {
+                    enabledRawCommands.Add(key);
+                }
+            }
+            enabledRawCommands.Sort(StringComparer.Ordinal);
+        }
+        return ToolCatalog.CommandAccessMap(enabledTools, gatedTools, enabledRawCommands);
     }
 
     /// <summary>Adds the live <c>commandAccess</c> block (#324) to a session-status/start snapshot.</summary>

--- a/src/Services/AgentToolExecutor.cs
+++ b/src/Services/AgentToolExecutor.cs
@@ -272,7 +272,34 @@ public sealed class AgentToolExecutor {
     private JsonObject RunSessionStart() {
         AgentSession session = _startSession();
         AgentRuntime.Audit("session-start", session.SessionId);
-        return McpResult(AgentToolResult.Success(session.ToStatusJson(), session.SessionId));
+        return McpResult(AgentToolResult.Success(WithCommandAccess(session.ToStatusJson()), session.SessionId));
+    }
+
+    /// <summary>
+    /// The LIVE command-access map (#324) for the connected instance: the same shape as
+    /// <see cref="ToolCatalog.CommandAccessDefaults"/>, but read from the actual loaded command table so it
+    /// reflects any command the operator has since granted (via <c>request-command-access</c>) as enabled.
+    /// Stamped onto <c>session-start</c>/<c>session-status</c> results so an agent can re-check the gated set
+    /// after a grant, where <c>initialize</c> only ever shows the provisioning defaults. A tool whose table
+    /// entry is missing or disabled is gated; <c>chars:</c> is the canary for the raw <c>send_command</c>
+    /// built-ins (a provisioned session enables none of them).
+    /// </summary>
+    public JsonObject LiveCommandAccess() {
+        CommandInvoker? invoker = _invoker();
+        List<string> enabled = [];
+        List<string> gated = [];
+        foreach (ToolDescriptor descriptor in ToolCatalog.All) {
+            bool on = (invoker?[descriptor.Name] as Command)?.Enabled == true;
+            (on ? enabled : gated).Add(descriptor.Name);
+        }
+        bool rawSendCommandGated = (invoker?["chars:"] as Command)?.Enabled != true;
+        return ToolCatalog.CommandAccessMap(enabled, gated, rawSendCommandGated);
+    }
+
+    /// <summary>Adds the live <c>commandAccess</c> block (#324) to a session-status/start snapshot.</summary>
+    private JsonObject WithCommandAccess(JsonObject status) {
+        status["commandAccess"] = LiveCommandAccess();
+        return status;
     }
 
     /// <summary>
@@ -289,7 +316,7 @@ public sealed class AgentToolExecutor {
                 "unknown-session", AgentErrorCategory.InvalidArgument, sessionId!);
         }
         AgentRuntime.Audit("session-status", session.SessionId);
-        return McpResult(AgentToolResult.Success(session.ToStatusJson(), session.SessionId));
+        return McpResult(AgentToolResult.Success(WithCommandAccess(session.ToStatusJson()), session.SessionId));
     }
 
     /// <summary>

--- a/src/Services/JsonRpcDispatcher.cs
+++ b/src/Services/JsonRpcDispatcher.cs
@@ -87,18 +87,28 @@ public sealed class JsonRpcDispatcher {
         "the full connect-time instructions. When finished, stop the instance's mcec.exe, then call " +
         "end-session here with the sessionId AND token to delete it.";
 
-    private JsonObject BuildInitializeResult() => new() {
-        ["protocolVersion"] = ProtocolVersion,
-        ["capabilities"] = new JsonObject { ["tools"] = new JsonObject() },
-        ["serverInfo"] = new JsonObject {
-            ["name"] = "MCEC",
-            ["version"] = Application.ProductVersion,
-        },
-        // Built-in agent guidance: surfaced to the model by the MCP client so it knows how to drive
-        // MCEC effectively (the observe -> target -> act loop) and understands the security model. In
-        // bootstrap mode (#296) the playbook would teach refused tools, so serve the handoff recipe.
-        ["instructions"] = Program.ProvisioningBootstrapOnly ? BootstrapInstructions : _instructions(),
-    };
+    private JsonObject BuildInitializeResult() {
+        JsonObject result = new() {
+            ["protocolVersion"] = ProtocolVersion,
+            ["capabilities"] = new JsonObject { ["tools"] = new JsonObject() },
+            ["serverInfo"] = new JsonObject {
+                ["name"] = "MCEC",
+                ["version"] = Application.ProductVersion,
+            },
+            // Built-in agent guidance: surfaced to the model by the MCP client so it knows how to drive
+            // MCEC effectively (the observe -> target -> act loop) and understands the security model. In
+            // bootstrap mode (#296) the playbook would teach refused tools, so serve the handoff recipe.
+            ["instructions"] = Program.ProvisioningBootstrapOnly ? BootstrapInstructions : _instructions(),
+        };
+        // #324: the connect-time command-access map — which tools a provisioned session enables vs gates
+        // (launch + raw send_command built-ins start gated), derived from the ToolCatalog so an agent can
+        // batch ONE request-command-access up front instead of probing command-disabled one call at a time.
+        // Omitted in bootstrap mode, whose only tools are provision-session/end-session (no gated surface).
+        if (!Program.ProvisioningBootstrapOnly) {
+            result["commandAccess"] = ToolCatalog.CommandAccessDefaults();
+        }
+        return result;
+    }
 
     // -------------------------------------------------------------------------------------------
     // tools/list

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -88,8 +88,9 @@ public class AgentServerTests {
         Assert.Contains("invoke", enabled);
         Assert.Contains("launch", gated);
         Assert.DoesNotContain("launch", enabled);
-        // Raw send_command built-ins (chars:, winr, …) are never provisioned by default.
-        Assert.True(access["rawSendCommandGated"]!.GetValue<bool>());
+        // No raw send_command built-in (chars:, winr, …) is provisioned by default, so the enabled-raw list
+        // is empty at connect time.
+        Assert.Empty(Names(access["enabledRawCommands"]!.AsArray()));
         Assert.False(string.IsNullOrWhiteSpace(access["note"]!.GetValue<string>()));
 
         // Every gated tool the map names is a real advertised tool the agent could request (#324): the
@@ -886,8 +887,13 @@ public class AgentServerTests {
     public void Dispatch_SessionStatus_IncludesLiveCommandAccess_ReflectingTheTable() {
         // #324: unlike initialize (the provisioning DEFAULTS), session-status reports the LIVE table, so a
         // command the operator has since granted shows as enabled. Here `launch` is enabled in the table (a
-        // grant would look the same), so it must appear enabled and NOT gated; `chars:` enabled clears the
-        // raw-send_command flag; `invoke` absent from the table stays gated.
+        // grant would look the same), so it must appear enabled and NOT gated; `invoke` absent from the table
+        // stays gated.
+        //
+        // #340 CR: `chars:` is granted but `mouse:` is not. A partial raw grant must report ONLY chars: in
+        // enabledRawCommands — never imply the whole raw send_command surface (mouse:, winr, …) is open, which
+        // a single canary boolean did. `launch` is a catalog tool, so it belongs in enabledTools, NOT the raw
+        // list.
         AgentTestSupport.EnsureTelemetry();
         AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
         AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
@@ -895,16 +901,23 @@ public class AgentServerTests {
         AgentRuntime.Invoker = new CommandInvoker {
             ["launch"] = new LaunchCommand { Cmd = "launch", Enabled = true },
             ["chars:"] = new CharsCommand { Cmd = "chars:", Enabled = true },
+            ["mouse:"] = new MouseCommand { Cmd = "mouse:", Enabled = false },
         };
         try {
             JsonObject access = CallEnvelope(55, "session-status")["result"]!.AsObject()["commandAccess"]!.AsObject();
             List<string> enabled = Names(access["enabledTools"]!.AsArray());
             List<string> gated = Names(access["gatedTools"]!.AsArray());
+            List<string> enabledRaw = Names(access["enabledRawCommands"]!.AsArray());
 
             Assert.Contains("launch", enabled);   // enabled in the table (a grant would read the same)
             Assert.DoesNotContain("launch", gated);
             Assert.Contains("invoke", gated);      // absent from the table → gated
-            Assert.False(access["rawSendCommandGated"]!.GetValue<bool>()); // chars: enabled clears the flag
+
+            // The partial raw grant is honest: chars: present, mouse: (disabled) absent, and the catalog
+            // launch is NOT double-reported as a raw command.
+            Assert.Contains("chars:", enabledRaw);
+            Assert.DoesNotContain("mouse:", enabledRaw);
+            Assert.DoesNotContain("launch", enabledRaw);
         }
         finally {
             AgentRuntime.Settings = null;

--- a/tests/MCEControl.xUnit/Services/AgentServerTests.cs
+++ b/tests/MCEControl.xUnit/Services/AgentServerTests.cs
@@ -75,6 +75,41 @@ public class AgentServerTests {
     }
 
     [Fact]
+    public void Dispatch_Initialize_IncludesCommandAccessDefaults() {
+        // #324: connect-time discovery of the gated set, so an agent can batch one request-command-access
+        // instead of probing command-disabled per command. The map is derived from the ToolCatalog's
+        // ProvisionedByDefault flags (single source of truth), so today only `launch` is gated among tools.
+        JsonObject result = AgentServer.Dispatch(Request(1, "initialize"))!["result"]!.AsObject();
+        JsonObject access = result["commandAccess"]!.AsObject();
+
+        List<string> enabled = Names(access["enabledTools"]!.AsArray());
+        List<string> gated = Names(access["gatedTools"]!.AsArray());
+        Assert.Contains("capture", enabled);
+        Assert.Contains("invoke", enabled);
+        Assert.Contains("launch", gated);
+        Assert.DoesNotContain("launch", enabled);
+        // Raw send_command built-ins (chars:, winr, …) are never provisioned by default.
+        Assert.True(access["rawSendCommandGated"]!.GetValue<bool>());
+        Assert.False(string.IsNullOrWhiteSpace(access["note"]!.GetValue<string>()));
+
+        // Every gated tool the map names is a real advertised tool the agent could request (#324): the
+        // list must be derived, never a hand-typed set that could name a tool that no longer exists.
+        foreach (string name in gated) {
+            Assert.True(ToolCatalog.Contains(name), $"gated tool '{name}' should be a real catalog tool");
+        }
+    }
+
+    private static List<string> Names(JsonArray arr) {
+        List<string> names = [];
+        foreach (JsonNode? n in arr) {
+            if (n?.GetValue<string>() is { } s) {
+                names.Add(s);
+            }
+        }
+        return names;
+    }
+
+    [Fact]
     public void StdioLoop_DispatchesRequestsConcurrently_NotOneAtATime() {
         // #113: the stdio transport must dispatch each request on its own worker, or a slow call blocks
         // later ones. Two requests rendezvous: each signals its arrival in dispatch and waits for the
@@ -843,6 +878,37 @@ public class AgentServerTests {
         }
         finally {
             AgentRuntime.Settings = null;
+            AgentRuntime.ResetSession();
+        }
+    }
+
+    [Fact]
+    public void Dispatch_SessionStatus_IncludesLiveCommandAccess_ReflectingTheTable() {
+        // #324: unlike initialize (the provisioning DEFAULTS), session-status reports the LIVE table, so a
+        // command the operator has since granted shows as enabled. Here `launch` is enabled in the table (a
+        // grant would look the same), so it must appear enabled and NOT gated; `chars:` enabled clears the
+        // raw-send_command flag; `invoke` absent from the table stays gated.
+        AgentTestSupport.EnsureTelemetry();
+        AgentRuntime.Settings = new AppSettings { AgentCommandsEnabled = true };
+        AgentRuntime.ArtifactRoot = Path.Combine(Path.GetTempPath(), "mcec-session-test", Path.GetRandomFileName());
+        AgentRuntime.ResetSession();
+        AgentRuntime.Invoker = new CommandInvoker {
+            ["launch"] = new LaunchCommand { Cmd = "launch", Enabled = true },
+            ["chars:"] = new CharsCommand { Cmd = "chars:", Enabled = true },
+        };
+        try {
+            JsonObject access = CallEnvelope(55, "session-status")["result"]!.AsObject()["commandAccess"]!.AsObject();
+            List<string> enabled = Names(access["enabledTools"]!.AsArray());
+            List<string> gated = Names(access["gatedTools"]!.AsArray());
+
+            Assert.Contains("launch", enabled);   // enabled in the table (a grant would read the same)
+            Assert.DoesNotContain("launch", gated);
+            Assert.Contains("invoke", gated);      // absent from the table → gated
+            Assert.False(access["rawSendCommandGated"]!.GetValue<bool>()); // chars: enabled clears the flag
+        }
+        finally {
+            AgentRuntime.Settings = null;
+            AgentRuntime.Invoker = null;
             AgentRuntime.ResetSession();
         }
     }


### PR DESCRIPTION
Closes #324.

## Problem

A freshly provisioned session enables the standard observation/actuation tools (`ToolCatalog.ProvisionedByDefault`) but leaves **`launch` and every raw `send_command` built-in** (`chars:`, `winr`, `mouse:`, `VK_*` keys, chords) gated. Per the #318 field report, an agent could only discover that set by hitting `command-disabled` one command at a time.

## Change

Expose the enabled/gated split at connect time so the agent can batch a single `request-command-access` before its first actuation.

- **`initialize` result** now carries a `commandAccess` object:
  ```json
  {
    "enabledTools": ["capture","query","displays","windows","window","find","wait-for","invoke","drag","click","focus","clipboard","record"],
    "gatedTools": ["launch"],
    "rawSendCommandGated": true,
    "note": "Gated commands need the operator's consent before first use: call request-command-access ... in ONE call ..."
  }
  ```
  Derived from `ToolCatalog.CommandAccessDefaults` (the `ProvisionedByDefault` flags) — **single source of truth in code, so it never drifts as provisioning defaults change** (acceptance criterion #2). Omitted in bootstrap mode (only tools are `provision-session`/`end-session`; no gated surface).

- **`session-start` / `session-status` results** stamp the **live** table via `AgentToolExecutor.LiveCommandAccess`, so an agent can re-check that a grant landed. Both surfaces share one builder (`ToolCatalog.CommandAccessMap`) and note, so shape/guidance can't diverge.

- **Connect-time prose** (`AgentInstructions.md` PROVISION / COMMAND ACCESS) now points at the field instead of relying on trial-and-error; docs (`agent_control.md`, `AGENTS.md`) updated.

### Why initialize over the provision handoff (issue Option A)
`BuildAgentPrompt` only renders on the operator's "Provision new…" dialog — a self-provisioning agent (bootstrap → `provision-session` → reconnect) never sees it, and it's operator-pasted prose decoupled from the instance. `initialize` is true connect-time, zero round-trip, reaches every path, and (via `session-status`) gives live post-grant accuracy.

### Note on the "one call" goal
The realistic win is knowing the *shape* up front (`launch` + raw built-ins gated) so the agent batches the built-ins its plan uses in one round — it still can't enumerate specific built-ins it hasn't planned yet, so the target isn't literally zero `command-disabled` ever.

## Acceptance
- [x] Agent connecting to a provisioned instance sees which commands need consent before first actuation (`initialize.commandAccess`).
- [x] List stays accurate when provisioning defaults change — derived from `ToolCatalog`, not hand-maintained prose.

## Tests
- `Dispatch_Initialize_IncludesCommandAccessDefaults` — `launch` gated, `capture`/`invoke` enabled, `rawSendCommandGated` true, every gated name is a real catalog tool.
- `Dispatch_SessionStatus_IncludesLiveCommandAccess_ReflectingTheTable` — live table drives the split; an enabled `launch`/`chars:` flips out of the gated set.
- Full xUnit suite green (1039 passed, 22 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)