### PR TITLE
Add Grok Build MCP registration instructions to handoff and docs

### DIFF
--- a/dev/hero-gif.md
+++ b/dev/hero-gif.md
@@ -42,6 +42,7 @@ pwsh -NoProfile -File scripts/Generate-HeroGif.ps1
 # ...
 #   MCP endpoint : http://127.0.0.1:<free-port>/mcp   (a free port is chosen; -Port pins one)
 #   Register it  : claude mcp add --transport http mcec http://127.0.0.1:<free-port>/mcp
+#                : grok mcp add --transport http mcec http://127.0.0.1:<free-port>/mcp
 #
 # HERO_MCP_URL=http://127.0.0.1:<free-port>/mcp        <- machine-readable; grep these, don't parse prose
 # HERO_MCP_PORT=<free-port>

--- a/docs/agent_control.md
+++ b/docs/agent_control.md
@@ -559,8 +559,9 @@ The exe also exposes a CLI surface (built on
 command metadata, and `agent-guide` prints the same agent guidance the MCP server
 hands connecting clients.
 
-Wire it into your MCP client config (the `claude_desktop_config.json` / `mcp.json`
-style used by most clients):
+Wire it into your MCP client config.
+
+**Claude / most clients** (claude_desktop_config.json / mcp.json style):
 
 ```json
 {
@@ -573,10 +574,29 @@ style used by most clients):
 }
 ```
 
+**Grok Build** (recommended CLI):
+
+```bash
+grok mcp add mcec -- "C:/mcec/mcec.exe" mcp
+```
+
+Useful commands:
+- `grok mcp list`
+- `grok mcp doctor mcec`
+- In Grok TUI: `/mcps` (or Ctrl+L → MCP Servers tab)
+
 (`C:/mcec` here is a writable copy of the install directory, or a provisioned session's
 `directory`. Pointing it at the Program Files path connects, but that copy serves only the
 `provision-session`/`end-session` bootstrap, per above — use it to mint an instance, then repoint your
 client at the instance's `directory`.)
+
+Grok also supports direct TOML in `~/.grok/config.toml`:
+
+```toml
+[mcp_servers.mcec]
+command = "C:/mcec/mcec.exe"
+args = ["mcp"]
+```
 
 `mcp` is a spawned server, not an interactive command: typed at a terminal it refuses
 (stdin is an interactive console; the server would block on the shared console and

--- a/scripts/Generate-HeroGif.ps1
+++ b/scripts/Generate-HeroGif.ps1
@@ -142,6 +142,7 @@ Write-Host ''
 Write-Host "Controller is up (pid=$ctrlPid, detached; survives this script exiting); agent commands and session provisioning are authorized."
 Write-Host "  MCP endpoint : $url"
 Write-Host "  Register it  : claude mcp add --transport http mcec $url"
+Write-Host "               : grok mcp add --transport http mcec $url"
 Write-Host '  Then ask your agent to recreate the hero per dev/hero-gif.md (it drives entirely via MCP tools).'
 Write-Host '  When finished: pwsh -NoProfile -File scripts/Generate-HeroGif.ps1 -Stop'
 Write-Host ''

--- a/src/Dialogs/ProvisionedInstanceDialog.cs
+++ b/src/Dialogs/ProvisionedInstanceDialog.cs
@@ -139,6 +139,11 @@ internal sealed class ProvisionedInstanceDialog : Form {
         _ = sb.AppendLine();
         _ = sb.AppendLine("e.g. Claude Code:");
         _ = sb.AppendLine($"  claude mcp add mcec -- \"{session.ExePath}\" --mcp");
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("Grok Build:");
+        _ = sb.AppendLine($"  grok mcp add mcec -- \"{session.ExePath}\" mcp");
+        _ = sb.AppendLine("  (or edit ~/.grok/config.toml under [mcp_servers.mcec])");
+        _ = sb.AppendLine("  Useful: grok mcp list | grok mcp doctor mcec | /mcps in TUI");
         if (session.McpServerEnabled) {
             _ = sb.AppendLine();
             _ = sb.AppendLine($"Or launch \"{session.ExePath}\" and POST JSON-RPC to its HTTP endpoint:");
@@ -198,6 +203,12 @@ internal sealed class ProvisionedInstanceDialog : Form {
         _ = sb.AppendLine("   If you are also connected to my installed MCEC's bootstrap server, call its");
         _ = sb.AppendLine("   end-session tool with the provision id and token above once this instance");
         _ = sb.AppendLine("   has stopped.");
+        _ = sb.AppendLine();
+        _ = sb.AppendLine("Client setup (for the human operator):");
+        _ = sb.AppendLine("  Grok Build:  grok mcp add mcec -- \"<exe path>\" mcp");
+        _ = sb.AppendLine("               (or add to ~/.grok/config.toml under [mcp_servers.mcec])");
+        _ = sb.AppendLine("  Claude etc.: claude mcp add mcec -- \"<exe path>\" --mcp   or JSON mcpServers");
+        _ = sb.AppendLine("  Check status with: grok mcp doctor mcec  |  /mcps  (in Grok TUI)");
         _ = sb.AppendLine();
         _ = sb.Append("My task for you: <describe the task here>");
         return sb.ToString();

--- a/tests/MCEControl.xUnit/Dialogs/AgentSettingsTabTests.cs
+++ b/tests/MCEControl.xUnit/Dialogs/AgentSettingsTabTests.cs
@@ -145,6 +145,7 @@ public class AgentSettingsTabTests : IDisposable {
         // credential; the operator may only ever copy this block).
         Assert.Contains(@"C:\sessions\0123456789ab\mcec.exe"" --mcp", text);
         Assert.Contains("claude mcp add mcec", text);
+        Assert.Contains("grok mcp add mcec", text);
         Assert.Contains("Provision id: 0123456789ab", text);
         Assert.Contains(@"C:\sessions\0123456789ab", text);
         Assert.Contains("deadbeefcafef00d", text);


### PR DESCRIPTION
Improve MCEC provisioning instructions and docs to include Grok Build (grok mcp add, doctor, /mcps, TOML) alongside Claude examples. Updates to BuildHandoffText, BuildAgentPrompt, agent_control.md, scripts, tests.